### PR TITLE
Preserve CF calendar phase through daily extraction

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -163,6 +163,12 @@
 
 ## Bug fixes
 
+* Point extraction now retains canonical CF calendar coordinates and annual
+  phase, uses them for non-Gregorian range selection and yearly Parquet
+  partitions, and prefers them in morphing summaries with legacy artifact
+  fallback. Multi-year extraction partitions no longer duplicate every row
+  into every year (#134, #135).
+
 * CMIP6 coverage checks now keep requested variable and grid values distinct
   from same-named convenience columns returned by ESGF providers, preventing
   complete catalog identities from being rejected (#130, #132).

--- a/R/dataset.R
+++ b/R/dataset.R
@@ -625,7 +625,8 @@ EsgDataset <- R6::R6Class(
         #'
         #' @param index File index for multi-file datasets. Default: `1L`.
         #'
-        #' @return A list containing time values, units, and calendar.
+        #' @return A list containing time values, units, calendar, canonical CF
+        #' coordinates, and axis length.
         #'
         #' @examples
         #' \dontrun{
@@ -658,11 +659,13 @@ EsgDataset <- R6::R6Class(
                 time_units,
                 time_calendar
             )
+            time_coordinates <- attr(time_vals, "cf_coordinates", exact = TRUE)
 
             result <- list(
                 values = time_vals,
                 units = time_units,
                 calendar = normalize_cf_calendar(time_calendar),
+                coordinates = time_coordinates,
                 length = time_dim$length
             )
 
@@ -849,9 +852,10 @@ EsgDataset <- R6::R6Class(
         #'        read. Only supported when `async = TRUE`.
         #'
         #' @return A data.table or list of data.tables with columns including
-        #' `file_index`, `variable`, `time`, `lon`, `lat`, `method`, and
-        #' `value`. The `"grid_sources"` attribute records contributing grid
-        #' coordinates and weights.
+        #' `file_index`, `variable`, `time`, canonical `cf_*` calendar
+        #' coordinates, `annual_phase`, `lon`, `lat`, `method`, and `value`.
+        #' The `"grid_sources"` attribute records contributing grid coordinates
+        #' and weights.
         #'
         #' @examples
         #' \dontrun{
@@ -1465,6 +1469,13 @@ EsgDataset <- R6::R6Class(
                 file_index = integer(),
                 variable = character(),
                 time = as.POSIXct(character(), tz = "UTC"),
+                cf_calendar = character(),
+                cf_year = integer(),
+                cf_month = integer(),
+                cf_day = integer(),
+                cf_day_of_year = integer(),
+                cf_year_days = integer(),
+                annual_phase = numeric(),
                 lon = numeric(),
                 lat = numeric(),
                 method = character(),
@@ -1729,12 +1740,16 @@ EsgDataset <- R6::R6Class(
                 }
             }
 
-            time_axis <- self$get_time_axis(index = index)$values
-            time_idx <- if (is.null(time)) {
-                seq_along(time_axis)
-            } else {
-                base::which(time_axis >= time[[1L]] & time_axis <= time[[2L]])
-            }
+            time_info <- self$get_time_axis(index = index)
+            time_axis <- time_info$values
+            time_coordinates <- time_info$coordinates
+            # Calendar-native range matching is required for 360-day and other
+            # non-Gregorian axes whose POSIXct values are only surrogates.
+            time_idx <- cf_time__range_indices(
+                time_axis,
+                time_coordinates,
+                time
+            )
             if (!length(time_idx)) {
                 empty <- private$empty_region_data_table()
                 attr(empty, "grid_sources") <- private$empty_grid_sources_data_table()
@@ -1824,7 +1839,28 @@ EsgDataset <- R6::R6Class(
                 lat = lat,
                 method = method
             )]
-            data.table::setcolorder(out, c("file_index", "variable", "time", "lon", "lat", "method", "value"))
+            coordinate_idx <- match(as.numeric(out$time), as.numeric(time_axis))
+            if (anyNA(coordinate_idx)) {
+                stop("Extracted timestamps could not be matched to the CF time axis.", call. = FALSE)
+            }
+            coordinate_rows <- time_coordinates[
+                coordinate_idx,
+                CF_TIME_COORDINATE_COLUMNS,
+                drop = FALSE
+            ]
+            for (name in CF_TIME_COORDINATE_COLUMNS) {
+                data.table::set(out, j = name, value = coordinate_rows[[name]])
+            }
+            data.table::setcolorder(out, c(
+                "file_index",
+                "variable",
+                "time",
+                CF_TIME_COORDINATE_COLUMNS,
+                "lon",
+                "lat",
+                "method",
+                "value"
+            ))
 
             grid_sources <- sources[, .(
                 file_index = index,

--- a/R/epw-morpher.R
+++ b/R/epw-morpher.R
@@ -1337,6 +1337,62 @@ morpher__reference_case_by <- function(by) {
     setdiff(by, c("experiment_id", "period"))
 }
 
+# Resolve calendar columns with row-level compatibility for old extraction
+# artifacts. Canonical CF fields take precedence; missing values fall back to
+# existing columns and finally to the surrogate POSIXct timestamp.
+morpher__resolve_calendar_columns <- function(climate, month = FALSE, day = FALSE) {
+    n <- nrow(climate)
+    time <- if ("time" %in% names(climate)) climate$time else NULL
+
+    # Resolve one field without replacing usable legacy values when a mixed
+    # collection contains both old and current Parquet schemas.
+    resolve <- function(target, canonical, fallback) {
+        value <- if (target %in% names(climate)) {
+            as.integer(climate[[target]])
+        } else {
+            rep.int(NA_integer_, n)
+        }
+        missing <- is.na(value)
+        value[missing] <- fallback[missing]
+        if (canonical %in% names(climate)) {
+            canonical_value <- as.integer(climate[[canonical]])
+            present <- !is.na(canonical_value)
+            value[present] <- canonical_value[present]
+        }
+        data.table::set(climate, j = target, value = value)
+    }
+
+    if (any(c("year", "cf_year") %in% names(climate)) || !is.null(time)) {
+        fallback_year <- if (is.null(time)) {
+            rep.int(NA_integer_, n)
+        } else {
+            as.integer(format(time, "%Y", tz = "UTC"))
+        }
+        resolve("year", "cf_year", fallback_year)
+    }
+
+    if (isTRUE(month) &&
+        (any(c("month", "cf_month") %in% names(climate)) || !is.null(time))) {
+        fallback_month <- if (is.null(time)) {
+            rep.int(NA_integer_, n)
+        } else {
+            as.integer(format(time, "%m", tz = "UTC"))
+        }
+        resolve("month", "cf_month", fallback_month)
+    }
+    if (isTRUE(day) &&
+        (any(c("day", "cf_day") %in% names(climate)) || !is.null(time))) {
+        fallback_day <- if (is.null(time)) {
+            rep.int(NA_integer_, n)
+        } else {
+            as.integer(format(time, "%d", tz = "UTC"))
+        }
+        resolve("day", "cf_day", fallback_day)
+    }
+
+    climate[]
+}
+
 morpher__normalize_context_climate <- function(climate, years = NULL, labels = NULL) {
     climate <- data.table::as.data.table(data.table::copy(climate))
     if (!"time" %in% names(climate) && "datetime" %in% names(climate)) {
@@ -1351,9 +1407,7 @@ morpher__normalize_context_climate <- function(climate, years = NULL, labels = N
     if (!"period" %in% names(climate) && "interval" %in% names(climate)) {
         climate[, period := as.character(interval)]
     }
-    if (!"year" %in% names(climate) && "time" %in% names(climate)) {
-        climate[, year := as.integer(format(time, "%Y", tz = "UTC"))]
-    }
+    climate <- morpher__resolve_calendar_columns(climate)
     if (!"period" %in% names(climate) && "year" %in% names(climate)) {
         if (!is.null(years) && !is.null(labels)) {
             label_map <- data.table::data.table(year = as.integer(years), period = as.character(labels))
@@ -1496,11 +1550,8 @@ morpher__monthly_climate <- function(data, years = NULL, labels = NULL, warning 
     if (length(missing)) {
         cli::cli_abort("Canonical EPW morphing climate data are missing column(s): {.val {missing}}.")
     }
-    data[, `:=`(
-        year = as.integer(year),
-        month = data.table::month(time),
-        day = data.table::mday(time)
-    )]
+    data <- morpher__resolve_calendar_columns(data, month = TRUE, day = TRUE)
+    data[, year := as.integer(year)]
     data <- data[!(month == 2L & day == 29L)]
 
     checkmate::assert_integerish(years, lower = 1900, unique = TRUE, sorted = TRUE, any.missing = FALSE, null.ok = TRUE)
@@ -3933,11 +3984,8 @@ morpher__belcher_monthly_precip_variable <- function(context, variable_id, refer
         return(data.table::data.table())
     }
     data <- data.table::as.data.table(data.table::copy(data))
-    data[, `:=`(
-        year = as.integer(year),
-        month = data.table::month(time),
-        day = data.table::mday(time)
-    )]
+    data <- morpher__resolve_calendar_columns(data, month = TRUE, day = TRUE)
+    data[, year := as.integer(year)]
     data <- data[!(month == 2L & day == 29L)]
 
     identity <- morpher__context_identity_rows(data)
@@ -4518,8 +4566,7 @@ EpwMorpher <- R6::R6Class(
                 pieces[[i]] <- dt
             }
             climate <- data.table::rbindlist(pieces, use.names = TRUE, fill = TRUE)
-            climate[, year := as.integer(format(time, "%Y", tz = "UTC"))]
-            climate[, month := as.integer(format(time, "%m", tz = "UTC"))]
+            climate <- morpher__resolve_calendar_columns(climate, month = TRUE)
             periods <- data.table::as.data.table(periods)
             periods[, year := as.integer(year)]
             period_years <- periods[, .(
@@ -5385,7 +5432,7 @@ EpwMorpher <- R6::R6Class(
             if (!nrow(climate)) {
                 cli::cli_abort("No extracted climate rows were found for climate summary ID {.val {summary_id}}.")
             }
-            climate[, year := as.integer(format(time, "%Y", tz = "UTC"))]
+            climate <- morpher__resolve_calendar_columns(climate)
             period_years <- private$summary_period_years(summary_id)
             climate <- climate[period_years, on = "year", nomatch = 0L, allow.cartesian = TRUE]
             if (!nrow(climate)) {
@@ -5535,8 +5582,7 @@ EpwMorpher <- R6::R6Class(
             }
 
             climate <- data.table::rbindlist(pieces, use.names = TRUE, fill = TRUE)
-            climate[, year := as.integer(format(time, "%Y", tz = "UTC"))]
-            climate[, month := as.integer(format(time, "%m", tz = "UTC"))]
+            climate <- morpher__resolve_calendar_columns(climate, month = TRUE)
             periods <- data.table::as.data.table(periods)
             periods[, year := as.integer(year)]
             climate <- climate[periods, on = "year", nomatch = 0L]

--- a/R/netcdf.R
+++ b/R/netcdf.R
@@ -178,6 +178,18 @@ CF_TIME_UNIT_SECONDS <- c(
     days = 86400
 )
 
+# Canonical CF coordinates remain valid after non-Gregorian timestamps are
+# represented by surrogate POSIXct values for compatibility with existing APIs.
+CF_TIME_COORDINATE_COLUMNS <- c(
+    "cf_calendar",
+    "cf_year",
+    "cf_month",
+    "cf_day",
+    "cf_day_of_year",
+    "cf_year_days",
+    "annual_phase"
+)
+
 cf_time_check_calendar <- function (calendar) {
     if (!calendar %in% CF_TIME_CALENDARS) {
         stop("Invalid calendar specification", call. = FALSE)
@@ -476,6 +488,90 @@ cf_time_fields2posix <- function (fields, origin, calendar, tz) {
     as.POSIXct(origin_time + day_offsets * 86400 + second_offsets, tz = tz)
 }
 
+# Return the number of days in each requested CF calendar year so annual phase
+# is computed from the model calendar rather than the surrogate Gregorian date.
+cf_time__year_days <- function(year, calendar) {
+    year <- as.integer(year)
+    switch(
+        calendar,
+        "360_day" = rep.int(360L, length(year)),
+        "365_day" = rep.int(365L, length(year)),
+        "noleap" = rep.int(365L, length(year)),
+        "366_day" = rep.int(366L, length(year)),
+        "all_leap" = rep.int(366L, length(year)),
+        ifelse(cf_time_is_leap_gregorian(year), 366L, 365L)
+    )
+}
+
+# Build calendar-native coordinates for persistence and daily morphing. The
+# phase includes the sub-day position, which keeps 3-hourly and 6-hourly axes
+# ordered while mapping every supported calendar onto the same [0, 1) cycle.
+cf_time__coordinates <- function(fields, calendar) {
+    year_start <- data.frame(
+        year = as.integer(fields$year),
+        month = 1L,
+        day = 1L
+    )
+    day_of_year <- as.integer(
+        cf_time_date2offset(fields, year_start, calendar) + 1L
+    )
+    year_days <- cf_time__year_days(fields$year, calendar)
+    day_fraction <- (
+        as.numeric(fields$hour) * 3600 +
+            as.numeric(fields$minute) * 60 +
+            as.numeric(fields$second)
+    ) / 86400
+
+    data.frame(
+        cf_calendar = rep.int(calendar, nrow(fields)),
+        cf_year = as.integer(fields$year),
+        cf_month = as.integer(fields$month),
+        cf_day = as.integer(fields$day),
+        cf_day_of_year = day_of_year,
+        cf_year_days = as.integer(year_days),
+        annual_phase = (day_of_year - 1 + day_fraction) / year_days,
+        stringsAsFactors = FALSE
+    )
+}
+
+# Select a user-supplied time range against calendar-native fields. Comparing
+# the CF date tuple avoids assigning the end of a 360-day year to the preceding
+# Gregorian year merely because its POSIXct value is a continuous surrogate.
+cf_time__range_indices <- function(time, coordinates, range) {
+    if (is.null(range)) {
+        return(seq_along(time))
+    }
+    if (length(time) != nrow(coordinates)) {
+        stop("CF time coordinates do not match the time axis length.", call. = FALSE)
+    }
+
+    # Encode calendar date tuples into sortable day-scale keys. Month and day
+    # bases exceed their legal maxima, so numeric ordering is lexicographic.
+    coordinate_fraction <- coordinates$annual_phase * coordinates$cf_year_days -
+        (coordinates$cf_day_of_year - 1L)
+    coordinate_key <- (
+        (as.numeric(coordinates$cf_year) * 13 + coordinates$cf_month) * 32 +
+            coordinates$cf_day
+    ) + coordinate_fraction
+
+    boundary <- as.POSIXlt(range, tz = "UTC")
+    boundary_fraction <- (
+        as.numeric(boundary$hour) * 3600 +
+            as.numeric(boundary$min) * 60 +
+            as.numeric(boundary$sec)
+    ) / 86400
+    boundary_key <- (
+        (as.numeric(boundary$year + 1900L) * 13 + boundary$mon + 1L) * 32 +
+            boundary$mday
+    ) + boundary_fraction
+
+    which(
+        !is.na(time) &
+            coordinate_key >= boundary_key[[1L]] &
+            coordinate_key <= boundary_key[[2L]]
+    )
+}
+
 parse_cf_time <- function (offsets, units, calendar = "standard", tz = "UTC") {
     calendar <- normalize_cf_calendar(calendar)
     calendar <- cf_time_check_calendar(calendar)
@@ -489,9 +585,11 @@ parse_cf_time <- function (offsets, units, calendar = "standard", tz = "UTC") {
     parsed <- cf_time_parse_definition(units, calendar)
     fields <- cf_time_offsets2fields(offsets, parsed$unit, parsed$origin, calendar)
     posix_time <- cf_time_fields2posix(fields, parsed$origin, calendar, tz)
+    coordinates <- cf_time__coordinates(fields, calendar)
 
     data.table::setattr(posix_time, "cf_units", units)
     data.table::setattr(posix_time, "cf_calendar", calendar)
+    data.table::setattr(posix_time, "cf_coordinates", coordinates)
     posix_time
 }
 
@@ -533,7 +631,8 @@ match_nc_time <- function (x, years = NULL) {
     if (is.null(years)) {
         list(datetime = list(time), which = list(seq_along(time)))
     } else {
-        y <- data.table::year(time)
+        coordinates <- attr(time, "cf_coordinates", exact = TRUE)
+        y <- coordinates$cf_year
         i <- lapply(as.integer(years), function (x) which(y == x))
 
         j <- 1L
@@ -549,7 +648,18 @@ match_nc_time <- function (x, years = NULL) {
             }
         }
 
-        list(datetime = lapply(l, function (idx) time[idx]), which = l)
+        datetime <- lapply(l, function (idx) {
+            value <- time[idx]
+            data.table::setattr(value, "cf_units", attr(time, "cf_units", exact = TRUE))
+            data.table::setattr(value, "cf_calendar", attr(time, "cf_calendar", exact = TRUE))
+            data.table::setattr(
+                value,
+                "cf_coordinates",
+                coordinates[idx, , drop = FALSE]
+            )
+            value
+        })
+        list(datetime = datetime, which = l)
     }
 }
 # }}}

--- a/R/store.R
+++ b/R/store.R
@@ -5895,7 +5895,8 @@ EsgStore <- R6::R6Class(
             ds <- opened$dataset
             on.exit(if (isTRUE(ds$is_open)) ds$close(), add = TRUE)
 
-            time_axis <- ds$get_time_axis(index = 1L)$values
+            time_info <- ds$get_time_axis(index = 1L)
+            time_axis <- time_info$values
             valid_time <- time_axis[!is.na(time_axis)]
             if (!length(valid_time)) {
                 stop("The NetCDF time axis is empty or unavailable.", call. = FALSE)
@@ -5903,7 +5904,13 @@ EsgStore <- R6::R6Class(
             actual_start <- min(valid_time)
             actual_end <- max(valid_time)
             requested_time <- c(plan$time_start[[1L]], plan$time_stop[[1L]])
-            available_time_count <- sum(valid_time >= requested_time[[1L]] & valid_time <= requested_time[[2L]])
+            # Count the same calendar-native indices that read_region() will
+            # extract; surrogate POSIXct years are wrong at 360-day boundaries.
+            available_time_count <- length(cf_time__range_indices(
+                time_axis,
+                time_info$coordinates,
+                requested_time
+            ))
             private$update_file_actual_time(file, actual_start, actual_end)
 
             # Remote reads run in the existing one-shot dataset worker so the
@@ -6143,6 +6150,7 @@ EsgStore <- R6::R6Class(
 
         # decorate_extract {{{
         decorate_extract = function(dt, plan, file) {
+            calendar_columns <- intersect(CF_TIME_COORDINATE_COLUMNS, names(dt))
             dt[, `:=`(
                 plan_id = plan$plan_id[[1L]],
                 file_key = plan$file_key[[1L]],
@@ -6173,6 +6181,7 @@ EsgStore <- R6::R6Class(
                     "variable",
                     "grid_label",
                     "time",
+                    calendar_columns,
                     "lon",
                     "lat",
                     "method",
@@ -6193,6 +6202,7 @@ EsgStore <- R6::R6Class(
                             "variable",
                             "grid_label",
                             "time",
+                            calendar_columns,
                             "lon",
                             "lat",
                             "method",
@@ -6272,13 +6282,22 @@ EsgStore <- R6::R6Class(
 
         # write_extract_partitions {{{
         write_extract_partitions = function(dt, plan, file, overwrite = FALSE) {
-            dt[, year := as.integer(format(time, "%Y", tz = "UTC"))]
+            # Preserve the historical `year` column while making it agree with
+            # the source CF calendar for new extraction artifacts.
+            partition_year <- if ("cf_year" %in% names(dt)) {
+                as.integer(dt$cf_year)
+            } else {
+                as.integer(format(dt$time, "%Y", tz = "UTC"))
+            }
+            dt[, year := partition_year]
             years <- sort(unique(dt$year))
             results <- vector("list", length(years))
             for (i in seq_along(years)) {
-                year <- years[[i]]
-                chunk <- dt[dt$year == year]
-                output_path <- private$output_path(plan, file, year)
+                target_year <- years[[i]]
+                # Use a non-column variable name so data.table does not resolve
+                # both sides of the predicate to `dt$year`.
+                chunk <- dt[dt[["year"]] == target_year]
+                output_path <- private$output_path(plan, file, target_year)
                 private$write_parquet(chunk, output_path, overwrite = overwrite)
                 artifact_id <- self$register_artifact(
                     kind = "extract",
@@ -6289,7 +6308,7 @@ EsgStore <- R6::R6Class(
                     file_key = plan$file_key[[1L]],
                     metadata = list(
                         plan_id = plan$plan_id[[1L]],
-                        year = as.integer(year),
+                        year = as.integer(target_year),
                         # Derived-variable rows carry their scientific lineage
                         # in both the Parquet data and artifact manifest. Raw
                         # extraction chunks simply record null provenance.
@@ -6310,7 +6329,13 @@ EsgStore <- R6::R6Class(
                         }
                     )
                 )
-                results[[i]] <- private$extract_result_row(plan, chunk, output_path, year, artifact_id)
+                results[[i]] <- private$extract_result_row(
+                    plan,
+                    chunk,
+                    output_path,
+                    target_year,
+                    artifact_id
+                )
             }
 
             data.table::rbindlist(results, use.names = TRUE, fill = TRUE)

--- a/man/EsgDataset.Rd
+++ b/man/EsgDataset.Rd
@@ -641,7 +641,8 @@ Get time axis information
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-A list containing time values, units, and calendar.
+A list containing time values, units, calendar, canonical CF
+coordinates, and axis length.
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -846,9 +847,10 @@ read. Only supported when \code{async = TRUE}.}
 }
 \subsection{Returns}{
 A data.table or list of data.tables with columns including
-\code{file_index}, \code{variable}, \code{time}, \code{lon}, \code{lat}, \code{method}, and
-\code{value}. The \code{"grid_sources"} attribute records contributing grid
-coordinates and weights.
+\code{file_index}, \code{variable}, \code{time}, canonical \verb{cf_*} calendar
+coordinates, \code{annual_phase}, \code{lon}, \code{lat}, \code{method}, and \code{value}.
+The \code{"grid_sources"} attribute records contributing grid coordinates
+and weights.
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}

--- a/tests/testthat/helper-cmip6-fixtures.R
+++ b/tests/testthat/helper-cmip6-fixtures.R
@@ -105,11 +105,21 @@ local_cmip6_variable_array <- function(variable_id, lon, lat, time) {
     values
 }
 
-write_local_cmip6_netcdf_fixture <- function(path, year, variable_id = "tas") {
+write_local_cmip6_netcdf_fixture <- function(path, year, variable_id = "tas",
+                                              calendar = "proleptic_gregorian",
+                                              n_years = 1L) {
     spec <- local_cmip6_variable_spec(variable_id)
     lat <- c(1.0, 2.0, 41.0)
     lon <- c(103.5, 104.0, 104.5, 254.0)
-    time <- seq_len(if (local_is_leap_year(year)) 366L else 365L) - 0.5
+    calendar <- normalize_cf_calendar(calendar)
+    calendar <- cf_time_check_calendar(calendar)
+    n_years <- as.integer(n_years)
+    stopifnot(length(n_years) == 1L, !is.na(n_years), n_years >= 1L)
+    fixture_years <- as.integer(year) + seq_len(n_years) - 1L
+    # Generate the exact source-calendar length so multi-year fixtures expose
+    # calendar boundaries that surrogate POSIXct dates cannot represent.
+    n_days <- sum(cf_time__year_days(fixture_years, calendar))
+    time <- seq_len(n_days) - 0.5
     time_bnds <- rbind(time - 0.5, time + 0.5)
     lat_step <- min(diff(sort(lat)))
     lon_step <- min(diff(sort(lon)))
@@ -148,7 +158,7 @@ write_local_cmip6_netcdf_fixture <- function(path, year, variable_id = "tas") {
     RNetCDF::att.put.nc(nc, "NC_GLOBAL", "tracking_id", "NC_CHAR", sprintf("hdl:21.14100/local-test-%s-%s", variable_id, year))
 
     RNetCDF::att.put.nc(nc, "time", "units", "NC_CHAR", sprintf("days since %s-01-01 00:00:00", year))
-    RNetCDF::att.put.nc(nc, "time", "calendar", "NC_CHAR", "proleptic_gregorian")
+    RNetCDF::att.put.nc(nc, "time", "calendar", "NC_CHAR", calendar)
     RNetCDF::att.put.nc(nc, "time", "axis", "NC_CHAR", "T")
     RNetCDF::att.put.nc(nc, "time", "bounds", "NC_CHAR", "time_bnds")
     RNetCDF::att.put.nc(nc, "lat", "units", "NC_CHAR", "degrees_north")

--- a/tests/testthat/test-dataset.R
+++ b/tests/testthat/test-dataset.R
@@ -407,7 +407,9 @@ test_that("EsgDataset$get_time_axis()", {
     expect_true("values" %in% names(time_info))
     expect_true("units" %in% names(time_info))
     expect_true("calendar" %in% names(time_info))
+    expect_true("coordinates" %in% names(time_info))
     expect_s3_class(time_info$values, "POSIXct")
+    expect_named(time_info$coordinates, CF_TIME_COORDINATE_COLUMNS)
 })
 # }}}
 # EsgDataset$get_spatial_grid() {{{
@@ -615,10 +617,26 @@ test_that("EsgDataset$read_region() reads grid-method values and time windows", 
         sources <- attr(dt, "grid_sources")
 
         expect_s3_class(dt, "data.table")
-        expect_named(dt, c("file_index", "variable", "time", "lon", "lat", "method", "value"))
+        expect_named(dt, c(
+            "file_index",
+            "variable",
+            "time",
+            CF_TIME_COORDINATE_COLUMNS,
+            "lon",
+            "lat",
+            "method",
+            "value"
+        ))
         expect_identical(unique(dt$file_index), 1L)
         expect_identical(unique(dt$variable), "tas")
         expect_identical(unique(dt$method), method)
+        expect_identical(unique(dt$cf_calendar), "proleptic_gregorian")
+        expect_identical(dt$cf_year, rep.int(2060L, 2L))
+        expect_identical(dt$cf_month, rep.int(1L, 2L))
+        expect_identical(dt$cf_day, 2:3)
+        expect_identical(dt$cf_day_of_year, 2:3)
+        expect_identical(dt$cf_year_days, rep.int(366L, 2L))
+        expect_equal(dt$annual_phase, c(1.5, 2.5) / 366)
         expect_equal(unique(dt$lon), 103.98)
         expect_equal(unique(dt$lat), 1.37)
         expect_equal(nrow(dt), 2L)
@@ -660,6 +678,43 @@ test_that("EsgDataset$read_region() reads grid-method values and time windows", 
     expect_error(
         ds$read_region("hurs", lon = 103.98, lat = 1.37),
         "None of the requested variable"
+    )
+})
+
+test_that("EsgDataset$read_region() selects and exposes 360-day CF boundaries", {
+    path <- tempfile(fileext = ".nc")
+    write_local_cmip6_netcdf_fixture(
+        path,
+        2060L,
+        calendar = "360_day",
+        n_years = 2L
+    )
+    on.exit(unlink(path), add = TRUE)
+
+    ds <- EsgDataset$new(path)
+    ds$open()
+    on.exit(ds$close(), add = TRUE)
+
+    dt <- ds$read_region(
+        variable = "tas",
+        lon = 103.98,
+        lat = 1.37,
+        time = c("2060-12-30T00:00:00Z", "2061-01-01T23:59:59Z")
+    )
+
+    expect_equal(nrow(dt), 2L)
+    expect_identical(dt$cf_calendar, rep.int("360_day", 2L))
+    expect_identical(dt$cf_year, c(2060L, 2061L))
+    expect_identical(dt$cf_month, c(12L, 1L))
+    expect_identical(dt$cf_day, c(30L, 1L))
+    expect_identical(dt$cf_day_of_year, c(360L, 1L))
+    expect_identical(dt$cf_year_days, rep.int(360L, 2L))
+    expect_equal(dt$annual_phase, c(359.5 / 360, 0.5 / 360))
+    # Both surrogate timestamps remain in Gregorian 2060; the CF columns are
+    # therefore the authoritative year/month identity.
+    expect_identical(
+        as.integer(format(dt$time, "%Y", tz = "UTC")),
+        rep.int(2060L, 2L)
     )
 })
 

--- a/tests/testthat/test-epw-morpher.R
+++ b/tests/testthat/test-epw-morpher.R
@@ -143,6 +143,90 @@ test_that("epw_morph_recipe() accepts morph.R statistical downscaling method ove
     expect_error(epw_morph_recipe(methods = c(tdb = "scale")), "Unsupported")
 })
 
+test_that("morpher calendar columns prefer CF identity with legacy fallback", {
+    climate <- data.table::data.table(
+        time = as.POSIXct(
+            c("2060-12-25 12:00:00", "2060-12-26 12:00:00"),
+            tz = "UTC"
+        ),
+        year = c(2060L, 2062L),
+        cf_year = c(2061L, NA_integer_),
+        cf_month = c(1L, NA_integer_),
+        cf_day = c(1L, NA_integer_)
+    )
+
+    resolved <- morpher__resolve_calendar_columns(
+        climate,
+        month = TRUE,
+        day = TRUE
+    )
+
+    expect_identical(resolved$year, c(2061L, 2062L))
+    expect_identical(resolved$month, c(1L, 12L))
+    expect_identical(resolved$day, c(1L, 26L))
+
+    legacy <- data.table::data.table(
+        time = as.POSIXct("2061-02-03 12:00:00", tz = "UTC")
+    )
+    legacy <- morpher__resolve_calendar_columns(
+        legacy,
+        month = TRUE,
+        day = TRUE
+    )
+    expect_identical(legacy$year, 2061L)
+    expect_identical(legacy$month, 2L)
+    expect_identical(legacy$day, 3L)
+})
+
+test_that("EpwMorpher$summarise_climate() selects 360-day CF years and months", {
+    skip_if_not_installed("duckdb")
+    skip_if_not_installed("RNetCDF")
+
+    nc <- tempfile(fileext = ".nc")
+    write_local_cmip6_netcdf_fixture(
+        nc,
+        2060L,
+        calendar = "360_day",
+        n_years = 2L
+    )
+    on.exit(unlink(nc), add = TRUE)
+
+    dir <- tempfile("esg-store-")
+    store <- EsgStore$new(dir)
+    on.exit(store$close(), add = TRUE)
+
+    docs <- epw_morpher_test_file_docs(
+        path = basename(nc),
+        opendap_url = nc,
+        download_url = nc
+    )
+    query_id <- store$add_files(epw_morpher_test_result(docs))
+    plan <- store$plan_region(
+        query_id = query_id,
+        lon = 103.98,
+        lat = 1.37,
+        time = c("2060-12-30T00:00:00Z", "2061-01-01T23:59:59Z"),
+        site_id = "SIN"
+    )
+    expect_equal(store$extract(plan_id = plan$plan_id)$status, "done")
+
+    morpher <- epw_morpher(
+        store = store,
+        epw = get_cache_epw(),
+        site_id = "SIN",
+        recipe = suppressWarnings(epw_morph_recipe("belcher_absolute"))
+    )
+    climate <- morpher$summarise_climate(
+        plan$plan_id,
+        epw_morph_periods(`2061` = 2061L),
+        strict = FALSE
+    )
+
+    expect_identical(unique(climate$period), "2061")
+    expect_identical(unique(climate$month), 1L)
+    expect_true(all(climate$n_records == 1L))
+})
+
 test_that("R6 EPW morphing backends can be looked up, registered, and selected", {
     expect_true("belcher" %in% epw_morph_backends())
     expect_true("belcher_absolute" %in% epw_morph_backends())

--- a/tests/testthat/test-netcdf.R
+++ b/tests/testthat/test-netcdf.R
@@ -45,6 +45,60 @@ test_that("parse_cf_time() returns POSIXct for common CF calendars", {
     }
 })
 
+test_that("parse_cf_time() retains calendar-native coordinates and annual phase", {
+    year_lengths <- c(
+        standard = 366L,
+        gregorian = 366L,
+        proleptic_gregorian = 366L,
+        noleap = 365L,
+        `365_day` = 365L,
+        `360_day` = 360L,
+        `366_day` = 366L,
+        all_leap = 366L
+    )
+
+    for (calendar in names(year_lengths)) {
+        year_days <- year_lengths[[calendar]]
+        time <- parse_cf_time(
+            c(0, year_days - 1L, year_days),
+            "days since 2000-01-01 00:00:00",
+            calendar
+        )
+        coordinates <- attr(time, "cf_coordinates", exact = TRUE)
+
+        expect_named(coordinates, CF_TIME_COORDINATE_COLUMNS, info = calendar)
+        expect_identical(
+            coordinates$cf_calendar,
+            rep.int(calendar, 3L),
+            info = calendar
+        )
+        expect_identical(coordinates$cf_year, c(2000L, 2000L, 2001L), info = calendar)
+        expect_identical(coordinates$cf_month, c(1L, 12L, 1L), info = calendar)
+        expect_identical(
+            coordinates$cf_day,
+            c(1L, if (identical(calendar, "360_day")) 30L else 31L, 1L),
+            info = calendar
+        )
+        expect_identical(
+            coordinates$cf_day_of_year,
+            c(1L, year_days, 1L),
+            info = calendar
+        )
+        expect_identical(
+            coordinates$cf_year_days,
+            cf_time__year_days(c(2000L, 2000L, 2001L), calendar),
+            info = calendar
+        )
+        expect_equal(
+            coordinates$annual_phase,
+            c(0, (year_days - 1L) / year_days, 0),
+            info = calendar
+        )
+        expect_true(all(coordinates$annual_phase >= 0), info = calendar)
+        expect_true(all(coordinates$annual_phase < 1), info = calendar)
+    }
+})
+
 test_that("get_nc_time() and EsgDataset$get_time_axis() share CF time parsing", {
     path <- local_nc_time_file(
         time_vals = c(0, 1.5),
@@ -73,6 +127,10 @@ test_that("get_nc_time() and EsgDataset$get_time_axis() share CF time parsing", 
     expect_equal(as.numeric(time_info$values), as.numeric(expected))
     expect_identical(attr(time_info$values, "cf_units"), time_info$units)
     expect_identical(attr(time_info$values, "cf_calendar"), time_info$calendar)
+    expect_identical(
+        time_info$coordinates,
+        attr(time_info$values, "cf_coordinates", exact = TRUE)
+    )
 })
 
 test_that("get_nc_time() and EsgDataset$get_time_axis() return POSIXct for 360_day", {
@@ -100,6 +158,32 @@ test_that("get_nc_time() and EsgDataset$get_time_axis() return POSIXct for 360_d
     expect_equal(as.numeric(time_info$values), as.numeric(time))
     expect_identical(attr(time_info$values, "cf_units"), time_info$units)
     expect_identical(attr(time_info$values, "cf_calendar"), time_info$calendar)
+    expect_identical(
+        time_info$coordinates,
+        attr(time_info$values, "cf_coordinates", exact = TRUE)
+    )
+    expect_identical(time_info$coordinates$cf_month, c(2L, 2L, 3L, 3L, 3L))
+    expect_identical(time_info$coordinates$cf_day, c(29L, 30L, 1L, 2L, 3L))
+})
+
+test_that("match_nc_time() groups non-Gregorian axes by CF year", {
+    path <- local_nc_time_file(
+        time_vals = 0:719,
+        units = "days since 2000-01-01 00:00:00",
+        calendar = "360_day"
+    )
+    on.exit(unlink(path), add = TRUE)
+
+    matched <- match_nc_time(path, 2001L)
+    coordinates <- attr(
+        matched$datetime[[1L]],
+        "cf_coordinates",
+        exact = TRUE
+    )
+
+    expect_identical(matched$which[[1L]], 361:720)
+    expect_identical(unique(coordinates$cf_year), 2001L)
+    expect_identical(coordinates$cf_day_of_year, 1:360)
 })
 
 test_that("get_nc_meta()", {

--- a/tests/testthat/test-store.R
+++ b/tests/testthat/test-store.R
@@ -2268,6 +2268,73 @@ test_that("EsgStore$extract()", {
     expect_equal(nrow(ddb_read_table(conn, "extraction_result")), 1L)
 })
 
+test_that("EsgStore$extract() persists and partitions calendar-native years", {
+    skip_if_not_installed("duckdb")
+
+    nc <- tempfile(fileext = ".nc")
+    write_local_cmip6_netcdf_fixture(
+        nc,
+        2060L,
+        calendar = "360_day",
+        n_years = 2L
+    )
+    on.exit(unlink(nc), add = TRUE)
+
+    dir <- tempfile("esg-store-")
+    store <- EsgStore$new(dir)
+    on.exit(store$close(), add = TRUE)
+
+    docs <- store_test__file_docs(
+        path = basename(nc),
+        opendap_url = nc,
+        download_url = nc
+    )
+    query_id <- store$add_files(store_test__result(docs = docs))
+    plan <- store$plan_region(
+        query_id = query_id,
+        lon = 103.98,
+        lat = 1.37,
+        time = c("2060-12-30T00:00:00Z", "2061-01-01T23:59:59Z"),
+        site_id = "SIN"
+    )
+
+    processed <- store$extract(plan_id = plan$plan_id)
+    conn <- priv(store)$conn
+    results <- data.table::as.data.table(
+        ddb_read_table(conn, "extraction_result")
+    )
+    data.table::setorder(results, year)
+
+    expect_equal(processed$status, "done")
+    expect_equal(processed$available_time_count, 2L)
+    expect_identical(results$year, c(2060L, 2061L))
+    expect_identical(results$row_count, c(1L, 1L))
+    expect_true(grepl("year=2060", results$output_path[[1L]], fixed = TRUE))
+    expect_true(grepl("year=2061", results$output_path[[2L]], fixed = TRUE))
+
+    rows <- data.table::rbindlist(lapply(results$output_path, function(path) {
+        parquet <- store_abs_path(path, root = dir)
+        ddb_query(conn, sprintf(
+            paste(
+                "SELECT year, cf_calendar, cf_year, cf_month, cf_day,",
+                "cf_day_of_year, cf_year_days, annual_phase",
+                "FROM read_parquet(%s)"
+            ),
+            ddb_literal(conn, parquet)
+        ))
+    }))
+    data.table::setorder(rows, cf_year)
+
+    expect_equal(rows$year, c(2060L, 2061L))
+    expect_identical(rows$cf_calendar, rep.int("360_day", 2L))
+    expect_equal(rows$cf_year, c(2060L, 2061L))
+    expect_equal(rows$cf_month, c(12L, 1L))
+    expect_equal(rows$cf_day, c(30L, 1L))
+    expect_equal(rows$cf_day_of_year, c(360L, 1L))
+    expect_equal(rows$cf_year_days, rep.int(360L, 2L))
+    expect_equal(rows$annual_phase, c(359.5 / 360, 0.5 / 360))
+})
+
 test_that("EsgStore$extract() records failed plans", {
     skip_if_not_installed("duckdb")
 


### PR DESCRIPTION
## Summary

- Preserve calendar-native year, month, day, day-of-year, year length, and annual phase through point extraction.
- Use CF coordinates for non-Gregorian range selection, yearly Parquet partitions, and morphing summaries while retaining legacy artifact fallback.
- Closes #134.

## Changes

- Attach canonical `cf_*` coordinates and `annual_phase` to parsed NetCDF time axes and `EsgDataset$read_region()` output.
- Select and count requested ranges using CF date tuples instead of surrogate `POSIXct` years.
- Persist and partition extracts by `cf_year`, including a fix for multi-year `data.table` partition predicates.
- Prefer canonical CF year/month/day in `EpwMorpher`, with row-level fallback for older Parquet schemas.
- Add synthetic coverage for Gregorian, no-leap, all-leap, and 360-day calendars, including a 360-day cross-year integration case.

## Validation

- `devtools::test(filter = "netcdf")`
- `R_COVR=true devtools::test(filter = "dataset")`
- `devtools::test(filter = "store")`
- `devtools::test(filter = "epw-morpher")`
- `R_COVR=true devtools::check(document = FALSE, manual = FALSE, cran = FALSE)`: 0 errors, 0 warnings; one pre-existing availability static-analysis NOTE.