### PR TITLE
fix(save): fill missing values before generating EPW files

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: epwshiftr
 Title: Create Future 'EnergyPlus' Weather Files using 'CMIP6' Data
-Version: 0.1.4
+Version: 0.1.4.9001
 Authors@R: c(
     person(given = "Hongyuan",
            family = "Jia",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# eplusr (development version)
+
+## Bug fixes
+
+* `future_epw()` now correctly handles missing values when generating future
+  weather files.
+
 # epwshiftr 0.1.4
 
 ## Major changes

--- a/R/morph.R
+++ b/R/morph.R
@@ -1020,6 +1020,8 @@ future_epw <- function (morphed, by = c("experiment", "source", "interval"),
             )
             # nocov end
         }
+        # fill abnormal data, including missing values with special values
+        new_epw$fill_abnormal(missing = TRUE, out_of_range = TRUE, special = TRUE)
         new_epw$save(output[i], overwrite = overwrite)
 
         new_epw


### PR DESCRIPTION
Pull request overview
---------------------

- `future_epw()` now always fills missing values and out-of-range values before generating EPW files.
