### PR TITLE
feat: add daily adjusted-series signal contract

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,6 +44,10 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.3
 Collate:
     'arima-temperature.R'
+    'weather-input.R'
+    'weather-component.R'
+    'weather-signal.R'
+    'bias-adjustment.R'
     'cli-doctor.R'
     'cli-download.R'
     'cli-extract.R'
@@ -97,9 +101,6 @@ Collate:
     'shift-ui.R'
     'sobie-curry-backend.R'
     'standalone-cache.R'
-    'weather-input.R'
-    'weather-component.R'
-    'weather-signal.R'
     'weather-pipeline.R'
     'weather-recipe.R'
     'zzz.R'

--- a/NEWS.md
+++ b/NEWS.md
@@ -40,6 +40,14 @@
 
 ## New features
 
+* Added the package-native `DailyAdjustedSeries` signal contract and registered
+  native R `linear_scaling_daily` component. The univariate component consumes
+  distinct observed-reference, historical-model, and future-model daily
+  series, applies monthly additive temperature or multiplicative precipitation
+  mean corrections, and returns the corrected future sequence with canonical
+  CF-calendar coordinates, resolved settings, correction provenance, bounds,
+  and explicit diagnostics (#161).
+
 * Added `arima_temperature()` and registered the temperature-focused
   `arima_rank_qm` recipe. The workflow carries baseline EPW, historical daily
   model `tas`, future daily model `tas`, and multi-year observed daily `tas` as

--- a/R/bias-adjustment.R
+++ b/R/bias-adjustment.R
@@ -1,0 +1,604 @@
+#' @include weather-signal.R
+NULL
+
+# A daily adjusted series is the package-native signal output shared by bias
+# adjustment methods, independently of any external method class hierarchy.
+BIAS_DAILY_SERIES_COLUMNS <- c(
+    "variable_id",
+    "value",
+    "units",
+    "frequency",
+    "cf_calendar",
+    "cf_year",
+    "cf_month",
+    "cf_day",
+    "cf_day_of_year",
+    "cf_year_days",
+    "annual_phase"
+)
+
+# Linear Scaling defaults cite the review in which the monthly additive
+# temperature and multiplicative precipitation transformations are defined.
+BIAS_LINEAR_SCALING_REFERENCES <- c(
+    "https://doi.org/10.1016/j.jhydrol.2012.05.052"
+)
+
+# Check the named-list fields carried by the signal result without constraining
+# the method-specific values stored inside them.
+bias__named_list_error <- function(value, name) {
+    if (!is.list(value)) {
+        return(sprintf("`%s` must be a list.", name))
+    }
+    if (length(value) &&
+        (is.null(names(value)) ||
+            anyNA(names(value)) ||
+            any(!nzchar(names(value))) ||
+            anyDuplicated(names(value)))) {
+        return(sprintf("`%s` must be a uniquely named list.", name))
+    }
+    NULL
+}
+
+# Validate the calendar-native daily table at the boundary shared by all
+# methods producing a DailyAdjustedSeries.
+bias__daily_data_error <- function(data) {
+    if (!is.data.frame(data)) {
+        return("`data` must be a data frame.")
+    }
+    missing <- setdiff(BIAS_DAILY_SERIES_COLUMNS, names(data))
+    if (length(missing)) {
+        return(sprintf(
+            "`data` is missing canonical daily column(s): %s.",
+            paste(sprintf("`%s`", missing), collapse = ", ")
+        ))
+    }
+    if (!nrow(data)) {
+        return("`data` must contain at least one daily value.")
+    }
+    if (!is.character(data[["variable_id"]]) ||
+        anyNA(data[["variable_id"]]) ||
+        any(!grepl(
+            "^[A-Za-z][A-Za-z0-9_]*$",
+            data[["variable_id"]]
+        ))) {
+        return("`variable_id` must contain CMIP-style identifiers.")
+    }
+    if (!is.numeric(data[["value"]]) ||
+        any(!is.finite(data[["value"]]))) {
+        return("`value` must contain only finite numeric values.")
+    }
+    if (!is.character(data[["units"]]) ||
+        anyNA(data[["units"]]) ||
+        any(!nzchar(data[["units"]]))) {
+        return("`units` must contain non-missing, non-empty strings.")
+    }
+    if (!is.character(data[["frequency"]]) ||
+        anyNA(data[["frequency"]]) ||
+        any(data[["frequency"]] != "day")) {
+        return("`frequency` must be `day` for every row.")
+    }
+    if (!is.character(data[["cf_calendar"]]) ||
+        anyNA(data[["cf_calendar"]]) ||
+        any(!data[["cf_calendar"]] %in% CF_TIME_CALENDARS)) {
+        return("`cf_calendar` contains an unsupported CF calendar.")
+    }
+
+    integer_columns <- c(
+        "cf_year",
+        "cf_month",
+        "cf_day",
+        "cf_day_of_year",
+        "cf_year_days"
+    )
+    for (column in integer_columns) {
+        value <- data[[column]]
+        if (!is.numeric(value) ||
+            any(!is.finite(value)) ||
+            any(value != as.integer(value))) {
+            return(sprintf(
+                "`%s` must contain finite integer values.",
+                column
+            ))
+        }
+    }
+    phase <- data[["annual_phase"]]
+    if (!is.numeric(phase) ||
+        any(!is.finite(phase)) ||
+        any(phase < 0 | phase >= 1)) {
+        return("`annual_phase` must contain finite values in [0, 1).")
+    }
+
+    # Validate dates and derived coordinates separately for each native
+    # calendar so no Gregorian interpretation is imposed on 360/365/366-day
+    # data.
+    for (calendar in unique(data[["cf_calendar"]])) {
+        index <- which(data[["cf_calendar"]] == calendar)
+        parts <- data.frame(
+            year = as.integer(data[["cf_year"]][index]),
+            month = as.integer(data[["cf_month"]][index]),
+            day = as.integer(data[["cf_day"]][index])
+        )
+        if (!all(cf_time_valid_days(parts, calendar))) {
+            return(sprintf(
+                "`data` contains an invalid date for calendar `%s`.",
+                calendar
+            ))
+        }
+        origin <- data.frame(
+            year = parts$year,
+            month = 1L,
+            day = 1L
+        )
+        expected_day <- as.integer(
+            cf_time_date2offset(parts, origin, calendar) + 1L
+        )
+        expected_days <- as.integer(
+            cf_time__year_days(parts$year, calendar)
+        )
+        if (any(data[["cf_day_of_year"]][index] != expected_day)) {
+            return("`cf_day_of_year` is inconsistent with the CF date.")
+        }
+        if (any(data[["cf_year_days"]][index] != expected_days)) {
+            return("`cf_year_days` is inconsistent with the CF calendar.")
+        }
+        lower <- (expected_day - 1) / expected_days
+        upper <- expected_day / expected_days
+        tolerance <- sqrt(.Machine$double.eps)
+        if (any(phase[index] < lower - tolerance |
+            phase[index] >= upper + tolerance)) {
+            return(
+                "`annual_phase` is inconsistent with the calendar-native day."
+            )
+        }
+    }
+
+    for (variable in unique(data[["variable_id"]])) {
+        index <- data[["variable_id"]] == variable
+        if (length(unique(data[["units"]][index])) != 1L) {
+            return(sprintf(
+                "Variable `%s` must use one unit within a daily series.",
+                variable
+            ))
+        }
+    }
+    key <- data[
+        c(
+            "variable_id",
+            "cf_calendar",
+            "cf_year",
+            "cf_month",
+            "cf_day"
+        )
+    ]
+    if (anyDuplicated(key)) {
+        return(
+            "`data` must have unique variable-calendar-year-month-day keys."
+        )
+    }
+    NULL
+}
+
+# DailyAdjustedSeries carries a canonical daily table and the semantic metadata
+# required by later sequence, hourly, physics, and output components.
+DailyAdjustedSeries <- S7::new_class(
+    "DailyAdjustedSeries",
+    properties = list(
+        data = S7::new_property(S7::class_any),
+        output_role = S7::new_property(S7::class_character),
+        transformation = S7::new_property(S7::class_character),
+        variable_metadata = S7::new_property(S7::class_list),
+        settings = S7::new_property(S7::class_list, default = list()),
+        provenance = S7::new_property(S7::class_list, default = list())
+    ),
+    validator = function(self) {
+        error <- bias__daily_data_error(self@data)
+        if (!is.null(error)) {
+            return(error)
+        }
+        if (length(self@output_role) != 1L ||
+            is.na(self@output_role) ||
+            !self@output_role %in% WEATHER_INPUT_ROLES) {
+            return("`output_role` must identify one future-weather input role.")
+        }
+        if (length(self@transformation) != 1L ||
+            is.na(self@transformation) ||
+            !grepl("^[a-z][a-z0-9_]*$", self@transformation)) {
+            return("`transformation` must use lower snake_case.")
+        }
+        variables <- unique(self@data[["variable_id"]])
+        metadata_error <- bias__named_list_error(
+            self@variable_metadata,
+            "variable_metadata"
+        )
+        if (!is.null(metadata_error) ||
+            !setequal(names(self@variable_metadata), variables) ||
+            length(self@variable_metadata) != length(variables) ||
+            !all(vapply(
+                self@variable_metadata,
+                is.list,
+                logical(1L)
+            ))) {
+            return(
+                "`variable_metadata` must contain one named list per variable."
+            )
+        }
+        for (name in c("settings", "provenance")) {
+            error <- bias__named_list_error(S7::prop(self, name), name)
+            if (!is.null(error)) {
+                return(error)
+            }
+        }
+        NULL
+    }
+)
+
+# Copy and normalize a canonical daily table without inferring missing dates or
+# calendars inside a signal method.
+bias__daily_table <- function(data, name = "data") {
+    if (!is.data.frame(data)) {
+        cli::cli_abort("{.arg {name}} must be a canonical daily data frame.")
+    }
+    out <- as.data.frame(data, stringsAsFactors = FALSE)
+    error <- bias__daily_data_error(out)
+    if (!is.null(error)) {
+        cli::cli_abort("{.arg {name}} is invalid: {error}")
+    }
+    out
+}
+
+# Derive stable per-variable descriptors directly from the validated output
+# table unless a method supplies richer metadata explicitly.
+bias__variable_metadata <- function(data) {
+    variables <- unique(data[["variable_id"]])
+    metadata <- lapply(variables, function(variable) {
+        index <- data[["variable_id"]] == variable
+        list(
+            units = unique(data[["units"]][index]),
+            frequency = "day",
+            calendars = sort(unique(data[["cf_calendar"]][index]))
+        )
+    })
+    stats::setNames(metadata, variables)
+}
+
+# Construct the common result type so method kernels cannot omit its semantic
+# role, settings, or provenance.
+bias__daily_adjusted_series <- function(
+    data,
+    output_role,
+    transformation,
+    variable_metadata = NULL,
+    settings = list(),
+    provenance = list()
+) {
+    data <- bias__daily_table(data)
+    checkmate::assert_choice(output_role, WEATHER_INPUT_ROLES)
+    checkmate::assert_string(
+        transformation,
+        pattern = "^[a-z][a-z0-9_]*$"
+    )
+    if (is.null(variable_metadata)) {
+        variable_metadata <- bias__variable_metadata(data)
+    }
+    checkmate::assert_list(variable_metadata, names = "unique")
+    checkmate::assert_list(settings, names = "unique")
+    checkmate::assert_list(provenance, names = "unique")
+
+    DailyAdjustedSeries(
+        data = data,
+        output_role = output_role,
+        transformation = transformation,
+        variable_metadata = variable_metadata,
+        settings = settings,
+        provenance = provenance
+    )
+}
+
+# Return one explicit diagnostic string when a signal kernel fails to produce
+# the package-native adjusted-series contract.
+bias__validate_daily_adjusted_result <- function(value, inputs, key) {
+    if (!S7::S7_inherits(value, DailyAdjustedSeries)) {
+        return(
+            "Linear Scaling must return a DailyAdjustedSeries object."
+        )
+    }
+    if (!identical(value@output_role, "model_future")) {
+        return(
+            "Linear Scaling output must retain the `model_future` role."
+        )
+    }
+    TRUE
+}
+
+# Define the published monthly-mean defaults separately for temperature and
+# precipitation while retaining their evidence and source in signal profiles.
+bias__linear_scaling_profiles <- function() {
+    temperature_settings <- list(
+        grouping = "calendar_month",
+        statistic = "mean",
+        transformation = "additive",
+        bounds = c(-Inf, Inf),
+        zero_tolerance = 0
+    )
+    precipitation_settings <- list(
+        grouping = "calendar_month",
+        statistic = "mean",
+        transformation = "multiplicative",
+        bounds = c(0, Inf),
+        zero_tolerance = sqrt(.Machine$double.eps)
+    )
+    temperature <- lapply(c("tas", "tasmin", "tasmax"), function(variable) {
+        signal__variable_profile(
+            variable,
+            settings = temperature_settings,
+            evidence = "published",
+            references = BIAS_LINEAR_SCALING_REFERENCES,
+            metadata = list(
+                method = "linear_scaling",
+                output_role = "model_future"
+            )
+        )
+    })
+    precipitation <- signal__variable_profile(
+        "pr",
+        settings = precipitation_settings,
+        evidence = "published",
+        references = BIAS_LINEAR_SCALING_REFERENCES,
+        metadata = list(
+            method = "linear_scaling",
+            output_role = "model_future"
+        )
+    )
+    c(temperature, list(precipitation))
+}
+
+# Resolve and validate the one variable-specific settings record accepted by
+# the univariate Linear Scaling kernel.
+bias__linear_scaling_settings <- function(settings) {
+    if (length(settings) != 1L ||
+        is.null(names(settings)) ||
+        !nzchar(names(settings)[[1L]])) {
+        cli::cli_abort(
+            "Linear Scaling requires settings for exactly one variable."
+        )
+    }
+    resolved <- settings[[1L]]
+    if (!is.list(resolved)) {
+        cli::cli_abort("Linear Scaling settings must be a named list.")
+    }
+    if (!identical(resolved$grouping, "calendar_month")) {
+        cli::cli_abort(
+            "Linear Scaling currently supports only `calendar_month` grouping."
+        )
+    }
+    if (!identical(resolved$statistic, "mean")) {
+        cli::cli_abort(
+            "Linear Scaling currently supports only the monthly mean statistic."
+        )
+    }
+    checkmate::assert_choice(
+        resolved$transformation,
+        c("additive", "multiplicative")
+    )
+    checkmate::assert_numeric(
+        resolved$bounds,
+        len = 2L,
+        any.missing = FALSE
+    )
+    if (resolved$bounds[[1L]] > resolved$bounds[[2L]]) {
+        cli::cli_abort(
+            "Linear Scaling bounds must be ordered from lower to upper."
+        )
+    }
+    checkmate::assert_number(
+        resolved$zero_tolerance,
+        lower = 0,
+        finite = TRUE
+    )
+    resolved
+}
+
+# Validate role payloads as one calendar-native, univariate unit of work and
+# reject unit changes that would make monthly corrections ambiguous.
+bias__linear_scaling_inputs <- function(inputs, variable, transformation) {
+    roles <- c(
+        "observed_reference",
+        "model_historical",
+        "model_future"
+    )
+    if (!identical(sort(names(inputs)), sort(roles))) {
+        cli::cli_abort(
+            "Linear Scaling requires observed, historical-model, and future-model role payloads."
+        )
+    }
+    series <- lapply(roles, function(role) {
+        bias__daily_table(inputs[[role]], role)
+    })
+    names(series) <- roles
+    for (role in roles) {
+        role_variables <- unique(series[[role]][["variable_id"]])
+        if (!identical(role_variables, variable)) {
+            cli::cli_abort(
+                "Linear Scaling role {.val {role}} must contain only variable {.val {variable}}."
+            )
+        }
+        calendars <- unique(series[[role]][["cf_calendar"]])
+        if (length(calendars) != 1L) {
+            cli::cli_abort(
+                "Linear Scaling role {.val {role}} must contain one native calendar per signal group."
+            )
+        }
+    }
+    units <- vapply(
+        series,
+        function(data) unique(data[["units"]]),
+        character(1L)
+    )
+    if (length(unique(units)) != 1L) {
+        cli::cli_abort(
+            "Linear Scaling inputs for {.val {variable}} must use identical units."
+        )
+    }
+    if (identical(transformation, "multiplicative") &&
+        any(vapply(
+            series,
+            function(data) any(data[["value"]] < 0),
+            logical(1L)
+        ))) {
+        cli::cli_abort(
+            "Multiplicative Linear Scaling requires non-negative input values."
+        )
+    }
+    series
+}
+
+# Calculate one monthly mean per role and retain only months required by the
+# future trajectory, which remains the temporal backbone of the output.
+bias__linear_scaling_monthly_means <- function(series) {
+    future_months <- sort(unique(series$model_future[["cf_month"]]))
+    monthly <- lapply(series, function(data) {
+        means <- tapply(
+            data[["value"]],
+            data[["cf_month"]],
+            mean
+        )
+        values <- unname(means[as.character(future_months)])
+        if (anyNA(values)) {
+            cli::cli_abort(
+                "Linear Scaling inputs do not cover every future calendar month."
+            )
+        }
+        values
+    })
+    data.frame(
+        cf_month = future_months,
+        observed_mean = monthly$observed_reference,
+        historical_mean = monthly$model_historical,
+        future_mean = monthly$model_future
+    )
+}
+
+# Apply the published monthly additive or multiplicative Linear Scaling
+# equation and return a typed daily model-future series.
+bias__linear_scaling_apply_group <- function(inputs, settings, key) {
+    resolved <- bias__linear_scaling_settings(settings)
+    variable <- names(settings)[[1L]]
+    series <- bias__linear_scaling_inputs(
+        inputs,
+        variable,
+        resolved$transformation
+    )
+    monthly <- bias__linear_scaling_monthly_means(series)
+
+    if (identical(resolved$transformation, "additive")) {
+        # Temperature uses the monthly observed-minus-historical mean bias as
+        # an additive correction on every future daily value in that month.
+        monthly$correction <- (
+            monthly$observed_mean - monthly$historical_mean
+        )
+    } else {
+        denominator_zero <- (
+            abs(monthly$historical_mean) <= resolved$zero_tolerance
+        )
+        if (any(denominator_zero)) {
+            cli::cli_abort(
+                "Multiplicative Linear Scaling is undefined because the historical monthly mean is zero for month(s) {.val {monthly$cf_month[denominator_zero]}}."
+            )
+        }
+        # Precipitation uses the monthly observed-to-historical mean ratio as
+        # a multiplicative correction on future daily values.
+        monthly$correction <- (
+            monthly$observed_mean / monthly$historical_mean
+        )
+    }
+
+    future <- series$model_future
+    correction <- monthly$correction[
+        match(future[["cf_month"]], monthly$cf_month)
+    ]
+    if (identical(resolved$transformation, "additive")) {
+        adjusted <- future[["value"]] + correction
+    } else {
+        adjusted <- future[["value"]] * correction
+    }
+    bounded <- pmin(
+        pmax(adjusted, resolved$bounds[[1L]]),
+        resolved$bounds[[2L]]
+    )
+    clipped <- sum(bounded != adjusted)
+    future[["value"]] <- bounded
+
+    bias__daily_adjusted_series(
+        future,
+        output_role = "model_future",
+        transformation = resolved$transformation,
+        settings = resolved,
+        provenance = list(
+            method = "linear_scaling",
+            references = BIAS_LINEAR_SCALING_REFERENCES,
+            group_key = key,
+            monthly_corrections = monthly,
+            clipped_values = clipped
+        )
+    )
+}
+
+# Construct the package-native Linear Scaling signal component with three
+# explicit input roles and alternative supported univariate variables.
+bias__linear_scaling_component <- function() {
+    alternatives <- as.list(c("tas", "tasmin", "tasmax", "pr"))
+    requirements <- lapply(
+        c(
+            "observed_reference",
+            "model_historical",
+            "model_future"
+        ),
+        function(role) {
+            component__input_requirement(
+                role,
+                representations = "series",
+                frequencies = "day",
+                variable_sets = alternatives
+            )
+        }
+    )
+    names(requirements) <- c(
+        "observed_reference",
+        "model_historical",
+        "model_future"
+    )
+    signal__component(
+        name = "linear_scaling_daily",
+        label = "Daily Linear Scaling",
+        required_inputs = requirements,
+        input_kinds = "calendar_indexed_daily_series",
+        output_kinds = "daily_adjusted_series",
+        scopes = "univariate",
+        stochastic = FALSE,
+        profiles = bias__linear_scaling_profiles(),
+        apply_group = bias__linear_scaling_apply_group,
+        operations = list(
+            validate_result = bias__validate_daily_adjusted_result
+        ),
+        metadata = list(
+            method_family = "bias_adjustment",
+            output_contract = "daily_adjusted_series",
+            references = BIAS_LINEAR_SCALING_REFERENCES
+        )
+    )
+}
+
+# Register the Linear Scaling signal component once so it is discoverable
+# through the same process-local component registry as complete recipes.
+bias__register_linear_scaling_component <- function() {
+    component <- bias__linear_scaling_component()
+    key <- component__registry_key(component@stage, component@name)
+    if (!exists(
+        key,
+        envir = WEATHER_COMPONENT_REGISTRY,
+        inherits = FALSE
+    )) {
+        component__register(component)
+    }
+    invisible(NULL)
+}

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -11,6 +11,9 @@
     registerS3method("print", "epwshiftr_bytes",
         print.epwshiftr_bytes, envir = asNamespace("base"))
     cache__configure(pkgname)
+    # Register standalone signal methods at load time so downstream component
+    # pipelines can resolve them without constructing a complete EPW recipe.
+    bias__register_linear_scaling_component()
 
     # set package options
     .opts <- list(

--- a/tests/testthat/test-bias-adjustment.R
+++ b/tests/testthat/test-bias-adjustment.R
@@ -1,0 +1,362 @@
+# Build compact canonical daily rows for package-native signal contract tests.
+bias_adjustment_test__series <- function(
+    variable_id,
+    year,
+    values,
+    months = c(1L, 1L, 2L, 2L),
+    days = c(1L, 2L, 1L, 2L),
+    calendar = "noleap",
+    units = if (identical(variable_id, "pr")) {
+        "kg m-2 s-1"
+    } else {
+        "K"
+    }
+) {
+    fields <- data.frame(
+        year = rep.int(as.integer(year), length(values)),
+        month = as.integer(months),
+        day = as.integer(days),
+        hour = rep.int(12, length(values)),
+        minute = rep.int(0, length(values)),
+        second = rep.int(0, length(values))
+    )
+    coordinates <- cf_time__coordinates(fields, calendar)
+    data.frame(
+        variable_id = rep.int(variable_id, length(values)),
+        value = as.numeric(values),
+        units = rep.int(units, length(values)),
+        frequency = rep.int("day", length(values)),
+        coordinates,
+        stringsAsFactors = FALSE
+    )
+}
+
+# Build all three role-labelled WeatherInput objects required by Linear
+# Scaling while retaining the same tables in the aligned SignalGroup.
+bias_adjustment_test__inputs <- function(observed, historical, future) {
+    weather__new_inputs(
+        observed_reference = weather__new_input(
+            "observed_reference",
+            observed
+        ),
+        model_historical = weather__new_input(
+            "model_historical",
+            historical
+        ),
+        model_future = weather__new_input(
+            "model_future",
+            future
+        )
+    )
+}
+
+test_that("daily adjusted series enforces canonical calendar-native data", {
+    source <- bias_adjustment_test__series(
+        "tas",
+        2061L,
+        c(280, 282, 284, 286)
+    )
+    result <- bias__daily_adjusted_series(
+        source,
+        output_role = "model_future",
+        transformation = "additive",
+        settings = list(grouping = "calendar_month"),
+        provenance = list(method = "test")
+    )
+
+    expect_true(S7::S7_inherits(result, DailyAdjustedSeries))
+    expect_identical(result@data, source)
+    expect_identical(result@output_role, "model_future")
+    expect_identical(result@variable_metadata$tas$units, "K")
+    expect_identical(result@variable_metadata$tas$frequency, "day")
+    expect_identical(result@variable_metadata$tas$calendars, "noleap")
+
+    for (calendar in CF_TIME_CALENDARS) {
+        calendar_data <- bias_adjustment_test__series(
+            "tas",
+            2000L,
+            c(280, 282, 284, 286),
+            calendar = calendar
+        )
+        expect_no_error(
+            bias__daily_adjusted_series(
+                calendar_data,
+                "model_future",
+                "additive"
+            )
+        )
+    }
+
+    duplicate <- rbind(source, source[1L, ])
+    expect_error(
+        bias__daily_adjusted_series(
+            duplicate,
+            "model_future",
+            "additive"
+        ),
+        "unique variable-calendar-year-month-day"
+    )
+    invalid_date <- source
+    invalid_date$cf_day[[1L]] <- 31L
+    invalid_date$cf_month[[1L]] <- 2L
+    expect_error(
+        bias__daily_adjusted_series(
+            invalid_date,
+            "model_future",
+            "additive"
+        ),
+        "invalid date"
+    )
+    invalid_phase <- source
+    invalid_phase$annual_phase[[1L]] <- 0.9
+    expect_error(
+        bias__daily_adjusted_series(
+            invalid_phase,
+            "model_future",
+            "additive"
+        ),
+        "annual_phase"
+    )
+})
+
+test_that("Linear Scaling applies monthly additive temperature corrections", {
+    observed <- bias_adjustment_test__series(
+        "tas",
+        2001L,
+        c(10, 14, 20, 24)
+    )
+    historical <- bias_adjustment_test__series(
+        "tas",
+        1991L,
+        c(8, 10, 17, 19)
+    )
+    future <- bias_adjustment_test__series(
+        "tas",
+        2061L,
+        c(18, 21, 30, 35)
+    )
+    component <- bias__linear_scaling_component()
+    inputs <- bias_adjustment_test__inputs(
+        observed,
+        historical,
+        future
+    )
+    group <- signal__group(
+        key = list(site = "A"),
+        inputs = list(
+            observed_reference = observed,
+            model_historical = historical,
+            model_future = future
+        ),
+        variables = "tas"
+    )
+
+    execution <- component__execute(
+        component,
+        "apply",
+        inputs = inputs,
+        groups = list(group),
+        overrides = list(tas = list(bounds = c(-Inf, 40)))
+    )
+    adjusted <- execution@values[[1L]]
+
+    expect_true(S7::S7_inherits(execution, SignalExecutionResult))
+    expect_true(S7::S7_inherits(adjusted, DailyAdjustedSeries))
+    expect_equal(adjusted@data$value, c(21, 24, 34, 39))
+    expect_identical(
+        adjusted@data[BIAS_DAILY_SERIES_COLUMNS[-2L]],
+        future[BIAS_DAILY_SERIES_COLUMNS[-2L]]
+    )
+    expect_identical(adjusted@transformation, "additive")
+    expect_identical(adjusted@output_role, "model_future")
+    expect_identical(execution@diagnostics$status, "ok")
+    expect_equal(
+        adjusted@provenance$monthly_corrections$correction,
+        c(3, 4)
+    )
+    expect_identical(adjusted@provenance$group_key, list(site = "A"))
+    expect_identical(adjusted@settings$bounds, c(-Inf, 40))
+    expect_identical(execution@profiles$tas$settings$bounds, c(-Inf, 40))
+})
+
+test_that("Linear Scaling applies multiplicative precipitation corrections", {
+    observed <- bias_adjustment_test__series(
+        "pr",
+        2001L,
+        c(2, 4, 3, 5)
+    )
+    historical <- bias_adjustment_test__series(
+        "pr",
+        1991L,
+        c(1, 2, 2, 2)
+    )
+    future <- bias_adjustment_test__series(
+        "pr",
+        2061L,
+        c(3, 6, 4, 8)
+    )
+    component <- bias__linear_scaling_component()
+    result <- component__execute(
+        component,
+        "apply_group",
+        inputs = list(
+            observed_reference = observed,
+            model_historical = historical,
+            model_future = future
+        ),
+        settings = list(
+            pr = component@metadata$signal_profiles$pr$settings
+        ),
+        key = list(site = "A")
+    )
+
+    expect_true(S7::S7_inherits(result, DailyAdjustedSeries))
+    expect_equal(result@data$value, c(6, 12, 8, 16))
+    expect_equal(
+        result@provenance$monthly_corrections$correction,
+        c(2, 2)
+    )
+    expect_identical(result@settings$bounds, c(0, Inf))
+    expect_identical(result@provenance$clipped_values, 0L)
+})
+
+test_that("Linear Scaling handles undefined ratios and bounds explicitly", {
+    observed <- bias_adjustment_test__series(
+        "pr",
+        2001L,
+        c(1, 1, 1, 1)
+    )
+    historical <- bias_adjustment_test__series(
+        "pr",
+        1991L,
+        c(0, 0, 1, 1)
+    )
+    future <- bias_adjustment_test__series(
+        "pr",
+        2061L,
+        c(2, 2, 2, 2)
+    )
+    component <- bias__linear_scaling_component()
+    settings <- component@metadata$signal_profiles$pr$settings
+
+    expect_error(
+        component__execute(
+            component,
+            "apply_group",
+            inputs = list(
+                observed_reference = observed,
+                model_historical = historical,
+                model_future = future
+            ),
+            settings = list(pr = settings),
+            key = list()
+        ),
+        "historical monthly mean is zero"
+    )
+    inputs <- bias_adjustment_test__inputs(
+        observed,
+        historical,
+        future
+    )
+    group <- signal__group(
+        inputs = list(
+            observed_reference = observed,
+            model_historical = historical,
+            model_future = future
+        ),
+        variables = "pr"
+    )
+    collected <- component__execute(
+        component,
+        "apply",
+        inputs = inputs,
+        groups = list(group),
+        error_policy = "collect"
+    )
+    expect_null(collected@values[[1L]])
+    expect_identical(collected@diagnostics$status, "error")
+    expect_match(
+        collected@diagnostics$message,
+        "historical monthly mean is zero"
+    )
+
+    historical$value <- 1
+    bounded <- component__execute(
+        component,
+        "apply_group",
+        inputs = list(
+            observed_reference = observed,
+            model_historical = historical,
+            model_future = future
+        ),
+        settings = list(
+            pr = utils::modifyList(
+                settings,
+                list(bounds = c(0, 1.5))
+            )
+        ),
+        key = list()
+    )
+    expect_equal(bounded@data$value, rep(1.5, 4L))
+    expect_identical(bounded@provenance$clipped_values, 4L)
+
+    future$value[[1L]] <- -1
+    expect_error(
+        component__execute(
+            component,
+            "apply_group",
+            inputs = list(
+                observed_reference = observed,
+                model_historical = historical,
+                model_future = future
+            ),
+            settings = list(pr = settings),
+            key = list()
+        ),
+        "non-negative"
+    )
+})
+
+test_that("Linear Scaling is a registered package-native signal component", {
+    bias__register_linear_scaling_component()
+    component <- component__get("signal", "linear_scaling_daily")
+
+    expect_true(S7::S7_inherits(component, WeatherComponentSpec))
+    expect_identical(component@stage, "signal")
+    expect_identical(
+        component@input_kinds,
+        "calendar_indexed_daily_series"
+    )
+    expect_identical(component@output_kinds, "daily_adjusted_series")
+    expect_identical(component@scopes, "univariate")
+    expect_false(component@stochastic)
+    expect_identical(
+        sort(names(component@required_inputs)),
+        sort(c(
+            "observed_reference",
+            "model_historical",
+            "model_future"
+        ))
+    )
+    expect_identical(
+        component@metadata$output_contract,
+        "daily_adjusted_series"
+    )
+
+    calendar <- component__spec(
+        name = "daily_calendar_test",
+        stage = "calendar",
+        input_kinds = "preprocessed_daily_series",
+        output_kinds = "calendar_indexed_daily_series",
+        operations = list(apply = identity)
+    )
+    sequence <- component__spec(
+        name = "adjusted_sequence_test",
+        stage = "sequence",
+        input_kinds = "daily_adjusted_series",
+        output_kinds = "weather_sequence",
+        operations = list(generate = identity)
+    )
+    expect_true(component__compatible(calendar, component))
+    expect_true(component__compatible(component, sequence))
+})

--- a/tools/daily-cmip6-method-development.md
+++ b/tools/daily-cmip6-method-development.md
@@ -130,7 +130,7 @@ Status in this table refers to the repository state checked on 2026-07-26.
 | Eames monthly temperature signal and BTWS recipe | Merged | PR [#153](https://github.com/ideas-lab-nus/epwshiftr/pull/153) |
 | Ek daily temperature factors | Implemented | PR [#155](https://github.com/ideas-lab-nus/epwshiftr/pull/155) |
 | Arima month-wise temperature quantile mapping | Implemented | PR [#157](https://github.com/ideas-lab-nus/epwshiftr/pull/157) |
-| Package-native daily adjusted-series contract and Linear Scaling signal | In development | Issue [#160](https://github.com/ideas-lab-nus/epwshiftr/issues/160) |
+| Package-native daily adjusted-series contract and Linear Scaling signal | Implemented | PR [#161](https://github.com/ideas-lab-nus/epwshiftr/pull/161) |
 
 The current daily temperature path:
 
@@ -653,8 +653,8 @@ Update this table as work is merged.
 | Eames non-temperature transformations | Not started |
 | Ek daily temperature factors | Implemented in PR #155 |
 | Arima rank/QM | Implemented in PR #157 |
-| Native daily adjusted-series signal contract | In development in #160 |
-| Linear Scaling signal | In development in #160 |
+| Native daily adjusted-series signal contract | Implemented in PR #161 |
+| Linear Scaling signal | Implemented in PR #161 |
 | Remaining seven native ibicus-compatible signal methods | Not started |
 | QQ/QM reproduction configuration | Not started |
 | BCCAQv2 reference-data/tool adapter | Not started |

--- a/tools/daily-cmip6-method-development.md
+++ b/tools/daily-cmip6-method-development.md
@@ -130,6 +130,7 @@ Status in this table refers to the repository state checked on 2026-07-26.
 | Eames monthly temperature signal and BTWS recipe | Merged | PR [#153](https://github.com/ideas-lab-nus/epwshiftr/pull/153) |
 | Ek daily temperature factors | Implemented | PR [#155](https://github.com/ideas-lab-nus/epwshiftr/pull/155) |
 | Arima month-wise temperature quantile mapping | Implemented | PR [#157](https://github.com/ideas-lab-nus/epwshiftr/pull/157) |
+| Package-native daily adjusted-series contract and Linear Scaling signal | In development | Issue [#160](https://github.com/ideas-lab-nus/epwshiftr/issues/160) |
 
 The current daily temperature path:
 
@@ -236,6 +237,16 @@ Implementation policy:
    stochastic behavior directly in the package;
 5. enable a method in an EPW recipe only after its native implementation and
    diagnostics are complete.
+
+The first implementation uses a package-native `DailyAdjustedSeries` result
+rather than an external debiaser type. It retains the transformed
+`model_future` role, canonical calendar-native daily coordinates, variable
+metadata, resolved settings, correction provenance, and the standard signal
+diagnostics. Linear Scaling is the first producer of this contract: monthly
+temperature mean bias is applied additively and monthly precipitation mean
+bias multiplicatively. The signal component deliberately stops at the
+corrected daily sequence; it does not invent an EPW sequence or hourly
+reconstruction policy.
 
 ### 6.2 Other signal and preprocessing methods
 
@@ -642,7 +653,9 @@ Update this table as work is merged.
 | Eames non-temperature transformations | Not started |
 | Ek daily temperature factors | Implemented in PR #155 |
 | Arima rank/QM | Implemented in PR #157 |
-| Eight native ibicus-compatible signal methods | Not started |
+| Native daily adjusted-series signal contract | In development in #160 |
+| Linear Scaling signal | In development in #160 |
+| Remaining seven native ibicus-compatible signal methods | Not started |
 | QQ/QM reproduction configuration | Not started |
 | BCCAQv2 reference-data/tool adapter | Not started |
 | Daily BCSD reference-data/tool adapter | Not started |
@@ -696,6 +709,9 @@ comparison.
   <https://doi.org/10.1175/JCLI-D-14-00754.1>
 - Lange (2019), ISIMIP3BASD:
   <https://doi.org/10.5194/gmd-12-3055-2019>
+- Teutschbein and Seibert (2012), precipitation and temperature bias-correction
+  methods for hydrological climate-change simulation:
+  <https://doi.org/10.1016/j.jhydrol.2012.05.052>
 - Cannon (2018), MBCn:
   <https://doi.org/10.1007/s00382-017-3580-6>
 - Spuler et al. (2024), ibicus:


### PR DESCRIPTION
## Summary

Closes #160 by adding a package-native typed output for daily bias-adjustment signals.

## Changes

- add the internal `DailyAdjustedSeries` S7 contract with canonical CF-calendar daily coordinates, semantic output role, variable metadata, resolved settings, and provenance
- implement and register native R monthly Linear Scaling for additive temperature and multiplicative precipitation corrections
- validate role-addressable inputs, units, calendars, finite values, unique daily keys, bounds, and undefined multiplicative denominators
- add equation, calendar, registration, compatibility, settings, provenance, and diagnostic tests
- update the daily CMIP6 method development guide