### PR TITLE
fix: drop legacy precipitation distance summary

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -43,6 +43,8 @@
 
 ## Bug fixes
 
+* Fixed precipitation morphing summaries to avoid carrying the removed legacy
+  `dist` extraction column after grid extraction methods became explicit (#124).
 * `EsgStore` now keeps ESGF query collection and downloader operations outside
   the store manifest lock, reducing lock hold time during query update and
   download workflows (#120).

--- a/R/epw-morpher.R
+++ b/R/epw-morpher.R
@@ -2068,7 +2068,6 @@ morpher__belcher_monthly_precip_variable <- function(context, variable_id, refer
     out <- data[, .(
         lon = mean(lon, na.rm = TRUE),
         lat = mean(lat, na.rm = TRUE),
-        dist = mean(dist, na.rm = TRUE),
         value = mean(value, na.rm = TRUE),
         years = list(sort(unique(year)))
     ), by = group_cols]
@@ -2086,7 +2085,7 @@ morpher__belcher_monthly_precip_variable <- function(context, variable_id, refer
         units = "mm",
         years = NULL
     )]
-    data.table::setcolorder(out, c("activity_drs", "institution_id", "source_id", "experiment_id", "member_id", "table_id", "lon", "lat", "dist", "units", "value", "month", "interval"))
+    data.table::setcolorder(out, c("activity_drs", "institution_id", "source_id", "experiment_id", "member_id", "table_id", "lon", "lat", "units", "value", "month", "interval"))
     out[]
 }
 
@@ -2177,7 +2176,7 @@ morpher__belcher_precip_from_monthly <- function(data_epw, data_mean, strict = T
     data[, .baseline_precip_depth := NULL]
     data[, .SD, .SDcols = c(
         "activity_drs", "institution_id", "source_id", "experiment_id", "member_id",
-        "table_id", "lon", "lat", "dist", "interval",
+        "table_id", "lon", "lat", "interval",
         "datetime", "year", "month", "day", "hour", "minute",
         "liquid_precip_depth", "liquid_precip_rate", "delta", "alpha"
     )]


### PR DESCRIPTION
## Summary

Fix precipitation morphing summaries after explicit grid extraction methods removed the legacy `dist` extraction column.

## Changes

- Drop the unused `dist` aggregation from precipitation monthly summaries.
- Keep precipitation output columns aligned with the ordinary monthly summary path so strict morphing no longer resolves `dist` as a base function.