### PR TITLE
chore: remove obsolete test start order

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -86,5 +86,4 @@ Collate:
     'shift-stage.R'
     'standalone-cache.R'
     'zzz.R'
-Config/testthat/start-first: utils, esgf, netcdf
 Config/testthat/edition: 3

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,11 @@
 * `future_epw()` now correctly handles missing values when generating future
   weather files.
 
+## Internal refactor
+
+* Removed the obsolete testthat start-order override now that tests no longer
+  depend on shared cache side effects (#117).
+
 # epwshiftr 0.1.4
 
 ## Major changes


### PR DESCRIPTION
## Summary

Remove the obsolete testthat start-order override now that tests no longer depend on a previous API test mutating shared cache state.

## Changes

* Drop `Config/testthat/start-first` from `DESCRIPTION`.
* Keep the test suite order-independent instead of renaming the stale `esgf` start-first entry.
