### PR TITLE
refactor: remove unused print trunc helpers

### DIFF
--- a/R/query-result.R
+++ b/R/query-result.R
@@ -1,13 +1,3 @@
-print_trunc <- function(x, n) {
-    total <- length(x)
-    if (is.null(n) || n >= total) {
-        return(invisible(FALSE))
-    }
-
-    cli::cli_text(cli::col_grey("# ... with {total - n} more item{?s}"))
-    invisible(TRUE)
-}
-
 # EsgResult {{{
 #' Base class for results for ESGF query
 #'

--- a/R/utils.R
+++ b/R/utils.R
@@ -55,14 +55,6 @@ vb <- function(...) {
     paste0(...)
 }
 
-print_trunc <- function(x, n) {
-    if (is.null(n) || length(x) <= n) {
-        return(invisible(NULL))
-    }
-    cli::cat_line(sprintf("... and %i more", length(x) - n))
-    invisible(NULL)
-}
-
 with_silent <- function(expr) {
     old <- options("epwshiftr.verbose" = FALSE)
     on.exit(options(old), add = TRUE)


### PR DESCRIPTION
Removes unused print_trunc() helper definitions left after the stacked PR split.\n\nChanges include:\n\n- remove the unused top-level helper from query-result.R\n- remove the unused duplicate helper from utils.R\n- keep the existing query_result__trunc() and dict__trunc() print paths unchanged