### PR TITLE
Prevent CMIP6 catalog input masking

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -156,6 +156,10 @@
 
 ## Bug fixes
 
+* CMIP6 coverage checks now keep requested variable and grid values distinct
+  from same-named convenience columns returned by ESGF providers, preventing
+  complete catalog identities from being rejected (#130, #132).
+
 * ESGF result persistence now recognizes the current bridge-provided
   `datetime_stop`, `geo`, and `mod_time` document fields. Nodes that ignore an
   explicit `fields` request no longer fail while saving otherwise valid

--- a/R/shift-stage.R
+++ b/R/shift-stage.R
@@ -6261,13 +6261,22 @@ shift__cmip6_partitions <- function(value) {
 # gap in the middle cannot satisfy the contract.
 shift__cmip6_input_complete <- function(catalog, identity, experiment,
                                         variable, table, grid, years) {
+    # ESGF providers may return convenience columns named `variable` and
+    # `grid`. Local aliases prevent data.table from resolving those columns
+    # instead of this helper's scalar arguments inside the row expression.
+    wanted_source_id <- identity$source_id[[1L]]
+    wanted_variant_label <- identity$variant_label[[1L]]
+    wanted_experiment <- experiment
+    wanted_variable <- variable
+    wanted_table <- table
+    wanted_grid <- grid
     files <- catalog[
-        shift__catalog_match(source_id, identity$source_id[[1L]]) &
-            shift__catalog_match(variant_label, identity$variant_label[[1L]]) &
-            shift__catalog_match(experiment_id, experiment) &
-            shift__catalog_match(variable_id, variable) &
-            shift__catalog_match(table_id, table) &
-            shift__catalog_match(grid_label, grid)
+        shift__catalog_match(source_id, wanted_source_id) &
+            shift__catalog_match(variant_label, wanted_variant_label) &
+            shift__catalog_match(experiment_id, wanted_experiment) &
+            shift__catalog_match(variable_id, wanted_variable) &
+            shift__catalog_match(table_id, wanted_table) &
+            shift__catalog_match(grid_label, wanted_grid)
     ]
     nrow(files) > 0L && !length(setdiff(years, shift__catalog_years(files)))
 }

--- a/tests/testthat/test-shift-stage.R
+++ b/tests/testthat/test-shift-stage.R
@@ -620,6 +620,38 @@ test_that("resolver coverage defensively repairs cached catalogs without times",
     expect_true(is.na(candidates$missing[[1L]]))
 })
 
+test_that("resolver inputs are not masked by provider convenience columns", {
+    catalog <- data.table::as.data.table(shift_test_file_docs(
+        "tas_day_Model-A_ssp245_r1i1p1f1_gn_20410101-20411231.nc",
+        variable_id = "tas",
+        datetime_start = "2041-01-01T00:00:00Z",
+        datetime_end = "2041-12-31T23:59:59Z"
+    ))
+    catalog$source_id <- "Model-A"
+    catalog$experiment_id <- "ssp245"
+    catalog$variant_label <- "r1i1p1f1"
+    catalog$frequency <- "day"
+    catalog$table_id <- "day"
+    catalog$grid_label <- "gn"
+    # These provider aliases deliberately disagree with the canonical fields.
+    catalog$variable <- "provider-variable"
+    catalog$grid <- "provider-grid"
+    identity <- data.table::data.table(
+        source_id = "Model-A",
+        variant_label = "r1i1p1f1"
+    )
+
+    expect_true(shift__cmip6_input_complete(
+        catalog,
+        identity,
+        experiment = "ssp245",
+        variable = "tas",
+        table = "day",
+        grid = "gn",
+        years = 2041L
+    ))
+})
+
 test_that("resolver satisfies canonical hurs only from direct data or huss plus tas and ps", {
     make_catalog <- function(variables) {
         data.table::rbindlist(lapply(variables, function(variable) {


### PR DESCRIPTION
## Summary

- Prevent ESGF convenience columns named `variable` and `grid` from masking the requested CMIP6 resolver inputs.
- Preserve the existing complete-period coverage contract.

## Changes

- Bind resolver arguments to unambiguous local scalar names before the `data.table` filter.
- Add a regression fixture where provider convenience columns deliberately disagree with canonical CMIP6 fields.
- Add the user-facing bug fix note.

Closes #130.
