### PR TITLE
fix: guard query pagination progress

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,9 @@
 
 ## Bug fixes
 
+* `EsgQuery$collect(all = TRUE)` now warns and returns partial results when
+  ESGF pagination stops making progress, instead of repeatedly requesting the
+  same offset (#116).
 * `future_epw()` now correctly handles missing values when generating future
   weather files.
 

--- a/R/query.R
+++ b/R/query.R
@@ -1928,6 +1928,16 @@ query__collect <- function(
     query_urls <- c(query_urls, url)
     response <- cache__read_json(url)
     docs <- response$response$docs
+    doc_pages <- list(docs)
+
+    warn_no_progress <- function(offset) {
+        cli::cli_warn(c(
+            "!" = "ESGF pagination stopped before all reported records were collected.",
+            "i" = "Index node: {index_node}",
+            "i" = "Offset: {offset}; collected: {current}; reported total: {total}."
+        ))
+        invisible(NULL)
+    }
 
     # check if the total number is less that the limit
     total <- response$response$numFound
@@ -1938,22 +1948,35 @@ query__collect <- function(
     if (total > 0L && all) {
         left <- total - current
 
-        while (left > 0L) {
-            store$offset(current)
+        if (left > 0L && current == 0L) {
+            warn_no_progress(0L)
+        } else {
+            while (left > 0L) {
+                page_offset <- current
+                store$offset(page_offset)
 
-            url <- query__build(index_node, store)
-            query_urls <- c(query_urls, url)
-            response <- cache__read_json(url)
+                url <- query__build(index_node, store)
+                query_urls <- c(query_urls, url)
+                response <- cache__read_json(url)
+                page_docs <- response$response$docs
+                page_n <- query__collect_nrow(page_docs)
+                if (page_n == 0L) {
+                    warn_no_progress(page_offset)
+                    break
+                }
 
-            # combine results
-            docs <- data.table::rbindlist(list(docs, response$response$docs), fill = TRUE)
-            current <- nrow(docs)
-            if (!is.null(progress_id)) {
-                cli::cli_progress_update(id = progress_id, total = total, set = current)
+                doc_pages[[length(doc_pages) + 1L]] <- page_docs
+                current <- current + page_n
+                if (!is.null(progress_id)) {
+                    cli::cli_progress_update(id = progress_id, total = total, set = current)
+                }
+
+                left <- total - current
             }
-
-            left <- total - current
         }
+    }
+    if (length(doc_pages) > 1L) {
+        docs <- data.table::rbindlist(doc_pages, fill = TRUE)
     }
 
     # 'score' is always returned in the response

--- a/tests/testthat/test-query.R
+++ b/tests/testthat/test-query.R
@@ -1200,6 +1200,39 @@ test_that("query__collect() records actual page query URLs", {
     expect_true(grepl("offset=2", utils::URLdecode(captured_url[[2L]]), fixed = TRUE))
 })
 
+test_that("query__collect() warns and returns partial docs when pagination does not progress", {
+    captured_url <- character()
+    testthat::local_mocked_bindings(
+        cache__read_json = function(url, ...) {
+            captured_url <<- c(captured_url, url)
+            docs <- if (length(captured_url) == 1L) {
+                data.frame(id = c("dataset-1", "dataset-2"), score = 1, check.names = FALSE)
+            } else {
+                data.frame(id = character(), score = numeric(), check.names = FALSE)
+            }
+            list(response = list(numFound = 3L, docs = docs))
+        },
+        .package = "epwshiftr"
+    )
+
+    expect_warning(
+        res <- query__collect(
+            "https://example.org",
+            QueryParamStore$new()$limit(2L),
+            all = TRUE,
+            limit = 2L
+        ),
+        "ESGF pagination stopped"
+    )
+
+    expect_equal(nrow(res$docs), 2L)
+    expect_identical(res$docs$id, c("dataset-1", "dataset-2"))
+    expect_length(captured_url, 2L)
+    expect_identical(res$context$query_url, captured_url)
+    expect_true(grepl("offset=0", utils::URLdecode(captured_url[[1L]]), fixed = TRUE))
+    expect_true(grepl("offset=2", utils::URLdecode(captured_url[[2L]]), fixed = TRUE))
+})
+
 test_that("query__collect() reports progress across collected pages", {
     reads <- 0L
     events <- character()


### PR DESCRIPTION
## Summary

- Prevent ESGF pagination from repeatedly copying accumulated query results.
- Stop paginated collection with a warning when an ESGF response reports more records but returns no new page rows.

## Changes

- Accumulate paginated docs in a list and combine them once after collection.
- Return partial collected docs with the actual query URL history when pagination stops without progress.
- Add focused test coverage for no-progress pagination.
