### PR TITLE
ci: update actions workflows for stacked prs

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -24,7 +24,7 @@ jobs:
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      NOT_CRAN: ${{ matrix.config.not_cran }}
+      NOT_CRAN: ${{ github.event_name != 'pull_request' && matrix.config.not_cran }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -27,7 +27,7 @@ jobs:
       NOT_CRAN: ${{ matrix.config.not_cran }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -53,7 +53,9 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck
+          extra-packages: |
+            any::rcmdcheck
+            url::https://cran.r-project.org/src/contrib/Archive/PCICt/PCICt_0.5-4.4.tar.gz
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -6,9 +6,6 @@ on:
       - main
       - master
   pull_request:
-    branches:
-      - main
-      - master
 
 name: R-CMD-check
 
@@ -48,7 +45,7 @@ jobs:
 
       - name: Cache NetCDF files
         if: runner.os != 'Windows'
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ env.EPWSHIFTR_CHECK_CACHE }}
           key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('DESCRIPTION') }}

--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -6,9 +6,6 @@ on:
       - main
       - master
   pull_request:
-    branches:
-      - main
-      - master
   release:
     types:
       - published
@@ -35,7 +32,7 @@ jobs:
 
 
       - name: Cache R packages
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ${{ env.R_LIBS_USER }}
           key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}

--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -22,7 +22,7 @@ jobs:
       NOT_CRAN: true
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-pandoc@v2
 
@@ -40,7 +40,10 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::pkgdown, local::.
+          extra-packages: |
+            any::pkgdown
+            local::.
+            url::https://cran.r-project.org/src/contrib/Archive/PCICt/PCICt_0.5-4.4.tar.gz
           needs: website
 
       - name: Deploy package

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -3,8 +3,6 @@ on:
     branches:
       - master
   pull_request:
-    branches:
-      - master
 
 name: test-coverage
 
@@ -33,7 +31,7 @@ jobs:
           if [ ! -d "${{ runner.temp }}/epwshiftr" ]; then mkdir -p "${{ runner.temp }}/epwshiftr"; fi
 
       - name: Cache NetCDF files
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ env.EPWSHIFTR_CHECK_CACHE }}
           key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('DESCRIPTION') }}

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -15,7 +15,7 @@ jobs:
       NOT_CRAN: true
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -39,7 +39,9 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::covr
+          extra-packages: |
+            any::covr
+            url::https://cran.r-project.org/src/contrib/Archive/PCICt/PCICt_0.5-4.4.tar.gz
           needs: coverage
 
       - name: Test coverage

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -12,7 +12,7 @@ jobs:
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      NOT_CRAN: true
+      NOT_CRAN: ${{ github.event_name != 'pull_request' }}
 
     steps:
       - uses: actions/checkout@v4
@@ -23,6 +23,13 @@ jobs:
           use-public-rspm: true
 
       - uses: r-lib/actions/setup-pandoc@v2
+
+      - name: Install macOS system libraries
+        shell: bash
+        run: |
+          brew install gettext
+          echo "PKG_CPPFLAGS=-I$(brew --prefix gettext)/include" >> $GITHUB_ENV
+          echo "PKG_LIBS=-L$(brew --prefix gettext)/lib -lintl" >> $GITHUB_ENV
 
       - name: Set EPWSHIFTR_CHECK_CACHE
         shell: bash


### PR DESCRIPTION
## Summary

Updates GitHub Actions workflows so the stacked PRs can run CI:

- upgrades deprecated `actions/cache@v1/v2` usage to `actions/cache@v4`
- upgrades package workflow checkout steps to `actions/checkout@v4`
- removes `pull_request` base-branch filters from package check, coverage, and pkgdown workflows
- adds the archived `PCICt` package source required by dependency resolution
- installs gettext for the macOS coverage job so archived `PCICt` can compile
- keeps live `NOT_CRAN` checks off for pull request events while preserving existing push behavior
- keeps existing push/release behavior unchanged
