### PR TITLE
[test] Make sure tests data is ready before morphing tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,3 +54,4 @@ Collate:
     'coord.R'
     'morph.R'
 VignetteBuilder: knitr
+Config/testthat/start-first: utils, esgf, coord, netcdf, morph


### PR DESCRIPTION
Pull request overview
---------------------

- Fixes #35
- This PR uses https://testthat.r-lib.org/articles/parallel.html#changing-the-order-of-the-test-files to make sure tests are run in the desired order.
