### PR TITLE
feat: add composable future-weather method contracts

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -90,6 +90,9 @@ Collate:
     'shift-tui.R'
     'shift-ui.R'
     'standalone-cache.R'
+    'weather-input.R'
+    'weather-component.R'
+    'weather-signal.R'
     'zzz.R'
 Config/testthat/edition: 3
 Config/Needs/website: r-lib/asciicast, r-lib/pkgload

--- a/NEWS.md
+++ b/NEWS.md
@@ -40,6 +40,13 @@
 
 ## New features
 
+* Added explicit future-weather input roles and reusable `preprocess`,
+  `calendar`, `signal`, `sequence`, `hourly`, `physics`, and `output`
+  component contracts. Registered components declare their input requirements,
+  intermediate data kinds, dimensional scope, stochastic behavior, settings,
+  provenance, and diagnostics while existing `EpwMorphBackend` runners remain
+  compatible (#143).
+
 * Added calendar-neutral daily temperature targets and constrained 24-hour
   temperature projection. Matching future and historical `tas`, `tasmin`, and
   `tasmax` climatologies provide daily mean, minimum, maximum, and DTR changes.

--- a/R/epw-morpher.R
+++ b/R/epw-morpher.R
@@ -1428,10 +1428,12 @@ morpher__normalize_context_climate <- function(climate, years = NULL, labels = N
 }
 
 morpher__context <- function(epw, climate, recipe = epw_morph_recipe("belcher"),
-                              reference_climate = NULL, years = NULL, labels = NULL,
+                              reference_climate = NULL,
+                              years = NULL, labels = NULL,
                               reference_years = NULL, reference_labels = NULL,
                               by = character(),
-                              case = NULL, strict = TRUE, warning = FALSE) {
+                              case = NULL, strict = TRUE, warning = FALSE,
+                              observed_reference = NULL) {
     if (!inherits(epw, "EpwFile")) {
         cli::cli_abort("`epw` must be an internal {.cls EpwFile} object.")
     }
@@ -1446,12 +1448,29 @@ morpher__context <- function(epw, climate, recipe = epw_morph_recipe("belcher"),
             labels = reference_labels
         )
     }
+    if (!is.null(observed_reference)) {
+        observed_reference <- morpher__normalize_context_climate(
+            observed_reference
+        )
+    }
     checkmate::assert_character(by, any.missing = FALSE, unique = TRUE)
+    epw <- epw$clone()
+    # The explicit input set is the authoritative semantic view for new
+    # components. Legacy fields remain available below so existing backends and
+    # external extensions continue to receive the context they already consume.
+    inputs <- weather__context_inputs(
+        epw = epw,
+        model_future = climate,
+        model_historical = reference_climate,
+        observed_reference = observed_reference
+    )
     structure(
         list(
-            epw = epw$clone(),
+            inputs = inputs,
+            epw = epw,
             climate = climate,
             reference_climate = reference_climate,
+            observed_reference = observed_reference,
             recipe = recipe,
             years = years,
             labels = labels,

--- a/R/weather-component.R
+++ b/R/weather-component.R
@@ -1,0 +1,624 @@
+#' @include weather-input.R
+NULL
+
+# Component stages form the stable execution vocabulary shared by paper-
+# faithful recipes, harmonized recipes, and external method adapters.
+WEATHER_COMPONENT_STAGES <- c(
+    "preprocess",
+    "calendar",
+    "signal",
+    "sequence",
+    "hourly",
+    "physics",
+    "output"
+)
+
+# Component scopes distinguish ordinary variable-wise methods from algorithms
+# that must receive multiple variables or a spatial field together.
+WEATHER_COMPONENT_SCOPES <- c(
+    "univariate",
+    "multivariate",
+    "spatial"
+)
+
+# Each stage has one operation that makes a registered component executable;
+# fitting, option validation, and diagnostics remain optional operations.
+WEATHER_COMPONENT_PRIMARY_OPERATIONS <- c(
+    preprocess = "apply",
+    calendar = "apply",
+    signal = "apply",
+    sequence = "generate",
+    hourly = "reconstruct",
+    physics = "apply",
+    output = "write"
+)
+
+# Allowed operation names describe stage semantics without imposing one common
+# run signature on statistically different algorithms.
+WEATHER_COMPONENT_ALLOWED_OPERATIONS <- list(
+    preprocess = c("validate_options", "fit", "apply", "diagnose"),
+    calendar = c("validate_options", "apply", "diagnose"),
+    signal = c(
+        "validate_options", "fit", "apply", "apply_group",
+        "validate_result", "diagnose"
+    ),
+    sequence = c("validate_options", "fit", "generate", "diagnose"),
+    hourly = c("validate_options", "fit", "reconstruct", "diagnose"),
+    physics = c("validate_options", "apply", "diagnose"),
+    output = c("validate_options", "write", "diagnose")
+)
+
+# Registered implementations live outside serialized recipes. Persisted
+# workflows will retain stable component names and options, then resolve the
+# executable functions from this process-local registry.
+WEATHER_COMPONENT_REGISTRY <- new.env(parent = emptyenv())
+
+# WeatherInputRequirement declares one role-specific component dependency.
+# Alternative variable sets use outer OR and inner AND semantics.
+WeatherInputRequirement <- S7::new_class(
+    "WeatherInputRequirement",
+    properties = list(
+        role = S7::new_property(S7::class_character),
+        representations = S7::new_property(
+            S7::class_character,
+            default = character()
+        ),
+        frequencies = S7::new_property(
+            S7::class_character,
+            default = character()
+        ),
+        calendars = S7::new_property(
+            S7::class_character,
+            default = character()
+        ),
+        variable_sets = S7::new_property(S7::class_list, default = list())
+    ),
+    validator = function(self) {
+        if (length(self@role) != 1L ||
+            is.na(self@role) ||
+            !self@role %in% WEATHER_INPUT_ROLES) {
+            return("`role` must identify one future-weather input role.")
+        }
+        for (property in c(
+            "representations",
+            "frequencies",
+            "calendars"
+        )) {
+            value <- S7::prop(self, property)
+            if (anyNA(value) || any(!nzchar(value)) || anyDuplicated(value)) {
+                return(sprintf(
+                    "`%s` must contain unique, non-missing, non-empty values.",
+                    property
+                ))
+            }
+        }
+        if (length(self@representations) &&
+            !all(self@representations %in% WEATHER_INPUT_REPRESENTATIONS)) {
+            return("`representations` contains an unknown input representation.")
+        }
+        for (variable_set in self@variable_sets) {
+            if (!is.character(variable_set) ||
+                !length(variable_set) ||
+                anyNA(variable_set) ||
+                any(!nzchar(variable_set)) ||
+                anyDuplicated(variable_set)) {
+                return(paste(
+                    "Every `variable_sets` entry must contain unique,",
+                    "non-missing, non-empty variable IDs."
+                ))
+            }
+        }
+        NULL
+    }
+)
+
+# Normalize alternative variable requirements once. One character vector is
+# one required AND-set; the list of vectors represents alternative OR-sets.
+component__variable_sets <- function(variable_sets) {
+    if (is.null(variable_sets)) {
+        return(list())
+    }
+    if (is.character(variable_sets)) {
+        variable_sets <- list(variable_sets)
+    }
+    checkmate::assert_list(variable_sets)
+    lapply(variable_sets, function(variable_set) {
+        checkmate::assert_character(
+            variable_set,
+            any.missing = FALSE,
+            min.len = 1L,
+            unique = TRUE
+        )
+        if (any(!nzchar(variable_set))) {
+            cli::cli_abort(
+                "Variable requirement sets cannot contain empty IDs."
+            )
+        }
+        as.character(variable_set)
+    })
+}
+
+# Construct one role-specific requirement consumed by a component spec.
+component__input_requirement <- function(
+    role,
+    representations = character(),
+    frequencies = character(),
+    calendars = character(),
+    variable_sets = list()
+) {
+    checkmate::assert_choice(role, WEATHER_INPUT_ROLES)
+    representations <- weather__descriptor_values(
+        representations,
+        "representations"
+    )
+    if (length(representations)) {
+        checkmate::assert_subset(
+            representations,
+            WEATHER_INPUT_REPRESENTATIONS
+        )
+    }
+    WeatherInputRequirement(
+        role = role,
+        representations = representations,
+        frequencies = weather__descriptor_values(
+            frequencies,
+            "frequencies"
+        ),
+        calendars = weather__descriptor_values(calendars, "calendars"),
+        variable_sets = component__variable_sets(variable_sets)
+    )
+}
+
+# Validate and preserve named role requirements for component construction.
+component__requirements <- function(requirements, name) {
+    if (is.null(requirements)) {
+        return(list())
+    }
+    checkmate::assert_list(requirements, names = "unique")
+    if (length(requirements) &&
+        (is.null(names(requirements)) || any(!nzchar(names(requirements))))) {
+        cli::cli_abort("{.arg {name}} must be named by input role.")
+    }
+    unknown <- setdiff(names(requirements), WEATHER_INPUT_ROLES)
+    if (length(unknown)) {
+        cli::cli_abort(
+            "{.arg {name}} contains unknown input role(s): {.val {unknown}}."
+        )
+    }
+    for (role in names(requirements)) {
+        requirement <- requirements[[role]]
+        if (!S7::S7_inherits(requirement, WeatherInputRequirement)) {
+            cli::cli_abort(
+                "{.arg {name}} entry {.val {role}} must be a WeatherInputRequirement."
+            )
+        }
+        if (!identical(requirement@role, role)) {
+            cli::cli_abort(
+                "{.arg {name}} entry {.val {role}} declares role {.val {requirement@role}}."
+            )
+        }
+    }
+    requirements
+}
+
+# WeatherComponentSpec describes one executable implementation independently
+# of any complete future-weather recipe.
+WeatherComponentSpec <- S7::new_class(
+    "WeatherComponentSpec",
+    properties = list(
+        name = S7::new_property(S7::class_character),
+        stage = S7::new_property(S7::class_character),
+        label = S7::new_property(S7::class_character),
+        required_inputs = S7::new_property(
+            S7::class_list,
+            default = list()
+        ),
+        optional_inputs = S7::new_property(
+            S7::class_list,
+            default = list()
+        ),
+        input_kinds = S7::new_property(S7::class_character),
+        output_kinds = S7::new_property(S7::class_character),
+        scopes = S7::new_property(S7::class_character),
+        stochastic = S7::new_property(S7::class_logical),
+        operations = S7::new_property(S7::class_list),
+        metadata = S7::new_property(S7::class_list, default = list())
+    ),
+    validator = function(self) {
+        if (length(self@name) != 1L ||
+            is.na(self@name) ||
+            !grepl("^[a-z][a-z0-9_]*$", self@name)) {
+            return(
+                "`name` must use lower snake_case and start with a letter."
+            )
+        }
+        if (length(self@stage) != 1L ||
+            is.na(self@stage) ||
+            !self@stage %in% WEATHER_COMPONENT_STAGES) {
+            return("`stage` must identify one future-weather component stage.")
+        }
+        if (length(self@label) != 1L ||
+            is.na(self@label) ||
+            !nzchar(self@label)) {
+            return("`label` must be one non-empty string.")
+        }
+        overlap <- intersect(
+            names(self@required_inputs),
+            names(self@optional_inputs)
+        )
+        if (length(overlap)) {
+            return(sprintf(
+                "Input role(s) cannot be both required and optional: %s.",
+                paste(overlap, collapse = ", ")
+            ))
+        }
+        for (property in c("input_kinds", "output_kinds", "scopes")) {
+            value <- S7::prop(self, property)
+            if (!length(value) ||
+                anyNA(value) ||
+                any(!nzchar(value)) ||
+                anyDuplicated(value)) {
+                return(sprintf(
+                    "`%s` must contain unique, non-missing, non-empty values.",
+                    property
+                ))
+            }
+        }
+        if (!all(self@scopes %in% WEATHER_COMPONENT_SCOPES)) {
+            return("`scopes` contains an unknown component scope.")
+        }
+        if (length(self@stochastic) != 1L || is.na(self@stochastic)) {
+            return("`stochastic` must be one non-missing logical value.")
+        }
+        if (is.null(names(self@operations)) ||
+            any(!nzchar(names(self@operations))) ||
+            anyDuplicated(names(self@operations)) ||
+            !all(vapply(self@operations, is.function, logical(1L)))) {
+            return("`operations` must be a uniquely named list of functions.")
+        }
+        allowed <- WEATHER_COMPONENT_ALLOWED_OPERATIONS[[self@stage]]
+        unknown <- setdiff(names(self@operations), allowed)
+        if (length(unknown)) {
+            return(sprintf(
+                "Unknown `%s` operation(s): %s.",
+                self@stage,
+                paste(unknown, collapse = ", ")
+            ))
+        }
+        primary <- WEATHER_COMPONENT_PRIMARY_OPERATIONS[[self@stage]]
+        if (!primary %in% names(self@operations)) {
+            return(sprintf(
+                "`%s` components require a named `%s` operation.",
+                self@stage,
+                primary
+            ))
+        }
+        NULL
+    }
+)
+
+# Construct a component specification after normalizing all inspectable
+# capabilities and executable operations.
+component__spec <- function(
+    name, stage, label = name,
+    required_inputs = list(), optional_inputs = list(),
+    input_kinds, output_kinds,
+    scopes = "univariate", stochastic = FALSE,
+    operations, metadata = list()
+) {
+    checkmate::assert_string(name, pattern = "^[a-z][a-z0-9_]*$")
+    checkmate::assert_choice(stage, WEATHER_COMPONENT_STAGES)
+    checkmate::assert_string(label, min.chars = 1L)
+    required_inputs <- component__requirements(
+        required_inputs,
+        "required_inputs"
+    )
+    optional_inputs <- component__requirements(
+        optional_inputs,
+        "optional_inputs"
+    )
+    overlap <- intersect(names(required_inputs), names(optional_inputs))
+    if (length(overlap)) {
+        cli::cli_abort(
+            "Input role(s) cannot be both required and optional: {.val {overlap}}."
+        )
+    }
+    input_kinds <- weather__descriptor_values(input_kinds, "input_kinds")
+    output_kinds <- weather__descriptor_values(output_kinds, "output_kinds")
+    scopes <- weather__descriptor_values(scopes, "scopes")
+    checkmate::assert_subset(scopes, WEATHER_COMPONENT_SCOPES)
+    checkmate::assert_flag(stochastic)
+    checkmate::assert_list(operations, names = "unique")
+    checkmate::assert_list(metadata, names = "unique")
+
+    WeatherComponentSpec(
+        name = name,
+        stage = stage,
+        label = label,
+        required_inputs = required_inputs,
+        optional_inputs = optional_inputs,
+        input_kinds = input_kinds,
+        output_kinds = output_kinds,
+        scopes = scopes,
+        stochastic = stochastic,
+        operations = operations,
+        metadata = metadata
+    )
+}
+
+# Resolve a stable registry key without relying on environment nesting or list
+# insertion order.
+component__registry_key <- function(stage, name) {
+    checkmate::assert_choice(stage, WEATHER_COMPONENT_STAGES)
+    checkmate::assert_string(name, pattern = "^[a-z][a-z0-9_]*$")
+    paste(stage, name, sep = "::")
+}
+
+# Register one executable component while keeping serialized recipes free from
+# process-specific function objects.
+component__register <- function(
+    component, overwrite = FALSE,
+    registry = WEATHER_COMPONENT_REGISTRY
+) {
+    if (!S7::S7_inherits(component, WeatherComponentSpec)) {
+        cli::cli_abort(
+            "{.arg component} must be a WeatherComponentSpec object."
+        )
+    }
+    checkmate::assert_flag(overwrite)
+    checkmate::assert_environment(registry)
+    key <- component__registry_key(component@stage, component@name)
+    if (exists(key, envir = registry, inherits = FALSE) &&
+        !isTRUE(overwrite)) {
+        cli::cli_abort(
+            "Weather component {.val {key}} is already registered."
+        )
+    }
+    assign(key, component, envir = registry)
+    invisible(component)
+}
+
+# Retrieve one registered component by its stage and stable name.
+component__get <- function(
+    stage, name,
+    registry = WEATHER_COMPONENT_REGISTRY
+) {
+    checkmate::assert_environment(registry)
+    key <- component__registry_key(stage, name)
+    if (!exists(key, envir = registry, inherits = FALSE)) {
+        cli::cli_abort("Unknown weather component: {.val {key}}.")
+    }
+    get(key, envir = registry, inherits = FALSE)
+}
+
+# Return inspectable registry metadata without exposing executable functions.
+component__list <- function(
+    stage = NULL,
+    registry = WEATHER_COMPONENT_REGISTRY
+) {
+    checkmate::assert_choice(
+        stage,
+        WEATHER_COMPONENT_STAGES,
+        null.ok = TRUE
+    )
+    checkmate::assert_environment(registry)
+    keys <- ls(envir = registry, all.names = TRUE)
+    components <- lapply(keys, get, envir = registry, inherits = FALSE)
+    if (!is.null(stage)) {
+        components <- Filter(
+            function(component) identical(component@stage, stage),
+            components
+        )
+    }
+    if (!length(components)) {
+        return(data.table::data.table(
+            stage = character(),
+            name = character(),
+            label = character(),
+            input_kinds = character(),
+            output_kinds = character(),
+            scopes = character(),
+            stochastic = logical()
+        ))
+    }
+    out <- data.table::rbindlist(lapply(components, function(component) {
+        data.table::data.table(
+            stage = component@stage,
+            name = component@name,
+            label = component@label,
+            input_kinds = paste(component@input_kinds, collapse = ","),
+            output_kinds = paste(component@output_kinds, collapse = ","),
+            scopes = paste(component@scopes, collapse = ","),
+            stochastic = component@stochastic
+        )
+    }))
+    # Use explicit column access so package checks do not treat temporary
+    # ordering columns as unresolved symbols.
+    data.table::set(
+        out,
+        j = ".stage_order",
+        value = match(out[["stage"]], WEATHER_COMPONENT_STAGES)
+    )
+    data.table::setorderv(out, c(".stage_order", "name"))
+    data.table::set(out, j = ".stage_order", value = NULL)
+    out[]
+}
+
+# Report whether an upstream component can feed a later component according to
+# declared stage order and at least one shared intermediate data kind.
+component__compatible <- function(upstream, downstream) {
+    if (!S7::S7_inherits(upstream, WeatherComponentSpec) ||
+        !S7::S7_inherits(downstream, WeatherComponentSpec)) {
+        cli::cli_abort(
+            "`upstream` and `downstream` must be WeatherComponentSpec objects."
+        )
+    }
+    upstream_order <- match(upstream@stage, WEATHER_COMPONENT_STAGES)
+    downstream_order <- match(downstream@stage, WEATHER_COMPONENT_STAGES)
+    upstream_order < downstream_order &&
+        length(intersect(
+            upstream@output_kinds,
+            downstream@input_kinds
+        )) > 0L
+}
+
+# Fail early with the precise stage or data-kind incompatibility that prevents
+# two components from being composed.
+component__assert_compatible <- function(upstream, downstream) {
+    if (component__compatible(upstream, downstream)) {
+        return(invisible(TRUE))
+    }
+    upstream_order <- match(upstream@stage, WEATHER_COMPONENT_STAGES)
+    downstream_order <- match(downstream@stage, WEATHER_COMPONENT_STAGES)
+    if (upstream_order >= downstream_order) {
+        cli::cli_abort(
+            "Component {.val {downstream@stage}::{downstream@name}} must follow {.val {upstream@stage}::{upstream@name}} in stage order."
+        )
+    }
+    cli::cli_abort(c(
+        "Component {.val {upstream@stage}::{upstream@name}} cannot feed {.val {downstream@stage}::{downstream@name}}.",
+        "x" = "Produced kind(s): {.val {upstream@output_kinds}}.",
+        "x" = "Accepted kind(s): {.val {downstream@input_kinds}}."
+    ))
+}
+
+# Check one concrete input against a role-specific component requirement.
+component__requirement_errors <- function(requirement, input) {
+    errors <- character()
+    if (length(requirement@representations) &&
+        !input@representation %in% requirement@representations) {
+        errors <- c(
+            errors,
+            sprintf(
+                "role `%s` representation `%s` is unsupported",
+                requirement@role,
+                input@representation
+            )
+        )
+    }
+    for (property in c("frequencies", "calendars")) {
+        required <- S7::prop(requirement, property)
+        if (!length(required)) {
+            next
+        }
+        available <- S7::prop(input, property)
+        if (!length(available) || !all(available %in% required)) {
+            shown <- if (length(available)) {
+                paste(available, collapse = ", ")
+            } else {
+                "<missing>"
+            }
+            errors <- c(
+                errors,
+                sprintf(
+                    "role `%s` %s `%s` do not satisfy `%s`",
+                    requirement@role,
+                    property,
+                    shown,
+                    paste(required, collapse = ", ")
+                )
+            )
+        }
+    }
+    if (length(requirement@variable_sets)) {
+        matched <- vapply(
+            requirement@variable_sets,
+            function(variable_set) all(variable_set %in% input@variables),
+            logical(1L)
+        )
+        if (!any(matched)) {
+            alternatives <- vapply(
+                requirement@variable_sets,
+                paste,
+                character(1L),
+                collapse = " + "
+            )
+            errors <- c(
+                errors,
+                sprintf(
+                    "role `%s` lacks variable alternative `%s`",
+                    requirement@role,
+                    paste(alternatives, collapse = "` or `")
+                )
+            )
+        }
+    }
+    errors
+}
+
+# Validate all required inputs and every supplied optional input before a
+# component starts fitting or transforming data.
+component__input_errors <- function(component, inputs) {
+    if (!S7::S7_inherits(component, WeatherComponentSpec)) {
+        cli::cli_abort(
+            "{.arg component} must be a WeatherComponentSpec object."
+        )
+    }
+    if (!S7::S7_inherits(inputs, WeatherInputs)) {
+        cli::cli_abort("{.arg inputs} must be a WeatherInputs object.")
+    }
+    errors <- character()
+    for (role in names(component@required_inputs)) {
+        input <- weather__get_input(inputs, role)
+        if (is.null(input)) {
+            errors <- c(errors, sprintf("required role `%s` is missing", role))
+            next
+        }
+        errors <- c(
+            errors,
+            component__requirement_errors(
+                component@required_inputs[[role]],
+                input
+            )
+        )
+    }
+    for (role in names(component@optional_inputs)) {
+        input <- weather__get_input(inputs, role)
+        if (is.null(input)) {
+            next
+        }
+        errors <- c(
+            errors,
+            component__requirement_errors(
+                component@optional_inputs[[role]],
+                input
+            )
+        )
+    }
+    unique(errors)
+}
+
+# Abort with all input-contract failures together so discovery and workflow
+# planning can explain every missing requirement in one pass.
+component__validate_inputs <- function(component, inputs) {
+    errors <- component__input_errors(component, inputs)
+    if (length(errors)) {
+        cli::cli_abort(c(
+            "Weather component input requirements are not satisfied.",
+            "x" = errors
+        ))
+    }
+    invisible(TRUE)
+}
+
+# Resolve one executable operation from a registered component specification.
+component__operation <- function(component, operation) {
+    if (!S7::S7_inherits(component, WeatherComponentSpec)) {
+        cli::cli_abort(
+            "{.arg component} must be a WeatherComponentSpec object."
+        )
+    }
+    checkmate::assert_string(operation, min.chars = 1L)
+    if (!operation %in% names(component@operations)) {
+        cli::cli_abort(
+            "Component {.val {component@stage}::{component@name}} does not implement operation {.val {operation}}."
+        )
+    }
+    component@operations[[operation]]
+}
+
+# Execute one named component operation without embedding function objects in a
+# recipe or persisted task specification.
+component__execute <- function(component, operation, ...) {
+    component__operation(component, operation)(...)
+}

--- a/R/weather-input.R
+++ b/R/weather-input.R
@@ -1,0 +1,258 @@
+# Future-weather input roles remain independent because bias adjustment can
+# require an observational reference and matching historical/future model data
+# in addition to the hourly weather template being transformed.
+WEATHER_INPUT_ROLES <- c(
+    "weather_template",
+    "observed_reference",
+    "model_historical",
+    "model_future"
+)
+
+# Representations describe how an input can be consumed without constraining
+# the concrete R object used to carry an EPW, table, grid, library, or workflow
+# stage.
+WEATHER_INPUT_REPRESENTATIONS <- c(
+    "epw",
+    "series",
+    "grid",
+    "hourly_library",
+    "stage",
+    "external"
+)
+
+# WeatherInput keeps the semantic role separate from source metadata so a
+# component never has to infer whether "reference" means observations or a
+# historical model run.
+WeatherInput <- S7::new_class(
+    "WeatherInput",
+    properties = list(
+        role = S7::new_property(S7::class_character),
+        source = S7::new_property(S7::class_any),
+        representation = S7::new_property(S7::class_character),
+        variables = S7::new_property(S7::class_character, default = character()),
+        frequencies = S7::new_property(S7::class_character, default = character()),
+        calendars = S7::new_property(S7::class_character, default = character()),
+        provenance = S7::new_property(S7::class_list, default = list()),
+        metadata = S7::new_property(S7::class_list, default = list())
+    ),
+    validator = function(self) {
+        if (is.null(self@source)) {
+            return("`source` cannot be NULL.")
+        }
+        if (length(self@role) != 1L ||
+            is.na(self@role) ||
+            !self@role %in% WEATHER_INPUT_ROLES) {
+            return(sprintf(
+                "`role` must be one of %s.",
+                paste(sprintf("`%s`", WEATHER_INPUT_ROLES), collapse = ", ")
+            ))
+        }
+        if (length(self@representation) != 1L ||
+            is.na(self@representation) ||
+            !self@representation %in% WEATHER_INPUT_REPRESENTATIONS) {
+            return(sprintf(
+                "`representation` must be one of %s.",
+                paste(
+                    sprintf("`%s`", WEATHER_INPUT_REPRESENTATIONS),
+                    collapse = ", "
+                )
+            ))
+        }
+        for (property in c("variables", "frequencies", "calendars")) {
+            value <- S7::prop(self, property)
+            if (anyNA(value) || any(!nzchar(value)) || anyDuplicated(value)) {
+                return(sprintf(
+                    "`%s` must contain unique, non-missing, non-empty values.",
+                    property
+                ))
+            }
+        }
+        NULL
+    }
+)
+
+# WeatherInputs provides one named slot for every semantic role. Missing roles
+# remain explicit NULL values instead of being guessed from another input.
+WeatherInputs <- S7::new_class(
+    "WeatherInputs",
+    properties = list(
+        weather_template = S7::new_property(S7::class_any, default = NULL),
+        observed_reference = S7::new_property(S7::class_any, default = NULL),
+        model_historical = S7::new_property(S7::class_any, default = NULL),
+        model_future = S7::new_property(S7::class_any, default = NULL)
+    ),
+    validator = function(self) {
+        present <- character()
+        for (role in WEATHER_INPUT_ROLES) {
+            value <- S7::prop(self, role)
+            if (is.null(value)) {
+                next
+            }
+            present <- c(present, role)
+            if (!S7::S7_inherits(value, WeatherInput)) {
+                return(sprintf("`%s` must be a WeatherInput or NULL.", role))
+            }
+            if (!identical(value@role, role)) {
+                return(sprintf(
+                    "`%s` contains input role `%s`.",
+                    role,
+                    value@role
+                ))
+            }
+        }
+        if (!length(present)) {
+            return("At least one future-weather input must be supplied.")
+        }
+        NULL
+    }
+)
+
+# Normalize optional descriptor values once so every input has stable,
+# serializable metadata even when its source table uses factors or list columns.
+weather__descriptor_values <- function(value, name) {
+    if (is.null(value)) {
+        return(character())
+    }
+    checkmate::assert_character(
+        value,
+        any.missing = FALSE,
+        unique = TRUE
+    )
+    value <- as.character(value)
+    if (any(!nzchar(value))) {
+        cli::cli_abort("{.arg {name}} cannot contain empty values.")
+    }
+    value
+}
+
+# Read one descriptor from a canonical climate table without requiring all
+# external or deferred sources to materialize their data at construction time.
+weather__source_values <- function(source, columns) {
+    if (!is.data.frame(source)) {
+        return(character())
+    }
+    column <- intersect(columns, names(source))
+    if (!length(column)) {
+        return(character())
+    }
+    values <- unique(as.character(source[[column[[1L]]]]))
+    values[!is.na(values) & nzchar(values)]
+}
+
+# Infer only the physical representation of common in-package sources. Unknown
+# objects remain explicit external inputs instead of being inspected by class
+# name heuristics that optional packages could accidentally satisfy.
+weather__representation <- function(source) {
+    if (inherits(source, "EpwFile") ||
+        (is.character(source) && length(source) == 1L &&
+            grepl("\\.epw$", source, ignore.case = TRUE))) {
+        return("epw")
+    }
+    if (is.data.frame(source)) {
+        return("series")
+    }
+    "external"
+}
+
+# Construct one role-labelled future-weather input while retaining the source
+# object unchanged and deriving only metadata that are already materialized.
+weather__new_input <- function(
+    role, source, representation = NULL,
+    variables = NULL, frequencies = NULL, calendars = NULL,
+    provenance = list(), metadata = list()
+) {
+    checkmate::assert_choice(role, WEATHER_INPUT_ROLES)
+    if (missing(source) || is.null(source)) {
+        cli::cli_abort("{.arg source} cannot be NULL.")
+    }
+    if (is.null(representation)) {
+        representation <- weather__representation(source)
+    }
+    checkmate::assert_choice(
+        representation,
+        WEATHER_INPUT_REPRESENTATIONS
+    )
+    if (is.null(variables)) {
+        variables <- weather__source_values(source, "variable_id")
+    }
+    if (is.null(frequencies)) {
+        frequencies <- weather__source_values(source, "frequency")
+    }
+    if (is.null(calendars)) {
+        calendars <- weather__source_values(
+            source,
+            c("cf_calendar", "calendar")
+        )
+    }
+    checkmate::assert_list(provenance, names = "unique")
+    checkmate::assert_list(metadata, names = "unique")
+
+    WeatherInput(
+        role = role,
+        source = source,
+        representation = representation,
+        variables = weather__descriptor_values(variables, "variables"),
+        frequencies = weather__descriptor_values(
+            frequencies,
+            "frequencies"
+        ),
+        calendars = weather__descriptor_values(calendars, "calendars"),
+        provenance = provenance,
+        metadata = metadata
+    )
+}
+
+# Construct the complete role-addressable input set used by component
+# validation and execution contexts.
+weather__new_inputs <- function(
+    weather_template = NULL,
+    observed_reference = NULL,
+    model_historical = NULL,
+    model_future = NULL
+) {
+    WeatherInputs(
+        weather_template = weather_template,
+        observed_reference = observed_reference,
+        model_historical = model_historical,
+        model_future = model_future
+    )
+}
+
+# Retrieve one input by semantic role without exposing callers to dynamic S7
+# property access.
+weather__get_input <- function(inputs, role) {
+    if (!S7::S7_inherits(inputs, WeatherInputs)) {
+        cli::cli_abort("{.arg inputs} must be a WeatherInputs object.")
+    }
+    checkmate::assert_choice(role, WEATHER_INPUT_ROLES)
+    S7::prop(inputs, role)
+}
+
+# Build explicit role-labelled inputs for the legacy morphing context. The old
+# context fields are retained separately for custom backend compatibility.
+weather__context_inputs <- function(
+    epw, model_future,
+    model_historical = NULL,
+    observed_reference = NULL
+) {
+    weather__new_inputs(
+        weather_template = weather__new_input(
+            "weather_template",
+            epw,
+            representation = "epw",
+            frequencies = "hour",
+            calendars = "gregorian"
+        ),
+        observed_reference = if (is.null(observed_reference)) {
+            NULL
+        } else {
+            weather__new_input("observed_reference", observed_reference)
+        },
+        model_historical = if (is.null(model_historical)) {
+            NULL
+        } else {
+            weather__new_input("model_historical", model_historical)
+        },
+        model_future = weather__new_input("model_future", model_future)
+    )
+}

--- a/R/weather-signal.R
+++ b/R/weather-signal.R
@@ -1,0 +1,618 @@
+#' @include weather-component.R
+NULL
+
+# Signal profiles distinguish defaults supported by a published method from
+# experimental defaults introduced by an implementation.
+SIGNAL_PROFILE_EVIDENCE <- c("published", "experimental")
+
+# Signal execution either aborts at the first failed group or returns the
+# failure explicitly alongside successful group results.
+SIGNAL_ERROR_POLICIES <- c("abort", "collect")
+
+# SignalVariableProfile records variable-specific defaults without embedding
+# them in an algorithm function or losing their evidence status.
+SignalVariableProfile <- S7::new_class(
+    "SignalVariableProfile",
+    properties = list(
+        variable_id = S7::new_property(S7::class_character),
+        evidence = S7::new_property(S7::class_character),
+        settings = S7::new_property(S7::class_list),
+        references = S7::new_property(
+            S7::class_character,
+            default = character()
+        ),
+        metadata = S7::new_property(S7::class_list, default = list())
+    ),
+    validator = function(self) {
+        if (length(self@variable_id) != 1L ||
+            is.na(self@variable_id) ||
+            !grepl("^[A-Za-z][A-Za-z0-9_]*$", self@variable_id)) {
+            return("`variable_id` must be one CMIP-style variable identifier.")
+        }
+        if (length(self@evidence) != 1L ||
+            is.na(self@evidence) ||
+            !self@evidence %in% SIGNAL_PROFILE_EVIDENCE) {
+            return(sprintf(
+                "`evidence` must be one of %s.",
+                paste(
+                    sprintf("`%s`", SIGNAL_PROFILE_EVIDENCE),
+                    collapse = ", "
+                )
+            ))
+        }
+        if (length(self@settings) &&
+            (is.null(names(self@settings)) ||
+                any(!nzchar(names(self@settings))) ||
+                anyDuplicated(names(self@settings)))) {
+            return("`settings` must be a uniquely named list.")
+        }
+        if (length(self@metadata) &&
+            (is.null(names(self@metadata)) ||
+                any(!nzchar(names(self@metadata))) ||
+                anyDuplicated(names(self@metadata)))) {
+            return("`metadata` must be a uniquely named list.")
+        }
+        if (anyNA(self@references) ||
+            any(!nzchar(self@references)) ||
+            anyDuplicated(self@references)) {
+            return(
+                "`references` must contain unique, non-missing, non-empty values."
+            )
+        }
+        if (identical(self@evidence, "published") &&
+            !length(self@references)) {
+            return(
+                "Published variable profiles must provide at least one reference."
+            )
+        }
+        NULL
+    }
+)
+
+# SignalGroup carries one already aligned unit of work. Calendar mapping and
+# source alignment happen before this boundary so kernels never infer dates.
+SignalGroup <- S7::new_class(
+    "SignalGroup",
+    properties = list(
+        key = S7::new_property(S7::class_list, default = list()),
+        inputs = S7::new_property(S7::class_list),
+        variables = S7::new_property(S7::class_character)
+    ),
+    validator = function(self) {
+        if (length(self@key)) {
+            if (is.null(names(self@key)) ||
+                any(!nzchar(names(self@key))) ||
+                anyDuplicated(names(self@key)) ||
+                any(vapply(self@key, length, integer(1L)) != 1L) ||
+                any(!vapply(self@key, is.atomic, logical(1L)))) {
+                return(
+                    "`key` must be a uniquely named list of atomic scalar values."
+                )
+            }
+        }
+        if (!length(self@inputs) ||
+            is.null(names(self@inputs)) ||
+            any(!nzchar(names(self@inputs))) ||
+            anyDuplicated(names(self@inputs))) {
+            return("`inputs` must be a non-empty, uniquely named role list.")
+        }
+        if (!all(names(self@inputs) %in% WEATHER_INPUT_ROLES)) {
+            return("`inputs` contains an unknown future-weather input role.")
+        }
+        if (any(vapply(self@inputs, is.null, logical(1L)))) {
+            return("`inputs` cannot contain NULL role payloads.")
+        }
+        if (!length(self@variables) ||
+            anyNA(self@variables) ||
+            any(!nzchar(self@variables)) ||
+            anyDuplicated(self@variables) ||
+            any(!grepl("^[A-Za-z][A-Za-z0-9_]*$", self@variables))) {
+            return(
+                "`variables` must contain unique, non-missing variable IDs."
+            )
+        }
+        NULL
+    }
+)
+
+# SignalExecutionResult keeps group outputs positionally aligned with their
+# inputs and records a status row for every attempted group.
+SignalExecutionResult <- S7::new_class(
+    "SignalExecutionResult",
+    properties = list(
+        groups = S7::new_property(S7::class_list),
+        values = S7::new_property(S7::class_list),
+        profiles = S7::new_property(S7::class_list),
+        diagnostics = S7::new_property(S7::class_any)
+    ),
+    validator = function(self) {
+        if (!all(vapply(
+            self@groups,
+            S7::S7_inherits,
+            logical(1L),
+            class = SignalGroup
+        ))) {
+            return("`groups` must contain only SignalGroup objects.")
+        }
+        if (length(self@values) != length(self@groups)) {
+            return("`values` must remain positionally aligned with `groups`.")
+        }
+        variables <- unique(unlist(
+            lapply(self@groups, function(group) group@variables),
+            use.names = FALSE
+        ))
+        if (is.null(names(self@profiles)) ||
+            !setequal(names(self@profiles), variables)) {
+            return(
+                "`profiles` must record the resolved settings for every group variable."
+            )
+        }
+        expected <- c(
+            "method", "group", "status", "variables", "evidence", "message"
+        )
+        if (!is.data.frame(self@diagnostics) ||
+            !identical(names(self@diagnostics), expected) ||
+            nrow(self@diagnostics) != length(self@groups)) {
+            return(
+                "`diagnostics` must contain one canonical row per signal group."
+            )
+        }
+        if (any(!self@diagnostics[["status"]] %in% c("ok", "error"))) {
+            return("Signal diagnostic status must be `ok` or `error`.")
+        }
+        NULL
+    }
+)
+
+# Construct one variable profile and enforce that published defaults cite their
+# source while experimental defaults remain visibly labelled.
+signal__variable_profile <- function(
+    variable_id,
+    settings = list(),
+    evidence = c("published", "experimental"),
+    references = character(),
+    metadata = list()
+) {
+    checkmate::assert_string(
+        variable_id,
+        pattern = "^[A-Za-z][A-Za-z0-9_]*$"
+    )
+    evidence <- match.arg(evidence)
+    checkmate::assert_list(settings, names = "unique")
+    if (length(settings) &&
+        (is.null(names(settings)) || any(!nzchar(names(settings))))) {
+        cli::cli_abort("{.arg settings} must be named.")
+    }
+    references <- weather__descriptor_values(references, "references")
+    checkmate::assert_list(metadata, names = "unique")
+
+    SignalVariableProfile(
+        variable_id = variable_id,
+        evidence = evidence,
+        settings = settings,
+        references = references,
+        metadata = metadata
+    )
+}
+
+# Normalize profile collections by variable ID so construction order never
+# changes profile lookup or serialized metadata.
+signal__profiles <- function(profiles) {
+    checkmate::assert_list(profiles)
+    if (!length(profiles)) {
+        cli::cli_abort("{.arg profiles} must contain at least one variable profile.")
+    }
+    if (!all(vapply(
+        profiles,
+        S7::S7_inherits,
+        logical(1L),
+        class = SignalVariableProfile
+    ))) {
+        cli::cli_abort(
+            "{.arg profiles} must contain only SignalVariableProfile objects."
+        )
+    }
+    ids <- vapply(
+        profiles,
+        function(profile) profile@variable_id,
+        character(1L)
+    )
+    if (anyDuplicated(ids)) {
+        cli::cli_abort(
+            "{.arg profiles} contains duplicate variable IDs: {.val {unique(ids[duplicated(ids)])}}."
+        )
+    }
+    stats::setNames(profiles, ids)
+}
+
+# Normalize variable-specific user overrides before applying them to profile
+# defaults. Overrides may change settings but not their evidence provenance.
+signal__overrides <- function(overrides, variables) {
+    checkmate::assert_list(overrides, names = "unique")
+    if (!length(overrides)) {
+        return(stats::setNames(
+            rep(list(list()), length(variables)),
+            variables
+        ))
+    }
+    if (is.null(names(overrides)) || any(!nzchar(names(overrides)))) {
+        cli::cli_abort(
+            "{.arg overrides} must be named by variable ID."
+        )
+    }
+    unknown <- setdiff(names(overrides), variables)
+    if (length(unknown)) {
+        cli::cli_abort(
+            "{.arg overrides} contains variable(s) not present in the signal groups: {.val {unknown}}."
+        )
+    }
+    if (!all(vapply(overrides, is.list, logical(1L)))) {
+        cli::cli_abort(
+            "Every {.arg overrides} entry must be a named settings list."
+        )
+    }
+    for (variable in names(overrides)) {
+        checkmate::assert_list(
+            overrides[[variable]],
+            names = "unique"
+        )
+        if (length(overrides[[variable]]) &&
+            (is.null(names(overrides[[variable]])) ||
+                any(!nzchar(names(overrides[[variable]]))))) {
+            cli::cli_abort(
+                "Override settings for {.val {variable}} must be named."
+            )
+        }
+    }
+    out <- stats::setNames(
+        rep(list(list()), length(variables)),
+        variables
+    )
+    out[names(overrides)] <- overrides
+    out
+}
+
+# Resolve every variable once per execution so experimental warnings are not
+# repeated for each location or temporal window.
+signal__resolve_profiles <- function(
+    profiles,
+    variables,
+    overrides = list(),
+    warn_experimental = TRUE
+) {
+    profiles <- signal__profiles(profiles)
+    variables <- weather__descriptor_values(variables, "variables")
+    checkmate::assert_flag(warn_experimental)
+    missing <- setdiff(variables, names(profiles))
+    if (length(missing)) {
+        cli::cli_abort(
+            "No signal variable profile is registered for {.val {missing}}."
+        )
+    }
+    overrides <- signal__overrides(overrides, variables)
+
+    resolved <- lapply(variables, function(variable) {
+        profile <- profiles[[variable]]
+        if (isTRUE(warn_experimental) &&
+            identical(profile@evidence, "experimental")) {
+            cli::cli_warn(c(
+                "Signal defaults for {.val {variable}} are experimental.",
+                "i" = "Review the method settings and resulting diagnostics."
+            ))
+        }
+        list(
+            profile = profile,
+            settings = utils::modifyList(
+                profile@settings,
+                overrides[[variable]],
+                keep.null = TRUE
+            )
+        )
+    })
+    stats::setNames(resolved, variables)
+}
+
+# Construct one pre-aligned group without imposing a package-wide array or
+# table representation on individual signal methods.
+signal__group <- function(key = list(), inputs, variables) {
+    checkmate::assert_list(key, names = "unique")
+    checkmate::assert_list(inputs, names = "unique", min.len = 1L)
+    variables <- weather__descriptor_values(variables, "variables")
+
+    SignalGroup(
+        key = key,
+        inputs = inputs,
+        variables = variables
+    )
+}
+
+# Render a deterministic group label for diagnostics without requiring every
+# upstream adapter to invent a string identifier.
+signal__group_label <- function(group, index) {
+    if (!length(group@key)) {
+        return(sprintf("group-%d", index))
+    }
+    values <- vapply(group@key, as.character, character(1L))
+    paste(sprintf("%s=%s", names(values), values), collapse = ",")
+}
+
+# Validate the role boundary again at group granularity because a globally
+# available source can still be absent after alignment for one location.
+signal__validate_group_roles <- function(component, group) {
+    required <- names(component@required_inputs)
+    optional <- names(component@optional_inputs)
+    missing <- setdiff(required, names(group@inputs))
+    if (length(missing)) {
+        cli::cli_abort(
+            "Signal group is missing required input role(s): {.val {missing}}."
+        )
+    }
+    unexpected <- setdiff(names(group@inputs), c(required, optional))
+    if (length(unexpected)) {
+        cli::cli_abort(
+            "Signal group contains undeclared input role(s): {.val {unexpected}}."
+        )
+    }
+    invisible(TRUE)
+}
+
+# Apply an optional method-specific output validator while keeping the common
+# executor independent from numeric-vector, table, or field representations.
+signal__validate_result <- function(component, value, group) {
+    if (is.null(value)) {
+        cli::cli_abort("A signal group kernel cannot return NULL.")
+    }
+    if (!"validate_result" %in% names(component@operations)) {
+        return(invisible(TRUE))
+    }
+    result <- component@operations$validate_result(
+        value = value,
+        inputs = group@inputs,
+        key = group@key
+    )
+    if (isTRUE(result)) {
+        return(invisible(TRUE))
+    }
+    if (is.character(result) && length(result) == 1L && !is.na(result)) {
+        cli::cli_abort(result)
+    }
+    cli::cli_abort(
+        "A signal result validator must return TRUE or one diagnostic string."
+    )
+}
+
+# Build one canonical diagnostic row for either a successful or failed group.
+signal__diagnostic <- function(
+    method,
+    group,
+    index,
+    status,
+    profiles,
+    message = NA_character_
+) {
+    data.table::data.table(
+        method = method,
+        group = signal__group_label(group, index),
+        status = status,
+        variables = paste(group@variables, collapse = ","),
+        evidence = paste(
+            unique(vapply(
+                profiles[group@variables],
+                function(resolved) resolved$profile@evidence,
+                character(1L)
+            )),
+            collapse = ","
+        ),
+        message = message
+    )
+}
+
+# Convert resolved profiles into data-only records that retain the actual
+# settings used after overrides as well as their original provenance.
+signal__profile_records <- function(profiles) {
+    lapply(profiles, function(resolved) {
+        list(
+            variable_id = resolved$profile@variable_id,
+            evidence = resolved$profile@evidence,
+            settings = resolved$settings,
+            references = resolved$profile@references,
+            metadata = resolved$profile@metadata
+        )
+    })
+}
+
+# Execute a component's single-group kernel over pre-aligned groups. Failed
+# groups remain NULL with explicit diagnostics instead of silently becoming NaN.
+signal__execute_groups <- function(
+    component,
+    inputs,
+    groups,
+    profiles,
+    overrides = list(),
+    error_policy = c("abort", "collect"),
+    warn_experimental = TRUE
+) {
+    if (!S7::S7_inherits(component, WeatherComponentSpec) ||
+        !identical(component@stage, "signal")) {
+        cli::cli_abort(
+            "{.arg component} must be a signal WeatherComponentSpec object."
+        )
+    }
+    component__validate_inputs(component, inputs)
+    checkmate::assert_list(groups, min.len = 1L)
+    if (!all(vapply(
+        groups,
+        S7::S7_inherits,
+        logical(1L),
+        class = SignalGroup
+    ))) {
+        cli::cli_abort("{.arg groups} must contain only SignalGroup objects.")
+    }
+    error_policy <- match.arg(error_policy)
+    variables <- unique(unlist(
+        lapply(groups, function(group) group@variables),
+        use.names = FALSE
+    ))
+    resolved <- signal__resolve_profiles(
+        profiles,
+        variables,
+        overrides = overrides,
+        warn_experimental = warn_experimental
+    )
+
+    values <- vector("list", length(groups))
+    diagnostics <- vector("list", length(groups))
+    for (i in seq_along(groups)) {
+        group <- groups[[i]]
+        # Role coverage is checked immediately before the method kernel so
+        # alignment failures are attributed to the exact group.
+        attempt <- tryCatch(
+            {
+                signal__validate_group_roles(component, group)
+                group_profiles <- resolved[group@variables]
+                value <- component@operations$apply_group(
+                    inputs = group@inputs,
+                    settings = lapply(
+                        group_profiles,
+                        function(item) item$settings
+                    ),
+                    key = group@key
+                )
+                signal__validate_result(component, value, group)
+                list(
+                    ok = TRUE,
+                    value = value,
+                    profiles = group_profiles
+                )
+            },
+            error = function(error) {
+                list(
+                    ok = FALSE,
+                    error = error,
+                    profiles = resolved[group@variables]
+                )
+            }
+        )
+        if (!isTRUE(attempt$ok) &&
+            identical(error_policy, "abort")) {
+            cli::cli_abort(
+                "Signal component {.val {component@name}} failed for {.val {signal__group_label(group, i)}}.",
+                parent = attempt$error
+            )
+        }
+        if (isTRUE(attempt$ok)) {
+            values[[i]] <- attempt$value
+            diagnostics[[i]] <- signal__diagnostic(
+                component@name,
+                group,
+                i,
+                "ok",
+                attempt$profiles
+            )
+        } else {
+            # Assign with single-bracket indexing so NULL remains an explicit
+            # position instead of shortening the values list.
+            values[i] <- list(NULL)
+            diagnostics[[i]] <- signal__diagnostic(
+                component@name,
+                group,
+                i,
+                "error",
+                attempt$profiles,
+                conditionMessage(attempt$error)
+            )
+        }
+    }
+
+    SignalExecutionResult(
+        groups = groups,
+        values = values,
+        profiles = signal__profile_records(resolved),
+        diagnostics = data.table::rbindlist(diagnostics)
+    )
+}
+
+# Construct a signal component whose public `apply` operation uses the common
+# group executor while `apply_group` remains the method-specific kernel.
+signal__component <- function(
+    name,
+    label = name,
+    required_inputs,
+    optional_inputs = list(),
+    input_kinds = "calendar_indexed",
+    output_kinds = "signal_adjusted",
+    scopes = "univariate",
+    stochastic = FALSE,
+    profiles,
+    apply_group,
+    operations = list(),
+    metadata = list()
+) {
+    profiles <- signal__profiles(profiles)
+    checkmate::assert_function(apply_group)
+    checkmate::assert_list(operations, names = "unique")
+    reserved <- intersect(names(operations), c("apply", "apply_group"))
+    if (length(reserved)) {
+        cli::cli_abort(
+            "{.arg operations} cannot replace reserved operation(s): {.val {reserved}}."
+        )
+    }
+    if (!length(required_inputs)) {
+        cli::cli_abort(
+            "A signal component must declare at least one required input role."
+        )
+    }
+    if ("signal_profiles" %in% names(metadata)) {
+        cli::cli_abort(
+            "{.arg metadata} cannot replace the reserved `signal_profiles` entry."
+        )
+    }
+
+    # Executable functions stay process-local, while profile summaries in
+    # metadata remain inspectable and serializable.
+    metadata$signal_profiles <- lapply(profiles, function(profile) {
+        list(
+            variable_id = profile@variable_id,
+            evidence = profile@evidence,
+            settings = profile@settings,
+            references = profile@references,
+            metadata = profile@metadata
+        )
+    })
+    state <- new.env(parent = emptyenv())
+    apply <- function(
+        inputs,
+        groups,
+        overrides = list(),
+        error_policy = c("abort", "collect"),
+        warn_experimental = TRUE
+    ) {
+        signal__execute_groups(
+            state$component,
+            inputs,
+            groups,
+            profiles = profiles,
+            overrides = overrides,
+            error_policy = error_policy,
+            warn_experimental = warn_experimental
+        )
+    }
+    component <- component__spec(
+        name = name,
+        stage = "signal",
+        label = label,
+        required_inputs = required_inputs,
+        optional_inputs = optional_inputs,
+        input_kinds = input_kinds,
+        output_kinds = output_kinds,
+        scopes = scopes,
+        stochastic = stochastic,
+        operations = c(
+            list(apply = apply, apply_group = apply_group),
+            operations
+        ),
+        metadata = metadata
+    )
+    state$component <- component
+    component
+}

--- a/man/epwshiftr-package.Rd
+++ b/man/epwshiftr-package.Rd
@@ -41,6 +41,7 @@ invalidate a persistent store.
 \seealso{
 Useful links:
 \itemize{
+  \item \url{https://ideas-lab-nus.github.io/epwshiftr/}
   \item \url{https://github.com/ideas-lab-nus/epwshiftr}
   \item Report bugs at \url{https://github.com/ideas-lab-nus/epwshiftr/issues}
 }

--- a/tests/testthat/test-weather-component.R
+++ b/tests/testthat/test-weather-component.R
@@ -1,0 +1,220 @@
+test_that("all seven future-weather component stages have executable contracts", {
+    specs <- lapply(WEATHER_COMPONENT_STAGES, function(stage) {
+        primary <- WEATHER_COMPONENT_PRIMARY_OPERATIONS[[stage]]
+        operations <- stats::setNames(
+            list(function(value) value),
+            primary
+        )
+        component__spec(
+            name = paste0(stage, "_test"),
+            stage = stage,
+            input_kinds = paste0(stage, "_input"),
+            output_kinds = paste0(stage, "_output"),
+            operations = operations
+        )
+    })
+
+    expect_identical(
+        vapply(specs, function(spec) spec@stage, character(1L)),
+        WEATHER_COMPONENT_STAGES
+    )
+    for (spec in specs) {
+        primary <- WEATHER_COMPONENT_PRIMARY_OPERATIONS[[spec@stage]]
+        expect_identical(
+            component__execute(spec, primary, "value"),
+            "value"
+        )
+    }
+})
+
+test_that("component registries retain metadata but not serialized operations", {
+    registry <- new.env(parent = emptyenv())
+    signal <- component__spec(
+        name = "daily_delta",
+        stage = "signal",
+        label = "Daily delta",
+        input_kinds = "calendar_indexed",
+        output_kinds = "seasonal_change",
+        operations = list(apply = function(value) value)
+    )
+
+    expect_identical(
+        component__register(signal, registry = registry),
+        signal
+    )
+    expect_identical(
+        component__get("signal", "daily_delta", registry),
+        signal
+    )
+    listed <- component__list(registry = registry)
+    expect_named(
+        listed,
+        c(
+            "stage", "name", "label", "input_kinds", "output_kinds",
+            "scopes", "stochastic"
+        )
+    )
+    expect_identical(listed$name, "daily_delta")
+    expect_false("operations" %in% names(listed))
+    expect_error(
+        component__register(signal, registry = registry),
+        "already registered"
+    )
+})
+
+test_that("component compatibility uses stage order and intermediate kinds", {
+    calendar <- component__spec(
+        name = "annual_phase",
+        stage = "calendar",
+        input_kinds = "prepared_inputs",
+        output_kinds = "calendar_indexed",
+        operations = list(apply = function(value) value)
+    )
+    signal <- component__spec(
+        name = "qdm",
+        stage = "signal",
+        input_kinds = "calendar_indexed",
+        output_kinds = "corrected_series",
+        operations = list(apply = function(value) value)
+    )
+    incompatible <- component__spec(
+        name = "monthly_only",
+        stage = "signal",
+        input_kinds = "monthly_summary",
+        output_kinds = "seasonal_change",
+        operations = list(apply = function(value) value)
+    )
+
+    expect_true(component__compatible(calendar, signal))
+    expect_false(component__compatible(signal, calendar))
+    expect_false(component__compatible(calendar, incompatible))
+    expect_invisible(component__assert_compatible(calendar, signal))
+    expect_error(
+        component__assert_compatible(signal, calendar),
+        "must follow"
+    )
+    expect_error(
+        component__assert_compatible(calendar, incompatible),
+        "cannot feed"
+    )
+})
+
+test_that("component input requirements keep inner AND and outer OR semantics", {
+    temperature <- component__input_requirement(
+        "model_future",
+        representations = "series",
+        frequencies = "day",
+        calendars = c("noleap", "360_day"),
+        variable_sets = list(
+            c("huss", "tas", "ps"),
+            c("hurs", "tas", "ps")
+        )
+    )
+    signal <- component__spec(
+        name = "humidity_signal",
+        stage = "signal",
+        required_inputs = list(model_future = temperature),
+        input_kinds = "calendar_indexed",
+        output_kinds = "corrected_series",
+        scopes = "multivariate",
+        operations = list(apply = function(value) value)
+    )
+    valid <- weather__new_inputs(
+        model_future = weather__new_input(
+            "model_future",
+            data.frame(
+                variable_id = c("hurs", "tas", "ps"),
+                frequency = "day",
+                cf_calendar = "360_day"
+            )
+        )
+    )
+    missing_pressure <- weather__new_inputs(
+        model_future = weather__new_input(
+            "model_future",
+            data.frame(
+                variable_id = c("hurs", "tas"),
+                frequency = "day",
+                cf_calendar = "360_day"
+            )
+        )
+    )
+
+    expect_identical(component__input_errors(signal, valid), character())
+    expect_invisible(component__validate_inputs(signal, valid))
+    expect_match(
+        component__input_errors(signal, missing_pressure),
+        "huss \\+ tas \\+ ps.*or.*hurs \\+ tas \\+ ps"
+    )
+    expect_error(
+        component__validate_inputs(signal, missing_pressure),
+        "input requirements are not satisfied"
+    )
+})
+
+test_that("component input validation distinguishes required and optional roles", {
+    observed <- component__input_requirement(
+        "observed_reference",
+        representations = "series",
+        frequencies = "day"
+    )
+    historical <- component__input_requirement(
+        "model_historical",
+        representations = "series",
+        frequencies = "day",
+        variable_sets = "tas"
+    )
+    signal <- component__spec(
+        name = "quantile_mapping",
+        stage = "signal",
+        required_inputs = list(
+            observed_reference = observed,
+            model_historical = historical
+        ),
+        optional_inputs = list(
+            model_future = component__input_requirement(
+                "model_future",
+                frequencies = "day"
+            )
+        ),
+        input_kinds = "calendar_indexed",
+        output_kinds = "corrected_series",
+        operations = list(
+            fit = function(value) value,
+            apply = function(value) value
+        )
+    )
+    inputs <- weather__new_inputs(
+        model_historical = weather__new_input(
+            "model_historical",
+            data.frame(variable_id = "tas", frequency = "day")
+        )
+    )
+
+    errors <- component__input_errors(signal, inputs)
+    expect_match(errors, "required role `observed_reference` is missing")
+    expect_length(errors, 1L)
+})
+
+test_that("component specs reject missing or stage-inappropriate operations", {
+    expect_error(
+        component__spec(
+            "bad_signal",
+            "signal",
+            input_kinds = "calendar_indexed",
+            output_kinds = "corrected_series",
+            operations = list(fit = function(value) value)
+        ),
+        "require a named `apply` operation"
+    )
+    expect_error(
+        component__spec(
+            "bad_output",
+            "output",
+            input_kinds = "physical_weather",
+            output_kinds = "weather_artifact",
+            operations = list(apply = function(value) value)
+        ),
+        "Unknown `output` operation"
+    )
+})

--- a/tests/testthat/test-weather-input.R
+++ b/tests/testthat/test-weather-input.R
@@ -1,0 +1,135 @@
+test_that("future-weather inputs preserve four distinct semantic roles", {
+    future <- data.frame(
+        variable_id = c("tas", "tasmin", "tasmax"),
+        frequency = "day",
+        cf_calendar = "360_day"
+    )
+    historical <- transform(future, cf_calendar = "noleap")
+    observed <- data.frame(
+        variable_id = "tas",
+        frequency = "day",
+        calendar = "gregorian"
+    )
+
+    inputs <- weather__new_inputs(
+        weather_template = weather__new_input(
+            "weather_template",
+            "baseline.epw"
+        ),
+        observed_reference = weather__new_input(
+            "observed_reference",
+            observed
+        ),
+        model_historical = weather__new_input(
+            "model_historical",
+            historical
+        ),
+        model_future = weather__new_input("model_future", future)
+    )
+
+    expect_true(S7::S7_inherits(inputs, WeatherInputs))
+    expect_identical(
+        weather__get_input(inputs, "weather_template")@representation,
+        "epw"
+    )
+    expect_identical(
+        weather__get_input(inputs, "observed_reference")@calendars,
+        "gregorian"
+    )
+    expect_identical(
+        weather__get_input(inputs, "model_historical")@calendars,
+        "noleap"
+    )
+    expect_identical(
+        weather__get_input(inputs, "model_future")@variables,
+        c("tas", "tasmin", "tasmax")
+    )
+    expect_identical(
+        weather__get_input(inputs, "model_future")@frequencies,
+        "day"
+    )
+    expect_identical(
+        weather__get_input(inputs, "model_future")@calendars,
+        "360_day"
+    )
+})
+
+test_that("future-weather input sets reject missing and mislabelled roles", {
+    future <- weather__new_input(
+        "model_future",
+        data.frame(variable_id = "tas", frequency = "day")
+    )
+
+    expect_error(
+        weather__new_inputs(),
+        "At least one future-weather input"
+    )
+    expect_error(
+        weather__new_inputs(model_historical = future),
+        "contains input role `model_future`"
+    )
+    expect_error(
+        weather__new_input(
+            "model_future",
+            data.frame(variable_id = "tas"),
+            representation = "unknown"
+        ),
+        "Must be element of set"
+    )
+})
+
+test_that("morphing contexts expose explicit inputs and preserve legacy fields", {
+    epw <- epw_file_read(get_cache_epw())
+    future <- data.table::data.table(
+        variable_id = "tas",
+        time = as.POSIXct("2050-01-01", tz = "UTC"),
+        period = "future",
+        year = 2050L,
+        lon = 103.8,
+        lat = 1.3,
+        units = "K",
+        value = 301,
+        frequency = "day",
+        cf_calendar = "360_day"
+    )
+    historical <- data.table::copy(future)
+    historical[, `:=`(
+        time = as.POSIXct("2000-01-01", tz = "UTC"),
+        period = "historical",
+        year = 2000L,
+        value = 299,
+        cf_calendar = "noleap"
+    )]
+    observed <- data.table::copy(historical)
+    observed[, `:=`(
+        period = "observed",
+        value = 298,
+        cf_calendar = "standard"
+    )]
+
+    context <- morpher__context(
+        epw,
+        future,
+        reference_climate = historical,
+        observed_reference = observed
+    )
+
+    expect_true(S7::S7_inherits(context$inputs, WeatherInputs))
+    expect_identical(context$inputs@weather_template@source, context$epw)
+    expect_identical(context$inputs@model_future@source, context$climate)
+    expect_identical(
+        context$inputs@model_historical@source,
+        context$reference_climate
+    )
+    expect_identical(
+        context$inputs@observed_reference@source,
+        context$observed_reference
+    )
+    expect_identical(context$inputs@weather_template@frequencies, "hour")
+    expect_identical(context$inputs@model_future@frequencies, "day")
+    expect_identical(context$inputs@model_future@calendars, "360_day")
+    expect_identical(
+        context$inputs@observed_reference@role,
+        "observed_reference"
+    )
+})

--- a/tests/testthat/test-weather-signal.R
+++ b/tests/testthat/test-weather-signal.R
@@ -1,0 +1,296 @@
+test_that("signal profiles keep published and experimental defaults distinct", {
+    expect_error(
+        signal__variable_profile(
+            "tas",
+            settings = list(offset = 2),
+            evidence = "published"
+        ),
+        "must provide at least one reference"
+    )
+
+    published <- signal__variable_profile(
+        "tas",
+        settings = list(offset = 2),
+        evidence = "published",
+        references = "doi:10.1000/example"
+    )
+    experimental <- signal__variable_profile(
+        "pr",
+        settings = list(factor = 1.1),
+        evidence = "experimental"
+    )
+
+    expect_identical(published@evidence, "published")
+    expect_identical(published@references, "doi:10.1000/example")
+    expect_identical(experimental@evidence, "experimental")
+})
+
+test_that("different signal kernels share one execution lifecycle", {
+    requirement <- component__input_requirement(
+        "model_future",
+        representations = "series",
+        frequencies = "day",
+        variable_sets = "tas"
+    )
+    profile <- signal__variable_profile(
+        "tas",
+        settings = list(offset = 2, factor = 3),
+        evidence = "published",
+        references = "doi:10.1000/example"
+    )
+    additive <- signal__component(
+        "additive_test",
+        required_inputs = list(model_future = requirement),
+        profiles = list(profile),
+        apply_group = function(inputs, settings, key) {
+            inputs$model_future + settings$tas$offset
+        },
+        operations = list(
+            validate_result = function(value, inputs, key) {
+                if (is.numeric(value) &&
+                    length(value) == length(inputs$model_future)) {
+                    return(TRUE)
+                }
+                "Signal result must match the future input length."
+            }
+        )
+    )
+    multiplicative <- signal__component(
+        "multiplicative_test",
+        required_inputs = list(model_future = requirement),
+        profiles = list(profile),
+        apply_group = function(inputs, settings, key) {
+            inputs$model_future * settings$tas$factor
+        }
+    )
+    inputs <- weather__new_inputs(
+        model_future = weather__new_input(
+            "model_future",
+            data.frame(variable_id = "tas", frequency = "day")
+        )
+    )
+    groups <- list(
+        signal__group(
+            key = list(site = "A"),
+            inputs = list(model_future = c(1, 2, 3)),
+            variables = "tas"
+        ),
+        signal__group(
+            key = list(site = "B"),
+            inputs = list(model_future = c(4, 5)),
+            variables = "tas"
+        )
+    )
+
+    additive_result <- component__execute(
+        additive,
+        "apply",
+        inputs = inputs,
+        groups = groups
+    )
+    multiplicative_result <- component__execute(
+        multiplicative,
+        "apply",
+        inputs = inputs,
+        groups = groups
+    )
+
+    expect_true(S7::S7_inherits(additive_result, SignalExecutionResult))
+    expect_identical(additive_result@values, list(c(3, 4, 5), c(6, 7)))
+    expect_identical(
+        multiplicative_result@values,
+        list(c(3, 6, 9), c(12, 15))
+    )
+    expect_identical(additive_result@diagnostics$status, c("ok", "ok"))
+    expect_identical(
+        additive_result@diagnostics$group,
+        c("site=A", "site=B")
+    )
+    expect_identical(
+        additive@metadata$signal_profiles$tas$evidence,
+        "published"
+    )
+    expect_identical(
+        additive@metadata$signal_profiles$tas$settings$offset,
+        2
+    )
+})
+
+test_that("signal execution resolves overrides without changing provenance", {
+    requirement <- component__input_requirement(
+        "model_future",
+        frequencies = "day",
+        variable_sets = "tas"
+    )
+    component <- signal__component(
+        "override_test",
+        required_inputs = list(model_future = requirement),
+        profiles = list(signal__variable_profile(
+            "tas",
+            settings = list(offset = 1),
+            evidence = "experimental"
+        )),
+        apply_group = function(inputs, settings, key) {
+            inputs$model_future + settings$tas$offset
+        }
+    )
+    inputs <- weather__new_inputs(
+        model_future = weather__new_input(
+            "model_future",
+            data.frame(variable_id = "tas", frequency = "day")
+        )
+    )
+    groups <- list(
+        signal__group(
+            key = list(site = "A"),
+            inputs = list(model_future = 1:2),
+            variables = "tas"
+        ),
+        signal__group(
+            key = list(site = "B"),
+            inputs = list(model_future = 3:4),
+            variables = "tas"
+        )
+    )
+
+    expect_warning(
+        result <- component__execute(
+            component,
+            "apply",
+            inputs = inputs,
+            groups = groups,
+            overrides = list(tas = list(offset = 5))
+        ),
+        "experimental"
+    )
+    expect_identical(result@values, list(c(6, 7), c(8, 9)))
+    expect_identical(
+        result@diagnostics$evidence,
+        c("experimental", "experimental")
+    )
+    expect_identical(
+        component@metadata$signal_profiles$tas$settings$offset,
+        1
+    )
+    expect_identical(result@profiles$tas$settings$offset, 5)
+})
+
+test_that("signal group failures are explicit instead of silent NaN output", {
+    requirement <- component__input_requirement(
+        "model_future",
+        frequencies = "day",
+        variable_sets = "tas"
+    )
+    component <- signal__component(
+        "failure_test",
+        required_inputs = list(model_future = requirement),
+        profiles = list(signal__variable_profile(
+            "tas",
+            evidence = "published",
+            references = "doi:10.1000/example"
+        )),
+        apply_group = function(inputs, settings, key) {
+            if (any(inputs$model_future < 0)) {
+                stop("negative input")
+            }
+            inputs$model_future
+        }
+    )
+    inputs <- weather__new_inputs(
+        model_future = weather__new_input(
+            "model_future",
+            data.frame(variable_id = "tas", frequency = "day")
+        )
+    )
+    groups <- list(
+        signal__group(
+            key = list(site = "A"),
+            inputs = list(model_future = 1:2),
+            variables = "tas"
+        ),
+        signal__group(
+            key = list(site = "B"),
+            inputs = list(model_future = c(-1, 2)),
+            variables = "tas"
+        )
+    )
+
+    collected <- component__execute(
+        component,
+        "apply",
+        inputs = inputs,
+        groups = groups,
+        error_policy = "collect"
+    )
+
+    expect_length(collected@values, 2L)
+    expect_identical(collected@values[[1L]], 1:2)
+    expect_null(collected@values[[2L]])
+    expect_identical(collected@diagnostics$status, c("ok", "error"))
+    expect_match(collected@diagnostics$message[[2L]], "negative input")
+    expect_error(
+        component__execute(
+            component,
+            "apply",
+            inputs = inputs,
+            groups = groups
+        ),
+        "failed for.*site=B"
+    )
+})
+
+test_that("signal execution validates source and group role contracts", {
+    observed <- component__input_requirement(
+        "observed_reference",
+        frequencies = "day",
+        variable_sets = "tas"
+    )
+    future <- component__input_requirement(
+        "model_future",
+        frequencies = "day",
+        variable_sets = "tas"
+    )
+    component <- signal__component(
+        "role_test",
+        required_inputs = list(
+            observed_reference = observed,
+            model_future = future
+        ),
+        profiles = list(signal__variable_profile(
+            "tas",
+            evidence = "published",
+            references = "doi:10.1000/example"
+        )),
+        apply_group = function(inputs, settings, key) {
+            inputs$model_future - mean(inputs$observed_reference)
+        }
+    )
+    inputs <- weather__new_inputs(
+        observed_reference = weather__new_input(
+            "observed_reference",
+            data.frame(variable_id = "tas", frequency = "day")
+        ),
+        model_future = weather__new_input(
+            "model_future",
+            data.frame(variable_id = "tas", frequency = "day")
+        )
+    )
+    incomplete <- list(signal__group(
+        inputs = list(model_future = 1:2),
+        variables = "tas"
+    ))
+
+    result <- component__execute(
+        component,
+        "apply",
+        inputs = inputs,
+        groups = incomplete,
+        error_policy = "collect"
+    )
+
+    expect_identical(result@diagnostics$status, "error")
+    expect_match(
+        result@diagnostics$message,
+        "missing required input role.*observed_reference"
+    )
+})

--- a/vignettes-raw/articles/epw-morpher.Rmd
+++ b/vignettes-raw/articles/epw-morpher.Rmd
@@ -243,11 +243,50 @@ first registration; it is not a special execution path.
 
 The runner receives one canonical context:
 
+- `context$inputs`: role-addressable future-weather inputs. Its
+  `weather_template`, `observed_reference`, `model_historical`, and
+  `model_future` properties remain distinct even when one role is absent;
 - `context$epw`: the package's internal baseline EPW representation;
 - `context$climate`: store-native climate rows with `variable_id`, `time`,
   `period`, `year`, `lon`, `lat`, `dist`, `units`, `value`, and case metadata;
+- `context$reference_climate`: optional matching historical model rows;
+- `context$observed_reference`: optional observations or reanalysis rows;
 - `context$recipe`: the selected recipe, including method overrides and rules;
 - `context$by`, `context$case`, `context$strict`, and `context$warning`.
+
+`context$epw`, `context$climate`, and `context$reference_climate` remain
+available for existing backends. New components should select inputs by their
+role through `context$inputs` instead of interpreting a generic reference.
+
+Future-weather methods can be assembled from seven ordered component stages.
+Each component declares its required and optional input roles, supported
+representations, frequencies, calendars, variable alternatives, input and
+output kinds, dimensional scope, and whether it is stochastic. Compatibility
+is checked from stage order and the intermediate kinds exchanged between
+components.
+
+| Component | Used for | Main function | Problem addressed |
+|:----------|:---------|:--------------|:------------------|
+| `preprocess` | Preparing every source before climate calculations | Normalize variables, units, missing values, spatial selections, and source metadata into method-ready inputs | Raw EPW, observations, reanalysis, and climate-model data otherwise have incompatible schemas and units |
+| `calendar` | Placing sources on a shared annual and temporal coordinate | Preserve each source calendar, calculate annual phase, form circular windows, and align 360-, 365-, and 366-day inputs | Direct date matching either loses days or assigns different seasonal positions to nominally similar dates |
+| `signal` | Estimating or transferring the future climate signal | Apply delta, scaling, quantile-based, weather-typing, or other statistical transformations to aligned groups | Different methods require different reference inputs and assumptions but need one validated, comparable execution contract |
+| `sequence` | Constructing the order of future days or weather states | Preserve, resample, rearrange, or generate daily sequences, including stochastic and analogue methods | A climatology or corrected distribution does not define event order, persistence, spells, or compound extremes |
+| `hourly` | Converting daily targets or selected days into hourly weather | Reconstruct 24-hour profiles from an EPW template, an hourly library, or a method-specific disaggregation model | Daily CMIP data cannot be written directly as an hourly EPW and naive interpolation damages diurnal shape and extrema |
+| `physics` | Closing related weather variables after transformation | Enforce temperature statistics, humidity closure, radiation balance, bounds, and cross-variable consistency | Independently transformed variables can violate thermodynamic, radiative, or EPW constraints |
+| `output` | Producing the final weather artifact and its record | Assemble fields and headers, write EPW or intermediate artifacts, and retain method settings, provenance, and diagnostics | Numerically valid series are not yet a standards-compliant, reproducible, and auditable future weather file |
+
+Bias-adjustment implementations belong to the `signal` stage. Their common
+`apply` operation validates the role-addressable inputs, resolves
+variable-specific settings, and executes aligned groups. Each method supplies
+only an `apply_group` kernel receiving the group's input payloads, resolved
+settings, and key. Published defaults retain their references, experimental
+defaults are labelled and warned about, and user overrides do not change that
+provenance. The execution result records the settings actually used after
+overrides. Calendar mapping and group alignment happen before the kernel, so a
+method cannot silently impose a Gregorian, no-leap, or fixed 366-day
+interpretation. Group failures either abort or return an explicit diagnostic
+with a `NULL` result; they are never silently converted to missing numeric
+values.
 
 The runner returns `epw_morph_result()` with complete hourly EPW weather data.
 `EpwMorpher$run()` writes that data as Parquet and adds the case metadata

--- a/vignettes/articles/epw-morpher.Rmd
+++ b/vignettes/articles/epw-morpher.Rmd
@@ -251,11 +251,50 @@ first registration; it is not a special execution path.
 
 The runner receives one canonical context:
 
+- `context$inputs`: role-addressable future-weather inputs. Its
+  `weather_template`, `observed_reference`, `model_historical`, and
+  `model_future` properties remain distinct even when one role is absent;
 - `context$epw`: the package's internal baseline EPW representation;
 - `context$climate`: store-native climate rows with `variable_id`, `time`,
   `period`, `year`, `lon`, `lat`, `dist`, `units`, `value`, and case metadata;
+- `context$reference_climate`: optional matching historical model rows;
+- `context$observed_reference`: optional observations or reanalysis rows;
 - `context$recipe`: the selected recipe, including method overrides and rules;
 - `context$by`, `context$case`, `context$strict`, and `context$warning`.
+
+`context$epw`, `context$climate`, and `context$reference_climate` remain
+available for existing backends. New components should select inputs by their
+role through `context$inputs` instead of interpreting a generic reference.
+
+Future-weather methods can be assembled from seven ordered component stages.
+Each component declares its required and optional input roles, supported
+representations, frequencies, calendars, variable alternatives, input and
+output kinds, dimensional scope, and whether it is stochastic. Compatibility
+is checked from stage order and the intermediate kinds exchanged between
+components.
+
+| Component | Used for | Main function | Problem addressed |
+|:----------|:---------|:--------------|:------------------|
+| `preprocess` | Preparing every source before climate calculations | Normalize variables, units, missing values, spatial selections, and source metadata into method-ready inputs | Raw EPW, observations, reanalysis, and climate-model data otherwise have incompatible schemas and units |
+| `calendar` | Placing sources on a shared annual and temporal coordinate | Preserve each source calendar, calculate annual phase, form circular windows, and align 360-, 365-, and 366-day inputs | Direct date matching either loses days or assigns different seasonal positions to nominally similar dates |
+| `signal` | Estimating or transferring the future climate signal | Apply delta, scaling, quantile-based, weather-typing, or other statistical transformations to aligned groups | Different methods require different reference inputs and assumptions but need one validated, comparable execution contract |
+| `sequence` | Constructing the order of future days or weather states | Preserve, resample, rearrange, or generate daily sequences, including stochastic and analogue methods | A climatology or corrected distribution does not define event order, persistence, spells, or compound extremes |
+| `hourly` | Converting daily targets or selected days into hourly weather | Reconstruct 24-hour profiles from an EPW template, an hourly library, or a method-specific disaggregation model | Daily CMIP data cannot be written directly as an hourly EPW and naive interpolation damages diurnal shape and extrema |
+| `physics` | Closing related weather variables after transformation | Enforce temperature statistics, humidity closure, radiation balance, bounds, and cross-variable consistency | Independently transformed variables can violate thermodynamic, radiative, or EPW constraints |
+| `output` | Producing the final weather artifact and its record | Assemble fields and headers, write EPW or intermediate artifacts, and retain method settings, provenance, and diagnostics | Numerically valid series are not yet a standards-compliant, reproducible, and auditable future weather file |
+
+Bias-adjustment implementations belong to the `signal` stage. Their common
+`apply` operation validates the role-addressable inputs, resolves
+variable-specific settings, and executes aligned groups. Each method supplies
+only an `apply_group` kernel receiving the group's input payloads, resolved
+settings, and key. Published defaults retain their references, experimental
+defaults are labelled and warned about, and user overrides do not change that
+provenance. The execution result records the settings actually used after
+overrides. Calendar mapping and group alignment happen before the kernel, so a
+method cannot silently impose a Gregorian, no-leap, or fixed 366-day
+interpretation. Group failures either abort or return an explicit diagnostic
+with a `NULL` result; they are never silently converted to missing numeric
+values.
 
 The runner returns `epw_morph_result()` with complete hourly EPW weather data.
 `EpwMorpher$run()` writes that data as Parquet and adds the case metadata


### PR DESCRIPTION
## Summary

Adds explicit future-weather input roles and reusable component contracts for composing and comparing weather-generation methods. Closes #142.

## Changes

- distinguish `weather_template`, `observed_reference`, `model_historical`, and `model_future` inputs in the canonical backend context
- define registered `preprocess`, `calendar`, `signal`, `sequence`, `hourly`, `physics`, and `output` component specifications
- validate component input requirements, intermediate data kinds, dimensional scopes, and stochastic behavior
- add a shared `signal` execution lifecycle for aligned groups, method settings, provenance, diagnostics, and explicit failure handling
- retain legacy `EpwMorphBackend` context fields and document the seven component stages
