### PR TITLE
feat: add constrained daily temperature projection

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -59,6 +59,7 @@ Collate:
     'cli.R'
     'cmip6-availability.R'
     'daily-climatology.R'
+    'daily-temperature.R'
     'data-node.R'
     'dataset.R'
     'dict-check.R'

--- a/NEWS.md
+++ b/NEWS.md
@@ -40,6 +40,13 @@
 
 ## New features
 
+* Added calendar-neutral daily temperature targets and constrained 24-hour
+  temperature projection. Matching future and historical `tas`, `tasmin`, and
+  `tasmax` climatologies provide daily mean, minimum, maximum, and DTR changes.
+  Feasible target statistics are closed while hourly order and extrema timing
+  are preserved; missing extrema and flat template days use explicit, reported
+  fallbacks (#139).
+
 * Added calendar-neutral circular daily-climatology primitives. Odd 21-, 31-,
   and 61-day windows operate on `annual_phase` and map 360-, 365-, and 366-day
   inputs onto a common target grid without date pairing (#137).

--- a/R/daily-temperature.R
+++ b/R/daily-temperature.R
@@ -1,0 +1,767 @@
+# Daily temperature targets and constrained projection {{{
+
+# Validate one long-form daily temperature source before climatology estimation.
+# Only tas, tasmax, and tasmin participate; unrelated variables are left out.
+daily__temperature_source <- function(data, name, by) {
+    checkmate::assert_data_frame(data)
+    checkmate::assert_string(name, min.chars = 1L)
+    checkmate::assert_character(by, any.missing = FALSE, unique = TRUE)
+
+    if (!nrow(data)) {
+        cli::cli_abort("{.arg {name}} must contain at least one observation.")
+    }
+    if (anyDuplicated(names(data))) {
+        cli::cli_abort("{.arg {name}} must have unique column names.")
+    }
+
+    required <- unique(c("variable_id", "annual_phase", "value", by))
+    missing <- setdiff(required, names(data))
+    if (length(missing)) {
+        cli::cli_abort(
+            "{.arg {name}} is missing required column{?s}: {.val {missing}}."
+        )
+    }
+
+    reserved_by <- intersect(
+        by,
+        c(
+            "variable_id", "annual_phase", "value", "target_day",
+            "climatology", "n", ".daily_value",
+            "future_mean", "future_minimum", "future_maximum",
+            "historical_mean", "historical_minimum", "historical_maximum",
+            "n_future_mean", "n_future_minimum", "n_future_maximum",
+            "n_historical_mean", "n_historical_minimum",
+            "n_historical_maximum",
+            "mean_delta", "minimum_delta", "maximum_delta", "dtr_delta",
+            "dtr_status"
+        )
+    )
+    if (length(reserved_by)) {
+        cli::cli_abort(
+            "{.arg by} cannot use temperature input or output column{?s}: {.val {reserved_by}}."
+        )
+    }
+
+    checkmate::assert_character(
+        data[["variable_id"]],
+        any.missing = FALSE,
+        min.len = 1L,
+        .var.name = sprintf("%s[['variable_id']]", name)
+    )
+    annual_phase <- daily__check_phase(
+        data[["annual_phase"]],
+        sprintf("%s[['annual_phase']]", name)
+    )
+    checkmate::assert_numeric(
+        data[["value"]],
+        finite = TRUE,
+        any.missing = TRUE,
+        .var.name = sprintf("%s[['value']]", name)
+    )
+
+    # Work on a private table so callers retain the original extraction rows.
+    source <- data.table::as.data.table(data.table::copy(data))
+    data.table::set(source, j = "annual_phase", value = annual_phase)
+    data.table::set(source, j = "value", value = as.numeric(source[["value"]]))
+    temperature_rows <- source[["variable_id"]] %in%
+        c("tas", "tasmax", "tasmin")
+    source <- source[
+        temperature_rows,
+        c(by, "variable_id", "annual_phase", "value"),
+        with = FALSE
+    ]
+    mean_rows <- source[["variable_id"]] == "tas"
+    if (!any(mean_rows)) {
+        cli::cli_abort("{.arg {name}} must contain {.val tas} observations.")
+    }
+
+    source[]
+}
+
+# Estimate one common-grid climatology for every available temperature variable.
+daily__temperature_climatology <- function(data, by, window_days,
+                                           target_year_days) {
+    daily__climatology(
+        data,
+        value = "value",
+        by = c(by, "variable_id"),
+        window_days = window_days,
+        target_year_days = target_year_days
+    )
+}
+
+# Select one temperature metric from a long climatology and give its value and
+# sample-count columns source-specific names for deterministic joins.
+daily__temperature_metric <- function(climatology, variable, by, source,
+                                      metric) {
+    keys <- c(by, "target_day", "annual_phase")
+    requested_variable <- variable
+    keep <- climatology[["variable_id"]] == requested_variable
+    out <- climatology[
+        keep,
+        c(keys, "climatology", "n"),
+        with = FALSE
+    ]
+    data.table::setnames(
+        out,
+        c("climatology", "n"),
+        c(
+            sprintf("%s_%s", source, metric),
+            sprintf("n_%s_%s", source, metric)
+        )
+    )
+    out[]
+}
+
+# Convert one source's tas/tasmax/tasmin climatologies into one row per target
+# day. The tas grid is authoritative; optional extrema are left-joined to it.
+daily__temperature_wide <- function(climatology, by, source) {
+    keys <- c(by, "target_day", "annual_phase")
+    out <- daily__temperature_metric(
+        climatology, "tas", by, source, "mean"
+    )
+    for (spec in list(
+        c(variable_id = "tasmin", metric = "minimum"),
+        c(variable_id = "tasmax", metric = "maximum")
+    )) {
+        metric <- daily__temperature_metric(
+            climatology,
+            unname(spec[["variable_id"]]),
+            by,
+            source,
+            unname(spec[["metric"]])
+        )
+        if (nrow(metric)) {
+            out <- merge(
+                out,
+                metric,
+                by = keys,
+                all.x = TRUE,
+                sort = FALSE
+            )
+        } else {
+            value_name <- sprintf("%s_%s", source, spec[["metric"]])
+            count_name <- sprintf("n_%s_%s", source, spec[["metric"]])
+            data.table::set(out, j = value_name, value = NA_real_)
+            data.table::set(out, j = count_name, value = NA_integer_)
+        }
+    }
+    out[]
+}
+
+# Build calendar-neutral daily temperature changes from matching future and
+# historical climatologies. Missing extrema retain the mean delta explicitly.
+daily__temperature_targets <- function(
+    future, historical, by = character(), window_days = 31L,
+    target_year_days = 365L
+) {
+    checkmate::assert_character(by, any.missing = FALSE, unique = TRUE)
+    future <- daily__temperature_source(future, "future", by)
+    historical <- daily__temperature_source(historical, "historical", by)
+
+    future_climatology <- daily__temperature_climatology(
+        future, by, window_days, target_year_days
+    )
+    historical_climatology <- daily__temperature_climatology(
+        historical, by, window_days, target_year_days
+    )
+    future_wide <- daily__temperature_wide(
+        future_climatology, by, "future"
+    )
+    historical_wide <- daily__temperature_wide(
+        historical_climatology, by, "historical"
+    )
+
+    keys <- c(by, "target_day", "annual_phase")
+    targets <- merge(
+        future_wide,
+        historical_wide,
+        by = keys,
+        all = TRUE,
+        sort = FALSE
+    )
+    missing_mean <- (
+        !is.finite(targets[["future_mean"]]) |
+            !is.finite(targets[["historical_mean"]]) |
+            targets[["n_future_mean"]] < 1L |
+            targets[["n_historical_mean"]] < 1L
+    )
+    if (any(missing_mean)) {
+        cli::cli_abort(
+            paste0(
+                "Matching future and historical {.val tas} climatologies are ",
+                "required for every target day and group."
+            )
+        )
+    }
+
+    extrema_columns <- c(
+        "future_minimum", "future_maximum",
+        "historical_minimum", "historical_maximum"
+    )
+    extrema_counts <- c(
+        "n_future_minimum", "n_future_maximum",
+        "n_historical_minimum", "n_historical_maximum"
+    )
+    complete_extrema <- Reduce(
+        `&`,
+        lapply(extrema_columns, function(column) {
+            is.finite(targets[[column]])
+        })
+    ) & Reduce(
+        `&`,
+        lapply(extrema_counts, function(column) {
+            !is.na(targets[[column]]) & targets[[column]] > 0L
+        })
+    )
+
+    invalid_extrema <- complete_extrema & (
+        targets[["future_maximum"]] < targets[["future_minimum"]] |
+            targets[["historical_maximum"]] < targets[["historical_minimum"]]
+    )
+    if (any(invalid_extrema)) {
+        cli::cli_abort(
+            paste0(
+                "Daily temperature extrema must satisfy ",
+                "{.val tasmax >= tasmin} for future and historical ",
+                "climatologies."
+            )
+        )
+    }
+
+    # Mean temperature always has an additive target; extrema remain explicitly
+    # unavailable until all four future/historical extrema series are present.
+    data.table::set(
+        targets,
+        j = "mean_delta",
+        value = as.numeric(
+            targets[["future_mean"]] - targets[["historical_mean"]]
+        )
+    )
+    data.table::set(
+        targets, j = "minimum_delta", value = rep.int(NA_real_, nrow(targets))
+    )
+    data.table::set(
+        targets, j = "maximum_delta", value = rep.int(NA_real_, nrow(targets))
+    )
+    data.table::set(
+        targets, j = "dtr_delta", value = rep.int(NA_real_, nrow(targets))
+    )
+    data.table::set(
+        targets,
+        j = "dtr_status",
+        value = rep.int("inherited_missing_extremes", nrow(targets))
+    )
+
+    # For complete extrema, DTR change is the future-minus-historical
+    # difference between their independently estimated daily ranges.
+    adjusted_rows <- which(complete_extrema)
+    if (length(adjusted_rows)) {
+        future_minimum <- targets[["future_minimum"]][adjusted_rows]
+        future_maximum <- targets[["future_maximum"]][adjusted_rows]
+        historical_minimum <- targets[["historical_minimum"]][adjusted_rows]
+        historical_maximum <- targets[["historical_maximum"]][adjusted_rows]
+        data.table::set(
+            targets,
+            i = adjusted_rows,
+            j = "minimum_delta",
+            value = as.numeric(future_minimum - historical_minimum)
+        )
+        data.table::set(
+            targets,
+            i = adjusted_rows,
+            j = "maximum_delta",
+            value = as.numeric(future_maximum - historical_maximum)
+        )
+        data.table::set(
+            targets,
+            i = adjusted_rows,
+            j = "dtr_delta",
+            value = as.numeric(
+                (future_maximum - future_minimum) -
+                    (historical_maximum - historical_minimum)
+            )
+        )
+        data.table::set(
+            targets,
+            i = adjusted_rows,
+            j = "dtr_status",
+            value = "adjusted"
+        )
+    }
+
+    ordered <- c(
+        by, "target_day", "annual_phase",
+        "mean_delta", "minimum_delta", "maximum_delta", "dtr_delta",
+        "dtr_status",
+        "n_future_mean", "n_historical_mean",
+        "n_future_minimum", "n_historical_minimum",
+        "n_future_maximum", "n_historical_maximum"
+    )
+    data.table::setcolorder(targets, ordered)
+    data.table::setorderv(targets, c(by, "target_day"))
+    targets[]
+}
+
+# Construct a monotone normalized shape with fixed zero/one endpoints and the
+# requested mean. A power family retains all ordering and extrema positions.
+daily__temperature_shape <- function(normalized, target_mean, tolerance) {
+    lower_mean <- mean(normalized == 1)
+    upper_mean <- mean(normalized > 0)
+    if (
+        target_mean < lower_mean - tolerance ||
+            target_mean > upper_mean + tolerance
+    ) {
+        cli::cli_abort(
+            paste0(
+                "The requested daily mean is infeasible while preserving all ",
+                "template minimum and maximum positions."
+            )
+        )
+    }
+
+    # Exact boundary means require a monotone step; interior means use a smooth
+    # power curve whose exponent is solved on the log scale.
+    if (target_mean <= lower_mean + tolerance) {
+        return(list(value = as.numeric(normalized == 1), exponent = Inf))
+    }
+    if (target_mean >= upper_mean - tolerance) {
+        return(list(value = as.numeric(normalized > 0), exponent = 0))
+    }
+    if (abs(target_mean - mean(normalized)) <= tolerance) {
+        return(list(value = normalized, exponent = 1))
+    }
+
+    objective <- function(log_exponent) {
+        mean(normalized ^ exp(log_exponent)) - target_mean
+    }
+    log_exponent <- stats::uniroot(
+        objective,
+        interval = c(-40, 40),
+        tol = min(tolerance, 1e-12)
+    )$root
+    exponent <- exp(log_exponent)
+    list(value = normalized ^ exponent, exponent = exponent)
+}
+
+# Project one finite hourly temperature vector onto requested daily statistics.
+# Explicit shift fallbacks keep missing extrema and flat templates traceable.
+daily__project_temperature_day <- function(
+    value, mean_delta, minimum_delta, maximum_delta, dtr_status,
+    tolerance
+) {
+    baseline_mean <- mean(value)
+    baseline_minimum <- min(value)
+    baseline_maximum <- max(value)
+    baseline_range <- baseline_maximum - baseline_minimum
+    target_mean <- baseline_mean + mean_delta
+
+    if (!identical(dtr_status, "adjusted")) {
+        projected <- value + mean_delta
+        return(list(
+            value = projected,
+            target_mean = target_mean,
+            target_minimum = baseline_minimum + mean_delta,
+            target_maximum = baseline_maximum + mean_delta,
+            status = "shift_inherited_dtr",
+            exponent = 1
+        ))
+    }
+    if (!is.finite(minimum_delta) || !is.finite(maximum_delta)) {
+        cli::cli_abort(
+            "Adjusted DTR targets require finite minimum and maximum changes."
+        )
+    }
+
+    target_minimum <- baseline_minimum + minimum_delta
+    target_maximum <- baseline_maximum + maximum_delta
+    target_range <- target_maximum - target_minimum
+    if (target_range < -tolerance) {
+        cli::cli_abort(
+            "The requested daily maximum is lower than the requested daily minimum."
+        )
+    }
+    if (
+        target_mean < target_minimum - tolerance ||
+            target_mean > target_maximum + tolerance
+    ) {
+        cli::cli_abort(
+            "The requested daily mean must lie between the requested minimum and maximum."
+        )
+    }
+
+    if (baseline_range <= tolerance) {
+        projected <- value + mean_delta
+        return(list(
+            value = projected,
+            target_mean = target_mean,
+            target_minimum = target_minimum,
+            target_maximum = target_maximum,
+            status = "fallback_shift_flat_template",
+            exponent = 1
+        ))
+    }
+    if (target_range <= tolerance) {
+        projected <- rep.int(target_mean, length(value))
+        return(list(
+            value = projected,
+            target_mean = target_mean,
+            target_minimum = target_minimum,
+            target_maximum = target_maximum,
+            status = "projected_collapsed_range",
+            exponent = NA_real_
+        ))
+    }
+
+    normalized <- (value - baseline_minimum) / baseline_range
+    normalized_mean <- (target_mean - target_minimum) / target_range
+    shape_tolerance <- tolerance / max(target_range, 1)
+    shape <- daily__temperature_shape(
+        normalized, normalized_mean, shape_tolerance
+    )
+    projected <- target_minimum + target_range * shape$value
+
+    # Guard the numerical contract before any grouped result reaches a backend.
+    closure_error <- max(
+        abs(mean(projected) - target_mean),
+        abs(min(projected) - target_minimum),
+        abs(max(projected) - target_maximum)
+    )
+    if (!is.finite(closure_error) || closure_error > max(tolerance, 1e-9)) {
+        cli::cli_abort(
+            "Daily temperature projection failed its mean/minimum/maximum closure check."
+        )
+    }
+
+    list(
+        value = projected,
+        target_mean = target_mean,
+        target_minimum = target_minimum,
+        target_maximum = target_maximum,
+        status = "projected",
+        exponent = shape$exponent
+    )
+}
+
+# Return cyclic previous values for annual boundary diagnostics. A single-day
+# input has no meaningful adjacent-day boundary and therefore returns NA.
+daily__cyclic_previous <- function(value) {
+    if (length(value) < 2L) {
+        return(rep.int(NA_real_, length(value)))
+    }
+    c(value[[length(value)]], value[-length(value)])
+}
+
+# Apply daily target changes to grouped 24-hour templates and expose closure and
+# cyclic boundary diagnostics without mutating the caller's source rows.
+daily__project_temperature <- function(
+    template, targets, value = "value", day = "target_day", hour = "hour",
+    by = character(), tolerance = 1e-8
+) {
+    checkmate::assert_data_frame(template)
+    checkmate::assert_data_frame(targets)
+    checkmate::assert_string(value, min.chars = 1L)
+    checkmate::assert_string(day, min.chars = 1L)
+    checkmate::assert_string(hour, min.chars = 1L)
+    checkmate::assert_character(by, any.missing = FALSE, unique = TRUE)
+    checkmate::assert_number(tolerance, lower = 0, finite = TRUE)
+    value_column <- value
+    day_column <- day
+    hour_column <- hour
+    reserved_by <- intersect(
+        by,
+        c(
+            value_column, day_column, hour_column,
+            "mean_delta", "minimum_delta", "maximum_delta", "dtr_status"
+        )
+    )
+    if (length(reserved_by)) {
+        cli::cli_abort(
+            "{.arg by} cannot use template, target, or output column{?s}: {.val {reserved_by}}."
+        )
+    }
+
+    if (!nrow(template) || !nrow(targets)) {
+        cli::cli_abort(
+            "{.arg template} and {.arg targets} must both contain rows."
+        )
+    }
+    if (anyDuplicated(names(template)) || anyDuplicated(names(targets))) {
+        cli::cli_abort(
+            "{.arg template} and {.arg targets} must have unique column names."
+        )
+    }
+
+    template_required <- unique(c(by, day, hour, value))
+    target_required <- unique(c(
+        by, day, "mean_delta", "minimum_delta", "maximum_delta", "dtr_status"
+    ))
+    missing_template <- setdiff(template_required, names(template))
+    missing_targets <- setdiff(target_required, names(targets))
+    if (length(missing_template)) {
+        cli::cli_abort(
+            "{.arg template} is missing required column{?s}: {.val {missing_template}}."
+        )
+    }
+    if (length(missing_targets)) {
+        cli::cli_abort(
+            "{.arg targets} is missing required column{?s}: {.val {missing_targets}}."
+        )
+    }
+
+    output_columns <- c(
+        "temperature_projected", "target_mean", "target_minimum",
+        "target_maximum", "projected_mean", "projected_minimum",
+        "projected_maximum", "dtr_status", "projection_status", "shape_exponent",
+        "boundary_jump", "boundary_jump_change"
+    )
+    working_columns <- c(
+        "mean_delta", "minimum_delta", "maximum_delta", "dtr_status",
+        ".daily_row", ".daily_target_found"
+    )
+    conflicts <- intersect(
+        c(output_columns, working_columns),
+        names(template)
+    )
+    if (length(conflicts)) {
+        cli::cli_abort(
+            "{.arg template} already contains output column{?s}: {.val {conflicts}}."
+        )
+    }
+
+    checkmate::assert_numeric(
+        template[[value]],
+        finite = TRUE,
+        any.missing = FALSE,
+        .var.name = sprintf("template[['%s']]", value)
+    )
+    checkmate::assert_integerish(
+        template[[day]],
+        lower = 1L,
+        any.missing = FALSE,
+        .var.name = sprintf("template[['%s']]", day)
+    )
+    checkmate::assert_numeric(
+        template[[hour]],
+        finite = TRUE,
+        any.missing = FALSE,
+        .var.name = sprintf("template[['%s']]", hour)
+    )
+    checkmate::assert_numeric(
+        targets[["mean_delta"]],
+        finite = TRUE,
+        any.missing = FALSE,
+        .var.name = "targets[['mean_delta']]"
+    )
+    checkmate::assert_numeric(
+        targets[["minimum_delta"]],
+        finite = TRUE,
+        any.missing = TRUE,
+        .var.name = "targets[['minimum_delta']]"
+    )
+    checkmate::assert_numeric(
+        targets[["maximum_delta"]],
+        finite = TRUE,
+        any.missing = TRUE,
+        .var.name = "targets[['maximum_delta']]"
+    )
+    checkmate::assert_integerish(
+        targets[[day_column]],
+        lower = 1L,
+        any.missing = FALSE,
+        .var.name = sprintf("targets[['%s']]", day_column)
+    )
+    checkmate::assert_character(
+        targets[["dtr_status"]],
+        any.missing = FALSE,
+        .var.name = "targets[['dtr_status']]"
+    )
+    unknown_status <- setdiff(
+        unique(targets[["dtr_status"]]),
+        c("adjusted", "inherited_missing_extremes")
+    )
+    if (length(unknown_status)) {
+        cli::cli_abort(
+            "Unknown daily temperature DTR status value{?s}: {.val {unknown_status}}."
+        )
+    }
+
+    keys <- c(by, day)
+    target_work <- data.table::as.data.table(data.table::copy(targets))
+    if (anyDuplicated(target_work[, keys, with = FALSE])) {
+        cli::cli_abort(
+            "{.arg targets} must contain one row per requested day and group."
+        )
+    }
+    data.table::set(
+        target_work,
+        j = ".daily_target_found",
+        value = rep.int(TRUE, nrow(target_work))
+    )
+
+    working <- data.table::as.data.table(data.table::copy(template))
+    data.table::set(
+        working, j = ".daily_row", value = seq_len(nrow(working))
+    )
+
+    # A left merge makes target coverage explicit while the private row index
+    # preserves the caller's original order through all grouped calculations.
+    target_join_columns <- c(
+        keys, "mean_delta", "minimum_delta", "maximum_delta", "dtr_status",
+        ".daily_target_found"
+    )
+    working <- merge(
+        working,
+        target_work[, target_join_columns, with = FALSE],
+        by = keys,
+        all.x = TRUE,
+        sort = FALSE
+    )
+    data.table::setorderv(working, ".daily_row")
+    if (any(!working[[".daily_target_found"]] %in% TRUE)) {
+        cli::cli_abort(
+            "{.arg targets} does not cover every template day and group."
+        )
+    }
+
+    group_columns <- c(by, day)
+    template_shape <- working[, .(
+        rows = .N,
+        unique_hours = data.table::uniqueN(get(hour_column))
+    ), by = group_columns]
+    if (any(template_shape$rows != 24L | template_shape$unique_hours != 24L)) {
+        cli::cli_abort(
+            "Each template day and group must contain exactly 24 unique hourly rows."
+        )
+    }
+
+    projection_input_columns <- c(
+        value_column, ".daily_row", "mean_delta", "minimum_delta",
+        "maximum_delta", "dtr_status"
+    )
+    projected <- working[, {
+        result <- daily__project_temperature_day(
+            as.numeric(.SD[[value_column]]),
+            unique(.SD[["mean_delta"]]),
+            unique(.SD[["minimum_delta"]]),
+            unique(.SD[["maximum_delta"]]),
+            unique(.SD[["dtr_status"]]),
+            tolerance
+        )
+        list(
+            .daily_row = .SD[[".daily_row"]],
+            temperature_projected = result$value,
+            target_mean = result$target_mean,
+            target_minimum = result$target_minimum,
+            target_maximum = result$target_maximum,
+            projected_mean = mean(result$value),
+            projected_minimum = min(result$value),
+            projected_maximum = max(result$value),
+            dtr_status = unique(.SD[["dtr_status"]]),
+            projection_status = result$status,
+            shape_exponent = result$exponent
+        )
+    }, by = group_columns, .SDcols = projection_input_columns]
+
+    original_columns <- names(template)
+    out <- data.table::as.data.table(data.table::copy(template))
+    data.table::set(out, j = ".daily_row", value = seq_len(nrow(out)))
+    projection_output_columns <- c(
+        ".daily_row", "temperature_projected", "target_mean",
+        "target_minimum", "target_maximum", "projected_mean",
+        "projected_minimum", "projected_maximum", "dtr_status",
+        "projection_status", "shape_exponent"
+    )
+    out <- merge(
+        out,
+        projected[, projection_output_columns, with = FALSE],
+        by = ".daily_row",
+        all.x = TRUE,
+        sort = FALSE
+    )
+    data.table::setorderv(out, ".daily_row")
+
+    # Measure each boundary at the first chronological hour of a target day.
+    chronological <- out[
+        ,
+        .SD,
+        .SDcols = c(
+            by, day_column, hour_column, value_column,
+            "temperature_projected"
+        )
+    ]
+    data.table::setorderv(
+        chronological,
+        c(by, day_column, hour_column)
+    )
+    boundary <- chronological[, {
+        daily_hour <- .SD[[hour_column]]
+        source_temperature <- .SD[[value_column]]
+        projected_temperature <- .SD[["temperature_projected"]]
+        list(
+            source_first = source_temperature[which.min(daily_hour)],
+            source_last = source_temperature[which.max(daily_hour)],
+            projected_first = projected_temperature[which.min(daily_hour)],
+            projected_last = projected_temperature[which.max(daily_hour)]
+        )
+    }, by = group_columns, .SDcols = c(
+        hour_column, value_column, "temperature_projected"
+    )]
+    data.table::setorderv(boundary, group_columns)
+
+    previous_columns <- c(
+        "previous_source_last", "previous_projected_last"
+    )
+    if (length(by)) {
+        boundary[, (previous_columns) := list(
+            daily__cyclic_previous(.SD[["source_last"]]),
+            daily__cyclic_previous(.SD[["projected_last"]])
+        ), by = by, .SDcols = c("source_last", "projected_last")]
+    } else {
+        data.table::set(
+            boundary,
+            j = "previous_source_last",
+            value = daily__cyclic_previous(boundary[["source_last"]])
+        )
+        data.table::set(
+            boundary,
+            j = "previous_projected_last",
+            value = daily__cyclic_previous(boundary[["projected_last"]])
+        )
+    }
+    projected_jump <- abs(
+        boundary[["projected_first"]] -
+            boundary[["previous_projected_last"]]
+    )
+    source_jump <- abs(
+        boundary[["source_first"]] - boundary[["previous_source_last"]]
+    )
+    data.table::set(
+        boundary, j = "boundary_jump", value = projected_jump
+    )
+    data.table::set(
+        boundary,
+        j = "boundary_jump_change",
+        value = projected_jump - source_jump
+    )
+    boundary_output_columns <- c(
+        keys, "boundary_jump", "boundary_jump_change"
+    )
+    out <- merge(
+        out,
+        boundary[, boundary_output_columns, with = FALSE],
+        by = keys,
+        all.x = TRUE,
+        sort = FALSE
+    )
+
+    data.table::setorderv(out, ".daily_row")
+    data.table::set(out, j = ".daily_row", value = NULL)
+    data.table::setcolorder(out, c(
+        original_columns,
+        setdiff(names(out), original_columns)
+    ))
+    out[]
+}
+
+# }}}

--- a/tests/testthat/test-daily-temperature.R
+++ b/tests/testthat/test-daily-temperature.R
@@ -1,0 +1,214 @@
+# Build deterministic native-calendar tas/tasmax/tasmin rows for target tests.
+daily_test__temperature_source <- function(
+    calendar_days, mean_shift = 0, minimum_shift = 0, maximum_shift = 0,
+    include_extrema = TRUE
+) {
+    data.table::rbindlist(lapply(names(calendar_days), function(calendar) {
+        phase <- daily__phase_grid(calendar_days[[calendar]])
+        mean_value <- 15 + 7 * sin(2 * pi * phase)
+        values <- list(
+            tas = mean_value + mean_shift
+        )
+        if (isTRUE(include_extrema)) {
+            values$tasmin <- mean_value - 4 + minimum_shift
+            values$tasmax <- mean_value + 5 + maximum_shift
+        }
+        data.table::rbindlist(lapply(names(values), function(variable_id) {
+            data.table::data.table(
+                calendar = calendar,
+                variable_id = variable_id,
+                annual_phase = phase,
+                value = values[[variable_id]]
+            )
+        }))
+    }))
+}
+
+test_that("daily temperature targets recover mean and DTR changes across calendars", {
+    calendar_days <- c(`360_day` = 360L, `365_day` = 365L, `366_day` = 366L)
+    historical <- daily_test__temperature_source(calendar_days)
+    future <- daily_test__temperature_source(
+        calendar_days,
+        mean_shift = 2,
+        minimum_shift = 1,
+        maximum_shift = 3
+    )
+    data.table::set(future, j = "source", value = future[["calendar"]])
+    data.table::set(
+        historical, j = "source", value = historical[["calendar"]]
+    )
+    original_future <- data.table::copy(future)
+    original_historical <- data.table::copy(historical)
+
+    targets <- daily__temperature_targets(
+        future,
+        historical,
+        by = c("calendar", "source")
+    )
+
+    expect_identical(future, original_future)
+    expect_identical(historical, original_historical)
+    expect_identical(
+        targets[, .N, by = calendar]$N,
+        rep.int(365L, 3L)
+    )
+    expect_equal(targets$mean_delta, rep(2, nrow(targets)), tolerance = 1e-12)
+    expect_equal(targets$minimum_delta, rep(1, nrow(targets)), tolerance = 1e-12)
+    expect_equal(targets$maximum_delta, rep(3, nrow(targets)), tolerance = 1e-12)
+    expect_equal(targets$dtr_delta, rep(2, nrow(targets)), tolerance = 1e-12)
+    expect_true(all(targets$dtr_status == "adjusted"))
+    expect_true(all(targets$n_future_mean > 0L))
+    expect_true(all(targets$n_historical_mean > 0L))
+})
+
+test_that("daily temperature targets inherit DTR when extrema are unavailable", {
+    calendar_days <- c(`365_day` = 365L)
+    historical <- daily_test__temperature_source(
+        calendar_days,
+        include_extrema = FALSE
+    )
+    future <- daily_test__temperature_source(
+        calendar_days,
+        mean_shift = 2.5,
+        include_extrema = FALSE
+    )
+
+    targets <- daily__temperature_targets(future, historical)
+
+    expect_equal(targets$mean_delta, rep(2.5, 365L), tolerance = 1e-12)
+    expect_true(all(is.na(targets$minimum_delta)))
+    expect_true(all(is.na(targets$maximum_delta)))
+    expect_true(all(is.na(targets$dtr_delta)))
+    expect_true(all(targets$dtr_status == "inherited_missing_extremes"))
+})
+
+test_that("daily temperature projection closes feasible mean and extrema targets", {
+    hour <- 1:24
+    shape <- 5 * sin(2 * pi * (hour - 1) / 24)
+    template <- data.table::data.table(
+        site = rep("A", 48L),
+        target_day = rep(1:2, each = 24L),
+        hour = rep(hour, 2L),
+        value = c(20 + shape, 22 + shape)
+    )
+    template <- template[c(24:1, 48:25)]
+    original <- data.table::copy(template)
+    targets <- data.table::data.table(
+        site = "A",
+        target_day = 1:2,
+        mean_delta = c(1, 3),
+        minimum_delta = c(1, 1),
+        maximum_delta = c(3, 3),
+        dtr_status = "adjusted"
+    )
+
+    projected <- daily__project_temperature(
+        template,
+        targets,
+        by = "site"
+    )
+
+    expect_identical(template, original)
+    expect_identical(nrow(projected), 48L)
+    expect_identical(
+        projected[, names(template), with = FALSE],
+        template
+    )
+    expect_equal(
+        projected[, unique(projected_mean), by = target_day]$V1,
+        c(21, 25),
+        tolerance = 1e-9
+    )
+    expect_equal(
+        projected[, unique(projected_minimum), by = target_day]$V1,
+        c(16, 18),
+        tolerance = 1e-9
+    )
+    expect_equal(
+        projected[, unique(projected_maximum), by = target_day]$V1,
+        c(28, 30),
+        tolerance = 1e-9
+    )
+    expect_true(all(projected$projection_status == "projected"))
+    expect_true(all(is.finite(projected$boundary_jump)))
+    expect_true(all(is.finite(projected$boundary_jump_change)))
+
+    for (day_value in 1:2) {
+        source_day <- template[target_day == day_value]
+        projected_day <- projected[target_day == day_value]
+        value_order <- order(source_day$value)
+
+        expect_true(all(diff(projected_day$temperature_projected[value_order]) >= -1e-12))
+        expect_identical(
+            which.min(projected_day$temperature_projected),
+            which.min(source_day$value)
+        )
+        expect_identical(
+            which.max(projected_day$temperature_projected),
+            which.max(source_day$value)
+        )
+    }
+})
+
+test_that("daily temperature projection records inherited and flat-template fallbacks", {
+    hour <- 1:24
+    source <- 18 + 4 * sin(2 * pi * (hour - 1) / 24)
+    inherited <- daily__project_temperature(
+        data.table::data.table(target_day = 1L, hour = hour, value = source),
+        data.table::data.table(
+            target_day = 1L,
+            mean_delta = 2,
+            minimum_delta = NA_real_,
+            maximum_delta = NA_real_,
+            dtr_status = "inherited_missing_extremes"
+        )
+    )
+    expect_equal(inherited$temperature_projected, source + 2)
+    expect_true(all(inherited$projection_status == "shift_inherited_dtr"))
+
+    flat <- daily__project_temperature(
+        data.table::data.table(target_day = 1L, hour = hour, value = rep(20, 24L)),
+        data.table::data.table(
+            target_day = 1L,
+            mean_delta = 2,
+            minimum_delta = 1,
+            maximum_delta = 3,
+            dtr_status = "adjusted"
+        )
+    )
+    expect_equal(flat$temperature_projected, rep(22, 24L))
+    expect_true(all(flat$projection_status == "fallback_shift_flat_template"))
+    expect_equal(unique(flat$target_minimum), 21)
+    expect_equal(unique(flat$target_maximum), 23)
+})
+
+test_that("daily temperature projection rejects infeasible targets and incomplete days", {
+    hour <- 1:24
+    source <- 20 + 5 * sin(2 * pi * (hour - 1) / 24)
+    target <- data.table::data.table(
+        target_day = 1L,
+        mean_delta = 20,
+        minimum_delta = 0,
+        maximum_delta = 0,
+        dtr_status = "adjusted"
+    )
+
+    expect_error(
+        daily__project_temperature(
+            data.table::data.table(target_day = 1L, hour = hour, value = source),
+            target
+        ),
+        "mean must lie between"
+    )
+    expect_error(
+        daily__project_temperature(
+            data.table::data.table(
+                target_day = 1L,
+                hour = hour[-1L],
+                value = source[-1L]
+            ),
+            target
+        ),
+        "exactly 24 unique"
+    )
+})


### PR DESCRIPTION
## Summary

Closes #138.

Builds daily temperature targets from calendar-neutral future and historical `tas`, `tasmin`, and `tasmax` climatologies, then projects each 24-hour EPW template day onto feasible mean, minimum, and maximum targets without reusing monthly Belcher calculations.

## Changes

- Calculate daily mean, minimum, maximum, and DTR changes on a common annual-phase grid; when extrema are unavailable, retain the mean change with an explicit inherited-DTR status.
- Use an order-preserving power transform that closes feasible daily targets while retaining hourly rank and extrema timing.
- Report achieved statistics and cyclic boundary-jump diagnostics, with explicit inherited-DTR and flat-template fallbacks.
- Cover 360-, 365-, and 366-day inputs, missing extrema, row and extrema preservation, fallbacks, infeasible targets, and incomplete days.