### PR TITLE
fix(query): use meta-grid node status url

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: epwshiftr
 Title: Create Future 'EnergyPlus' Weather Files using 'CMIP6' Data
-Version: 0.1.3.9014
+Version: 0.1.3.9015
 Authors@R: c(
     person(given = "Hongyuan",
            family = "Jia",

--- a/NEWS.md
+++ b/NEWS.md
@@ -96,6 +96,7 @@
   climate variables (#25).
 * Fix the wrong warning messages when `combined` method is used in
   `morphing_epw()` (#25).
+* Now `get_data_node()` works again (#80)
 
 ## Internal refactor
 

--- a/R/esgf.R
+++ b/R/esgf.R
@@ -252,7 +252,7 @@ esgf_query <- function(activity = "ScenarioMIP",
     assert_choice(type, choices = c("Dataset", "File"))
     assert_character(data_node, any.missing = FALSE, null.ok = TRUE)
 
-    url_base <- "http://esgf-node.llnl.gov/esg-search/search/?"
+    url_base <- "https://esgf-node.llnl.gov/esg-search/search?"
 
     dict <- c(
         activity = "activity_id",

--- a/R/query.R
+++ b/R/query.R
@@ -1420,10 +1420,15 @@ query_build <- function(host, params, type = "search") {
 }
 
 query_build_facet_cache <- function(host, project = "CMIP6") {
+    # NOTE: not all index nodes support facet listing without project one
+    # example is https://esgf-node.llnl.gov/esg-search/search
+    # It will return status '500' and 'Read timed out' for queries with large
+    # size. So currently we only support facet cache for a single project
+
     # build a query without project to get facet names and values
     url <- query_build(host,
         list(
-            project = NULL,
+            project = project,
             facets = "*",
             limit = 0,
             distrib = TRUE,
@@ -1435,7 +1440,7 @@ query_build_facet_cache <- function(host, project = "CMIP6") {
     # build a query with project to get the Shards
     url <- query_build(host,
         list(
-            project = "CMIP6",
+            project = project,
             limit = 0,
             distrib = TRUE,
             format = "application/solr+json"

--- a/R/query.R
+++ b/R/query.R
@@ -1405,7 +1405,7 @@ query_build <- function(host, params, type = "search") {
     }
 
     # skip empty parameter
-    params <- params[!vapply(params, is.null, logical(1L))]
+    params <- params[vapply(params, length, integer(1L)) > 0L]
 
     if (type == "wget") {
         params <- params[!names(params) %in% c("type", "format")]

--- a/R/query.R
+++ b/R/query.R
@@ -388,7 +388,10 @@ EsgfQuery <- R6::R6Class("EsgfQuery",
         #' }
         project = function(value = "CMIP6") {
             if (missing(value)) return(private$param_project)
-            private$param_project <- private$new_facet_param("project", value)
+            # see: https://stackoverflow.com/questions/75543796/how-to-use-substitute-and-quote-with-nested-functions-in-r
+            private$param_project <- eval(bquote(
+                private$new_facet_param("project", .(substitute(value)), env = parent.frame(2L))
+            ))
             self
         },
 
@@ -417,7 +420,10 @@ EsgfQuery <- R6::R6Class("EsgfQuery",
         #' }
         activity_id = function(value) {
             if (missing(value)) return(private$param_activity_id)
-            private$param_activity_id <- private$new_facet_param("activity_id", value)
+            # see: https://stackoverflow.com/questions/75543796/how-to-use-substitute-and-quote-with-nested-functions-in-r
+            private$param_activity_id <- eval(bquote(
+                private$new_facet_param("activity_id", .(substitute(value)), env = parent.frame(2L))
+            ))
             self
         },
 
@@ -446,7 +452,10 @@ EsgfQuery <- R6::R6Class("EsgfQuery",
         #' }
         experiment_id = function(value) {
             if (missing(value)) return(private$param_experiment_id)
-            private$param_experiment_id <- private$new_facet_param("experiment_id", value)
+            # see: https://stackoverflow.com/questions/75543796/how-to-use-substitute-and-quote-with-nested-functions-in-r
+            private$param_experiment_id <- eval(bquote(
+                private$new_facet_param("experiment_id", .(substitute(value)), env = parent.frame(2L))
+            ))
             invisible(self)
         },
 
@@ -475,7 +484,10 @@ EsgfQuery <- R6::R6Class("EsgfQuery",
         #' }
         source_id = function(value) {
             if (missing(value)) return(private$param_source_id)
-            private$param_source_id <- private$new_facet_param("source_id", value)
+            # see: https://stackoverflow.com/questions/75543796/how-to-use-substitute-and-quote-with-nested-functions-in-r
+            private$param_source_id <- eval(bquote(
+                private$new_facet_param("source_id", .(substitute(value)), env = parent.frame(2L))
+            ))
             invisible(self)
         },
 
@@ -504,7 +516,10 @@ EsgfQuery <- R6::R6Class("EsgfQuery",
         #' }
         variable_id = function(value) {
             if (missing(value)) return(private$param_variable_id)
-            private$param_variable_id <- private$new_facet_param("variable_id", value)
+            # see: https://stackoverflow.com/questions/75543796/how-to-use-substitute-and-quote-with-nested-functions-in-r
+            private$param_variable_id <- eval(bquote(
+                private$new_facet_param("variable_id", .(substitute(value)), env = parent.frame(2L))
+            ))
             invisible(self)
         },
 
@@ -533,7 +548,10 @@ EsgfQuery <- R6::R6Class("EsgfQuery",
         #' }
         frequency = function(value) {
             if (missing(value)) return(private$param_frequency)
-            private$param_frequency <- private$new_facet_param("frequency", value)
+            # see: https://stackoverflow.com/questions/75543796/how-to-use-substitute-and-quote-with-nested-functions-in-r
+            private$param_frequency <- eval(bquote(
+                private$new_facet_param("frequency", .(substitute(value)), env = parent.frame(2L))
+            ))
             invisible(self)
         },
 
@@ -562,7 +580,10 @@ EsgfQuery <- R6::R6Class("EsgfQuery",
         #' }
         variant_label = function(value) {
             if (missing(value)) return(private$param_variant_label)
-            private$param_variant_label <- private$new_facet_param("variant_label", value)
+            # see: https://stackoverflow.com/questions/75543796/how-to-use-substitute-and-quote-with-nested-functions-in-r
+            private$param_variant_label <- eval(bquote(
+                private$new_facet_param("variant_label", .(substitute(value)), env = parent.frame(2L))
+            ))
             invisible(self)
         },
 
@@ -591,7 +612,10 @@ EsgfQuery <- R6::R6Class("EsgfQuery",
         #' }
         nominal_resolution = function(value) {
             if (missing(value)) return(private$param_nominal_resolution)
-            param <- private$new_facet_param("nominal_resolution", value)
+            # see: https://stackoverflow.com/questions/75543796/how-to-use-substitute-and-quote-with-nested-functions-in-r
+            param <- eval(bquote(
+                private$new_facet_param("nominal_resolution", .(substitute(value)), env = parent.frame(2L))
+            ))
 
             if (!is.null(param)) {
                 # handle nominal resolution specially
@@ -637,7 +661,10 @@ EsgfQuery <- R6::R6Class("EsgfQuery",
         #' }
         data_node = function(value) {
             if (missing(value)) return(private$param_data_node)
-            private$param_data_node <- private$new_facet_param("data_node", value)
+            # see: https://stackoverflow.com/questions/75543796/how-to-use-substitute-and-quote-with-nested-functions-in-r
+            private$param_data_node <- eval(bquote(
+                private$new_facet_param("data_node", .(substitute(value)), env = parent.frame(2L))
+            ))
             invisible(self)
         },
 
@@ -667,7 +694,7 @@ EsgfQuery <- R6::R6Class("EsgfQuery",
         #' }
         facets = function(value) {
             if (missing(value)) return(private$param_facets)
-            private$param_facets <- private$new_facet_param("facets", value, FALSE)
+            private$param_facets <- private$new_facet_param("facets", value, FALSE, env = parent.frame(2L))
             invisible(self)
         },
 
@@ -702,7 +729,7 @@ EsgfQuery <- R6::R6Class("EsgfQuery",
         #' }
         fields = function(value = "*") {
             if (missing(value)) return(private$param_fields)
-            private$param_fields <- private$new_facet_param("fields", value, FALSE)
+            private$param_fields <- private$new_facet_param("fields", value, FALSE, env = parent.frame(2L))
             invisible(self)
         },
 
@@ -745,7 +772,7 @@ EsgfQuery <- R6::R6Class("EsgfQuery",
             if (!private$param_distrib$value && !is.null(value)) {
                 stop("'$distrib()' returns FALSE. Shard specification is only applicable for distributed queries.")
             }
-            private$param_shards <- private$new_facet_param("shards", value, FALSE)
+            private$param_shards <- private$new_facet_param("shards", value, FALSE, env = parent.frame(2L))
             invisible(self)
         },
 
@@ -987,7 +1014,7 @@ EsgfQuery <- R6::R6Class("EsgfQuery",
                 return(invisible(self))
             }
 
-            params <- eval_with_bang(...)
+            params <- eval_with_bang(..., .env = parent.frame(2L))
             checkmate::assert_list(
                 lapply(params, .subset2, "value"),
                 # allow NULL
@@ -1331,7 +1358,8 @@ EsgfQuery <- R6::R6Class("EsgfQuery",
 
         new_facet_param = function(facet, value, allow_negate = TRUE, env = parent.frame()) {
             if (allow_negate) {
-                value <- eval(substitute(eval_with_bang(value)[[1L]], env))
+                # see: https://stackoverflow.com/questions/75543796/how-to-use-substitute-and-quote-with-nested-functions-in-r
+                value <- eval(bquote(eval_with_bang(.(substitute(value)), .env = env)[[1L]]))
             } else {
                 value <- list(value = value, negate = FALSE)
             }

--- a/R/query.R
+++ b/R/query.R
@@ -388,11 +388,12 @@ EsgfQuery <- R6::R6Class("EsgfQuery",
         #' }
         project = function(value = "CMIP6") {
             if (missing(value)) return(private$param_project)
-            # see: https://stackoverflow.com/questions/75543796/how-to-use-substitute-and-quote-with-nested-functions-in-r
+            # See: https://stackoverflow.com/questions/75543796/how-to-use-substitute-and-quote-with-nested-functions-in-r
+            env <- parent.frame()
             private$param_project <- eval(bquote(
-                private$new_facet_param("project", .(substitute(value)), env = parent.frame(2L))
+                private$new_facet_param("project", .(substitute(value)), env = env)
             ))
-            self
+            invisible(self)
         },
 
         #' @description
@@ -421,10 +422,11 @@ EsgfQuery <- R6::R6Class("EsgfQuery",
         activity_id = function(value) {
             if (missing(value)) return(private$param_activity_id)
             # see: https://stackoverflow.com/questions/75543796/how-to-use-substitute-and-quote-with-nested-functions-in-r
+            env <- parent.frame()
             private$param_activity_id <- eval(bquote(
-                private$new_facet_param("activity_id", .(substitute(value)), env = parent.frame(2L))
+                private$new_facet_param("activity_id", .(substitute(value)), env = env)
             ))
-            self
+            invisible(self)
         },
 
         #' @description
@@ -453,8 +455,9 @@ EsgfQuery <- R6::R6Class("EsgfQuery",
         experiment_id = function(value) {
             if (missing(value)) return(private$param_experiment_id)
             # see: https://stackoverflow.com/questions/75543796/how-to-use-substitute-and-quote-with-nested-functions-in-r
+            env <- parent.frame()
             private$param_experiment_id <- eval(bquote(
-                private$new_facet_param("experiment_id", .(substitute(value)), env = parent.frame(2L))
+                private$new_facet_param("experiment_id", .(substitute(value)), env = env)
             ))
             invisible(self)
         },
@@ -485,8 +488,9 @@ EsgfQuery <- R6::R6Class("EsgfQuery",
         source_id = function(value) {
             if (missing(value)) return(private$param_source_id)
             # see: https://stackoverflow.com/questions/75543796/how-to-use-substitute-and-quote-with-nested-functions-in-r
+            env <- parent.frame()
             private$param_source_id <- eval(bquote(
-                private$new_facet_param("source_id", .(substitute(value)), env = parent.frame(2L))
+                private$new_facet_param("source_id", .(substitute(value)), env = env)
             ))
             invisible(self)
         },
@@ -517,8 +521,9 @@ EsgfQuery <- R6::R6Class("EsgfQuery",
         variable_id = function(value) {
             if (missing(value)) return(private$param_variable_id)
             # see: https://stackoverflow.com/questions/75543796/how-to-use-substitute-and-quote-with-nested-functions-in-r
+            env <- parent.frame()
             private$param_variable_id <- eval(bquote(
-                private$new_facet_param("variable_id", .(substitute(value)), env = parent.frame(2L))
+                private$new_facet_param("variable_id", .(substitute(value)), env = env)
             ))
             invisible(self)
         },
@@ -549,8 +554,9 @@ EsgfQuery <- R6::R6Class("EsgfQuery",
         frequency = function(value) {
             if (missing(value)) return(private$param_frequency)
             # see: https://stackoverflow.com/questions/75543796/how-to-use-substitute-and-quote-with-nested-functions-in-r
+            env <- parent.frame()
             private$param_frequency <- eval(bquote(
-                private$new_facet_param("frequency", .(substitute(value)), env = parent.frame(2L))
+                private$new_facet_param("frequency", .(substitute(value)), env = env)
             ))
             invisible(self)
         },
@@ -581,8 +587,9 @@ EsgfQuery <- R6::R6Class("EsgfQuery",
         variant_label = function(value) {
             if (missing(value)) return(private$param_variant_label)
             # see: https://stackoverflow.com/questions/75543796/how-to-use-substitute-and-quote-with-nested-functions-in-r
+            env <- parent.frame()
             private$param_variant_label <- eval(bquote(
-                private$new_facet_param("variant_label", .(substitute(value)), env = parent.frame(2L))
+                private$new_facet_param("variant_label", .(substitute(value)), env = env)
             ))
             invisible(self)
         },
@@ -613,8 +620,9 @@ EsgfQuery <- R6::R6Class("EsgfQuery",
         nominal_resolution = function(value) {
             if (missing(value)) return(private$param_nominal_resolution)
             # see: https://stackoverflow.com/questions/75543796/how-to-use-substitute-and-quote-with-nested-functions-in-r
+            env <- parent.frame()
             param <- eval(bquote(
-                private$new_facet_param("nominal_resolution", .(substitute(value)), env = parent.frame(2L))
+                private$new_facet_param("nominal_resolution", .(substitute(value)), env = env)
             ))
 
             if (!is.null(param)) {
@@ -661,9 +669,10 @@ EsgfQuery <- R6::R6Class("EsgfQuery",
         #' }
         data_node = function(value) {
             if (missing(value)) return(private$param_data_node)
-            # see: https://stackoverflow.com/questions/75543796/how-to-use-substitute-and-quote-with-nested-functions-in-r
+            # See: https://stackoverflow.com/questions/75543796/how-to-use-substitute-and-quote-with-nested-functions-in-r
+            env <- parent.frame()
             private$param_data_node <- eval(bquote(
-                private$new_facet_param("data_node", .(substitute(value)), env = parent.frame(2L))
+                private$new_facet_param("data_node", .(substitute(value)), env = env)
             ))
             invisible(self)
         },
@@ -694,7 +703,7 @@ EsgfQuery <- R6::R6Class("EsgfQuery",
         #' }
         facets = function(value) {
             if (missing(value)) return(private$param_facets)
-            private$param_facets <- private$new_facet_param("facets", value, FALSE, env = parent.frame(2L))
+            private$param_facets <- private$new_facet_param("facets", value, FALSE)
             invisible(self)
         },
 
@@ -729,7 +738,7 @@ EsgfQuery <- R6::R6Class("EsgfQuery",
         #' }
         fields = function(value = "*") {
             if (missing(value)) return(private$param_fields)
-            private$param_fields <- private$new_facet_param("fields", value, FALSE, env = parent.frame(2L))
+            private$param_fields <- private$new_facet_param("fields", value, FALSE)
             invisible(self)
         },
 
@@ -772,7 +781,7 @@ EsgfQuery <- R6::R6Class("EsgfQuery",
             if (!private$param_distrib$value && !is.null(value)) {
                 stop("'$distrib()' returns FALSE. Shard specification is only applicable for distributed queries.")
             }
-            private$param_shards <- private$new_facet_param("shards", value, FALSE, env = parent.frame(2L))
+            private$param_shards <- private$new_facet_param("shards", value, FALSE)
             invisible(self)
         },
 
@@ -1014,7 +1023,8 @@ EsgfQuery <- R6::R6Class("EsgfQuery",
                 return(invisible(self))
             }
 
-            params <- eval_with_bang(..., .env = parent.frame(2L))
+            env <- parent.frame()
+            params <- eval_with_bang(..., .env = env)
             checkmate::assert_list(
                 lapply(params, .subset2, "value"),
                 # allow NULL
@@ -1358,6 +1368,20 @@ EsgfQuery <- R6::R6Class("EsgfQuery",
 
         new_facet_param = function(facet, value, allow_negate = TRUE, env = parent.frame()) {
             if (allow_negate) {
+                # NOTE: We have to force `env` first otherwise R's lazy
+                # evaluation feature will cause lexical scoping error
+                # Take a look at the following example:
+                # q <- 1
+                # f1 <- function(x) {
+                #     eval(bquote(f2(.(substitute(x)), parent.frame())))
+                # }
+                # f2 <- function(y, env = parent.frame()) {
+                #     print(eval(substitute(y), env))
+                # }
+                #
+                # f1(q) will return `base::q()` instead of 1
+                force(env)
+
                 # see: https://stackoverflow.com/questions/75543796/how-to-use-substitute-and-quote-with-nested-functions-in-r
                 value <- eval(bquote(eval_with_bang(.(substitute(value)), .env = env)[[1L]]))
             } else {

--- a/R/query.R
+++ b/R/query.R
@@ -1425,6 +1425,11 @@ query_build_facet_cache <- function(host, project = "CMIP6") {
     # It will return status '500' and 'Read timed out' for queries with large
     # size. So currently we only support facet cache for a single project
 
+    # set the timeout to 5 minutes temporarily
+    old <- getOption("timeout")
+    on.exit(options(timeout = old), add = TRUE)
+    options(timeout = 300)
+
     # build a query without project to get facet names and values
     url <- query_build(host,
         list(

--- a/R/query.R
+++ b/R/query.R
@@ -1319,6 +1319,10 @@ EsgfQuery <- R6::R6Class("EsgfQuery",
                 if (length(choices)) {
                     choices <- gsub("(?<=/solr).+", "", choices, perl = TRUE)
                 }
+            } else if (facet == "project") {
+                # TODO: find a way to programmatically get all project names
+                # right now no validation is performed
+                return(value)
             } else {
                 choices <- self$list_all_values(facet)
             }

--- a/R/utils.R
+++ b/R/utils.R
@@ -170,5 +170,5 @@ utils::globalVariables(c(
     "variable", "wmo_number", "file_mtime", "i.file_path", "i.interval",
     "interval", "time_calendar", "time_units", "overlap", "frequency",
     "ind_lon", "ind_lat", "ord_lon", "ord_lat", "dist", "num_years", "type",
-    "year"
+    "year", "status"
 ))

--- a/tests/testthat/test-esgf.R
+++ b/tests/testthat/test-esgf.R
@@ -83,7 +83,7 @@ test_that("init_cmip6_index()", {
 
     expect_s3_class(
         idx <- init_cmip6_index(variable = "tas", source = "EC-Earth3",
-            experiment = "ssp858", years = 2060, limit = 1, save = TRUE
+            experiment = "ssp585", years = 2060, limit = 1, save = TRUE
         ),
         "data.table"
     )

--- a/tests/testthat/test-query.R
+++ b/tests/testthat/test-query.R
@@ -1,3 +1,6 @@
+# this host that currently supports facet listing
+host <- "https://esgf.ceda.ac.uk/esg-search"
+
 test_that("ESGF Query Parameter works", {
     # can create new query parameter
     expect_s3_class(
@@ -122,8 +125,8 @@ test_that("ESGF Query works", {
     expect_error(q$shards("a"), "distrib")
     expect_true(q$distrib(TRUE)$distrib()$value)
     expect_error(q$shards("a"), "Assertion")
-    sh <- q$list_all_shards()[1L]
-    expect_equal(q$shards(sh)$shards()$value, sh)
+    shard <- gsub("(?<=/solr).+", "", q$list_all_shards()[1L], perl = TRUE)
+    expect_equal(q$shards(shard)$shards()$value, shard)
     expect_null(q$shards(NULL)$shards())
 
     # replica
@@ -164,10 +167,10 @@ test_that("ESGF Query works", {
     expect_equal(q$params(frequency = NULL)$params(), list())
     expect_null(q$frequency())
     expect_equal(
-        q$params(table_id = "Amon", member_id = "00")$params(),
+        q$params(table_id = "Amon", member_id = "r1i1p1f1")$params(),
         list(
             table_id = new_query_param("table_id", "Amon"),
-            member_id = new_query_param("member_id", "00")
+            member_id = new_query_param("member_id", "r1i1p1f1")
         )
     )
     ## can reset format
@@ -200,7 +203,7 @@ test_that("ESGF Query works", {
     expect_s3_class(q <- EsgfQuery$new(host), "EsgfQuery")
     expect_type(q$limit(0)$frequency("1hr")$count(), "integer")
     expect_type(q$response(), "list")
-    expect_equal(names(q$response()), c("responseHeader", "response"))
+    expect_equal(names(q$response()), c("responseHeader", "response", "facet_counts"))
 
-    expect_snapshot_output(EsgfQuery$new(host)$params(table_id = "Amon", member_id = "00")$print())
+    expect_snapshot_output(EsgfQuery$new(host)$params(table_id = "Amon", member_id = "r1i1p1f1")$print())
 })

--- a/tests/testthat/test-query.R
+++ b/tests/testthat/test-query.R
@@ -45,8 +45,9 @@ test_that("ESGF Query Parameter works", {
 test_that("ESGF Query works", {
     skip_on_cran()
 
-    expect_s3_class(q <- EsgfQuery$new(), "EsgfQuery")
-    expect_s3_class(q <- query_esgf(), "EsgfQuery")
+    host <- "https://esgf.ceda.ac.uk/esg-search"
+    expect_s3_class(q <- EsgfQuery$new(host), "EsgfQuery")
+    expect_s3_class(q <- query_esgf(host), "EsgfQuery")
 
     # listing
     expect_type(q$list_all_facets(), "character")
@@ -100,7 +101,8 @@ test_that("ESGF Query works", {
 
     # data_node
     expect_null(q$data_node())
-    expect_equal(q$data_node("esg.lasg.ac.cn")$data_node()$value, "esg.lasg.ac.cn")
+    dn <- q$list_all_values("data_node")
+    expect_equal(q$data_node(dn)$data_node()$value, dn)
     expect_null(q$data_node(NULL)$data_node())
 
     # facets
@@ -180,27 +182,27 @@ test_that("ESGF Query works", {
     expect_equal(q$params(NULL)$params(), list())
 
     # can get url
-    expect_type(EsgfQuery$new()$nominal_resolution("100 km")$url(), "character")
-    expect_type(EsgfQuery$new()$nominal_resolution("100 km")$url(TRUE), "character")
-    expect_type(EsgfQuery$new()$params(project = "CMIP5", table_id = "Amon")$url(), "character")
+    expect_type(EsgfQuery$new(host)$nominal_resolution("100 km")$url(), "character")
+    expect_type(EsgfQuery$new(host)$nominal_resolution("100 km")$url(TRUE), "character")
+    expect_type(EsgfQuery$new(host)$params(project = "CMIP5", table_id = "Amon")$url(), "character")
 
     # can get count
-    expect_type(EsgfQuery$new()$frequency("1hr")$count(FALSE), "integer")
-    expect_type(EsgfQuery$new()$frequency("1hr")$count(TRUE), "integer")
-    expect_type(cnt <- EsgfQuery$new()$frequency("1hr")$count("activity_id"), "list")
+    expect_type(EsgfQuery$new(host)$frequency("1hr")$count(FALSE), "integer")
+    expect_type(EsgfQuery$new(host)$frequency("1hr")$count(TRUE), "integer")
+    expect_type(cnt <- EsgfQuery$new(host)$frequency("1hr")$count("activity_id"), "list")
     expect_equal(names(cnt), c("total", "activity_id"))
 
     # can collect data
-    expect_equal(EsgfQuery$new()$limit(0)$frequency("1hr")$collect(), data.table::setDT(list()))
-    expect_s3_class(res <- EsgfQuery$new()$limit(1)$fields("source_id")$collect(), "data.table")
+    expect_equal(EsgfQuery$new(host)$limit(0)$frequency("1hr")$collect(), data.table::setDT(list()))
+    expect_s3_class(res <- EsgfQuery$new(host)$limit(1)$fields("source_id")$collect(), "data.table")
     expect_equal(names(res), "source_id")
 
     # can return last response
-    expect_null(EsgfQuery$new()$response())
-    expect_s3_class(q <- EsgfQuery$new(), "EsgfQuery")
+    expect_null(EsgfQuery$new(host)$response())
+    expect_s3_class(q <- EsgfQuery$new(host), "EsgfQuery")
     expect_type(q$limit(0)$frequency("1hr")$count(), "integer")
     expect_type(q$response(), "list")
     expect_equal(names(q$response()), c("responseHeader", "response"))
 
-    expect_snapshot_output(EsgfQuery$new()$params(table_id = "Amon", member_id = "00")$print())
+    expect_snapshot_output(EsgfQuery$new(host)$params(table_id = "Amon", member_id = "00")$print())
 })

--- a/tests/testthat/test-query.R
+++ b/tests/testthat/test-query.R
@@ -122,10 +122,8 @@ test_that("ESGF Query works", {
     expect_error(q$shards("a"), "distrib")
     expect_true(q$distrib(TRUE)$distrib()$value)
     expect_error(q$shards("a"), "Assertion")
-    expect_equal(
-        q$shards("esgf-node.llnl.gov:8985/solr")$shards()$value,
-        "esgf-node.llnl.gov:8985/solr"
-    )
+    sh <- q$list_all_shards()[1L]
+    expect_equal(q$shards(sh)$shards()$value, sh)
     expect_null(q$shards(NULL)$shards())
 
     # replica


### PR DESCRIPTION
Pull request overview
---------------------

- Fixes #80 
- Use the MetaGrid node status URL in `get_data_node()`
