### PR TITLE
feat: add native daily Delta Change signal

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -46,6 +46,13 @@
 
 ## New features
 
+* Added the native R `delta_change_daily` signal component. It transfers
+  historical-to-future monthly mean changes onto the observed-reference daily
+  sequence: additively for `tas`, `tasmin`, and `tasmax`, and multiplicatively
+  for `pr`. The typed result preserves observed calendar coordinates and
+  variability while recording resolved settings, modeled monthly changes,
+  bounds, clipping, provenance, and explicit diagnostics (#163).
+
 * Added the package-native `DailyAdjustedSeries` signal contract and registered
   native R `linear_scaling_daily` component. The univariate component consumes
   distinct observed-reference, historical-model, and future-model daily

--- a/R/bias-adjustment.R
+++ b/R/bias-adjustment.R
@@ -23,6 +23,12 @@ BIAS_LINEAR_SCALING_REFERENCES <- c(
     "https://doi.org/10.1016/j.jhydrol.2012.05.052"
 )
 
+# Delta Change defaults follow the published monthly additive-temperature and
+# multiplicative-precipitation change-factor formulation.
+BIAS_DELTA_CHANGE_REFERENCES <- c(
+    "https://doi.org/10.5194/hess-16-4343-2012"
+)
+
 # Check the named-list fields carried by the signal result without constraining
 # the method-specific values stored inside them.
 bias__named_list_error <- function(value, name) {
@@ -294,9 +300,9 @@ bias__daily_adjusted_series <- function(
     )
 }
 
-# Return one explicit diagnostic string when a signal kernel fails to produce
-# the package-native adjusted-series contract.
-bias__validate_daily_adjusted_result <- function(value, inputs, key) {
+# Return one explicit diagnostic string when Linear Scaling fails to produce
+# its package-native future-model result.
+bias__validate_linear_scaling_result <- function(value, inputs, key) {
     if (!S7::S7_inherits(value, DailyAdjustedSeries)) {
         return(
             "Linear Scaling must return a DailyAdjustedSeries object."
@@ -305,6 +311,22 @@ bias__validate_daily_adjusted_result <- function(value, inputs, key) {
     if (!identical(value@output_role, "model_future")) {
         return(
             "Linear Scaling output must retain the `model_future` role."
+        )
+    }
+    TRUE
+}
+
+# Return one explicit diagnostic string when Delta Change fails to produce its
+# package-native observed-reference result.
+bias__validate_delta_change_result <- function(value, inputs, key) {
+    if (!S7::S7_inherits(value, DailyAdjustedSeries)) {
+        return(
+            "Delta Change must return a DailyAdjustedSeries object."
+        )
+    }
+    if (!identical(value@output_role, "observed_reference")) {
+        return(
+            "Delta Change output must retain the `observed_reference` role."
         )
     }
     TRUE
@@ -352,28 +374,28 @@ bias__linear_scaling_profiles <- function() {
     c(temperature, list(precipitation))
 }
 
-# Resolve and validate the one variable-specific settings record accepted by
-# the univariate Linear Scaling kernel.
-bias__linear_scaling_settings <- function(settings) {
+# Resolve the monthly mean-change settings shared by Linear Scaling and Delta
+# Change while keeping method names in user-facing diagnostics.
+bias__mean_change_settings <- function(settings, method) {
     if (length(settings) != 1L ||
         is.null(names(settings)) ||
         !nzchar(names(settings)[[1L]])) {
         cli::cli_abort(
-            "Linear Scaling requires settings for exactly one variable."
+            "{method} requires settings for exactly one variable."
         )
     }
     resolved <- settings[[1L]]
     if (!is.list(resolved)) {
-        cli::cli_abort("Linear Scaling settings must be a named list.")
+        cli::cli_abort("{method} settings must be a named list.")
     }
     if (!identical(resolved$grouping, "calendar_month")) {
         cli::cli_abort(
-            "Linear Scaling currently supports only `calendar_month` grouping."
+            "{method} currently supports only `calendar_month` grouping."
         )
     }
     if (!identical(resolved$statistic, "mean")) {
         cli::cli_abort(
-            "Linear Scaling currently supports only the monthly mean statistic."
+            "{method} currently supports only the monthly mean statistic."
         )
     }
     checkmate::assert_choice(
@@ -387,7 +409,7 @@ bias__linear_scaling_settings <- function(settings) {
     )
     if (resolved$bounds[[1L]] > resolved$bounds[[2L]]) {
         cli::cli_abort(
-            "Linear Scaling bounds must be ordered from lower to upper."
+            "{method} bounds must be ordered from lower to upper."
         )
     }
     checkmate::assert_number(
@@ -400,7 +422,12 @@ bias__linear_scaling_settings <- function(settings) {
 
 # Validate role payloads as one calendar-native, univariate unit of work and
 # reject unit changes that would make monthly corrections ambiguous.
-bias__linear_scaling_inputs <- function(inputs, variable, transformation) {
+bias__mean_change_inputs <- function(
+    inputs,
+    variable,
+    transformation,
+    method
+) {
     roles <- c(
         "observed_reference",
         "model_historical",
@@ -408,7 +435,7 @@ bias__linear_scaling_inputs <- function(inputs, variable, transformation) {
     )
     if (!identical(sort(names(inputs)), sort(roles))) {
         cli::cli_abort(
-            "Linear Scaling requires observed, historical-model, and future-model role payloads."
+            "{method} requires observed, historical-model, and future-model role payloads."
         )
     }
     series <- lapply(roles, function(role) {
@@ -419,13 +446,13 @@ bias__linear_scaling_inputs <- function(inputs, variable, transformation) {
         role_variables <- unique(series[[role]][["variable_id"]])
         if (!identical(role_variables, variable)) {
             cli::cli_abort(
-                "Linear Scaling role {.val {role}} must contain only variable {.val {variable}}."
+                "{method} role {.val {role}} must contain only variable {.val {variable}}."
             )
         }
         calendars <- unique(series[[role]][["cf_calendar"]])
         if (length(calendars) != 1L) {
             cli::cli_abort(
-                "Linear Scaling role {.val {role}} must contain one native calendar per signal group."
+                "{method} role {.val {role}} must contain one native calendar per signal group."
             )
         }
     }
@@ -436,7 +463,7 @@ bias__linear_scaling_inputs <- function(inputs, variable, transformation) {
     )
     if (length(unique(units)) != 1L) {
         cli::cli_abort(
-            "Linear Scaling inputs for {.val {variable}} must use identical units."
+            "{method} inputs for {.val {variable}} must use identical units."
         )
     }
     if (identical(transformation, "multiplicative") &&
@@ -446,32 +473,36 @@ bias__linear_scaling_inputs <- function(inputs, variable, transformation) {
             logical(1L)
         ))) {
         cli::cli_abort(
-            "Multiplicative Linear Scaling requires non-negative input values."
+            "Multiplicative {method} requires non-negative input values."
         )
     }
     series
 }
 
-# Calculate one monthly mean per role and retain only months required by the
-# future trajectory, which remains the temporal backbone of the output.
-bias__linear_scaling_monthly_means <- function(series) {
-    future_months <- sort(unique(series$model_future[["cf_month"]]))
+# Calculate one native-calendar monthly mean per role for the months present
+# in the method's declared output backbone.
+bias__mean_change_monthly_means <- function(
+    series,
+    output_role,
+    method
+) {
+    output_months <- sort(unique(series[[output_role]][["cf_month"]]))
     monthly <- lapply(series, function(data) {
         means <- tapply(
             data[["value"]],
             data[["cf_month"]],
             mean
         )
-        values <- unname(means[as.character(future_months)])
+        values <- unname(means[as.character(output_months)])
         if (anyNA(values)) {
             cli::cli_abort(
-                "Linear Scaling inputs do not cover every future calendar month."
+                "{method} inputs do not cover every output calendar month."
             )
         }
         values
     })
     data.frame(
-        cf_month = future_months,
+        cf_month = output_months,
         observed_mean = monthly$observed_reference,
         historical_mean = monthly$model_historical,
         future_mean = monthly$model_future
@@ -481,14 +512,20 @@ bias__linear_scaling_monthly_means <- function(series) {
 # Apply the published monthly additive or multiplicative Linear Scaling
 # equation and return a typed daily model-future series.
 bias__linear_scaling_apply_group <- function(inputs, settings, key) {
-    resolved <- bias__linear_scaling_settings(settings)
+    method <- "Linear Scaling"
+    resolved <- bias__mean_change_settings(settings, method)
     variable <- names(settings)[[1L]]
-    series <- bias__linear_scaling_inputs(
+    series <- bias__mean_change_inputs(
         inputs,
         variable,
-        resolved$transformation
+        resolved$transformation,
+        method
     )
-    monthly <- bias__linear_scaling_monthly_means(series)
+    monthly <- bias__mean_change_monthly_means(
+        series,
+        "model_future",
+        method
+    )
 
     if (identical(resolved$transformation, "additive")) {
         # Temperature uses the monthly observed-minus-historical mean bias as
@@ -578,7 +615,7 @@ bias__linear_scaling_component <- function() {
         profiles = bias__linear_scaling_profiles(),
         apply_group = bias__linear_scaling_apply_group,
         operations = list(
-            validate_result = bias__validate_daily_adjusted_result
+            validate_result = bias__validate_linear_scaling_result
         ),
         metadata = list(
             method_family = "bias_adjustment",
@@ -592,6 +629,183 @@ bias__linear_scaling_component <- function() {
 # through the same process-local component registry as complete recipes.
 bias__register_linear_scaling_component <- function() {
     component <- bias__linear_scaling_component()
+    key <- component__registry_key(component@stage, component@name)
+    if (!exists(
+        key,
+        envir = WEATHER_COMPONENT_REGISTRY,
+        inherits = FALSE
+    )) {
+        component__register(component)
+    }
+    invisible(NULL)
+}
+
+# Define published Delta Change defaults for additive temperature changes and
+# multiplicative precipitation changes on the observed-reference backbone.
+bias__delta_change_profiles <- function() {
+    temperature_settings <- list(
+        grouping = "calendar_month",
+        statistic = "mean",
+        transformation = "additive",
+        bounds = c(-Inf, Inf),
+        zero_tolerance = 0
+    )
+    precipitation_settings <- list(
+        grouping = "calendar_month",
+        statistic = "mean",
+        transformation = "multiplicative",
+        bounds = c(0, Inf),
+        zero_tolerance = sqrt(.Machine$double.eps)
+    )
+    temperature <- lapply(c("tas", "tasmin", "tasmax"), function(variable) {
+        signal__variable_profile(
+            variable,
+            settings = temperature_settings,
+            evidence = "published",
+            references = BIAS_DELTA_CHANGE_REFERENCES,
+            metadata = list(
+                method = "delta_change",
+                output_role = "observed_reference"
+            )
+        )
+    })
+    precipitation <- signal__variable_profile(
+        "pr",
+        settings = precipitation_settings,
+        evidence = "published",
+        references = BIAS_DELTA_CHANGE_REFERENCES,
+        metadata = list(
+            method = "delta_change",
+            output_role = "observed_reference"
+        )
+    )
+    c(temperature, list(precipitation))
+}
+
+# Apply published monthly Delta Change equations to the observed daily series
+# and retain that series as the typed temporal backbone of the result.
+bias__delta_change_apply_group <- function(inputs, settings, key) {
+    method <- "Delta Change"
+    resolved <- bias__mean_change_settings(settings, method)
+    variable <- names(settings)[[1L]]
+    series <- bias__mean_change_inputs(
+        inputs,
+        variable,
+        resolved$transformation,
+        method
+    )
+    monthly <- bias__mean_change_monthly_means(
+        series,
+        "observed_reference",
+        method
+    )
+
+    if (identical(resolved$transformation, "additive")) {
+        # For temperature, Delta_m = mean(future_m) - mean(historical_m)
+        # transfers the modeled mean change without replacing observed
+        # day-to-day anomalies.
+        monthly$change <- (
+            monthly$future_mean - monthly$historical_mean
+        )
+    } else {
+        denominator_zero <- (
+            abs(monthly$historical_mean) <= resolved$zero_tolerance
+        )
+        if (any(denominator_zero)) {
+            cli::cli_abort(
+                "Multiplicative Delta Change is undefined because the historical monthly mean is zero for month(s) {.val {monthly$cf_month[denominator_zero]}}."
+            )
+        }
+        # For precipitation, R_m = mean(future_m) / mean(historical_m)
+        # scales observed wet-day magnitudes while preserving the observed
+        # zero/non-zero occurrence sequence.
+        monthly$change <- (
+            monthly$future_mean / monthly$historical_mean
+        )
+    }
+
+    observed <- series$observed_reference
+    change <- monthly$change[
+        match(observed[["cf_month"]], monthly$cf_month)
+    ]
+    if (identical(resolved$transformation, "additive")) {
+        # The additive output equation is x'_obs,d = x_obs,d + Delta_m(d).
+        adjusted <- observed[["value"]] + change
+    } else {
+        # The multiplicative output equation is x'_obs,d = x_obs,d * R_m(d).
+        adjusted <- observed[["value"]] * change
+    }
+    bounded <- pmin(
+        pmax(adjusted, resolved$bounds[[1L]]),
+        resolved$bounds[[2L]]
+    )
+    clipped <- sum(bounded != adjusted)
+    observed[["value"]] <- bounded
+
+    bias__daily_adjusted_series(
+        observed,
+        output_role = "observed_reference",
+        transformation = resolved$transformation,
+        settings = resolved,
+        provenance = list(
+            method = "delta_change",
+            references = BIAS_DELTA_CHANGE_REFERENCES,
+            group_key = key,
+            monthly_changes = monthly,
+            clipped_values = clipped
+        )
+    )
+}
+
+# Construct the package-native Delta Change signal with explicit three-role
+# inputs and an observed-reference daily output.
+bias__delta_change_component <- function() {
+    alternatives <- as.list(c("tas", "tasmin", "tasmax", "pr"))
+    requirements <- lapply(
+        c(
+            "observed_reference",
+            "model_historical",
+            "model_future"
+        ),
+        function(role) {
+            component__input_requirement(
+                role,
+                representations = "series",
+                frequencies = "day",
+                variable_sets = alternatives
+            )
+        }
+    )
+    names(requirements) <- c(
+        "observed_reference",
+        "model_historical",
+        "model_future"
+    )
+    signal__component(
+        name = "delta_change_daily",
+        label = "Daily Delta Change",
+        required_inputs = requirements,
+        input_kinds = "calendar_indexed_daily_series",
+        output_kinds = "daily_adjusted_series",
+        scopes = "univariate",
+        stochastic = FALSE,
+        profiles = bias__delta_change_profiles(),
+        apply_group = bias__delta_change_apply_group,
+        operations = list(
+            validate_result = bias__validate_delta_change_result
+        ),
+        metadata = list(
+            method_family = "bias_adjustment",
+            output_contract = "daily_adjusted_series",
+            references = BIAS_DELTA_CHANGE_REFERENCES
+        )
+    )
+}
+
+# Register Delta Change once so it is discoverable alongside Linear Scaling
+# through the process-local component registry.
+bias__register_delta_change_component <- function() {
+    component <- bias__delta_change_component()
     key <- component__registry_key(component@stage, component@name)
     if (!exists(
         key,

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -14,6 +14,7 @@
     # Register standalone signal methods at load time so downstream component
     # pipelines can resolve them without constructing a complete EPW recipe.
     bias__register_linear_scaling_component()
+    bias__register_delta_change_component()
 
     # set package options
     .opts <- list(

--- a/tests/testthat/test-bias-adjustment.R
+++ b/tests/testthat/test-bias-adjustment.R
@@ -31,8 +31,8 @@ bias_adjustment_test__series <- function(
     )
 }
 
-# Build all three role-labelled WeatherInput objects required by Linear
-# Scaling while retaining the same tables in the aligned SignalGroup.
+# Build all three role-labelled WeatherInput objects required by monthly
+# mean-change signals while retaining the same tables in the aligned group.
 bias_adjustment_test__inputs <- function(observed, historical, future) {
     weather__new_inputs(
         observed_reference = weather__new_input(
@@ -317,6 +317,250 @@ test_that("Linear Scaling handles undefined ratios and bounds explicitly", {
     )
 })
 
+test_that("Delta Change transfers additive changes onto observed daily data", {
+    observed <- bias_adjustment_test__series(
+        "tas",
+        2001L,
+        c(10, 14, 20, 24),
+        calendar = "360_day"
+    )
+    historical <- bias_adjustment_test__series(
+        "tas",
+        1991L,
+        c(8, 10, 17, 19),
+        calendar = "noleap"
+    )
+    future <- bias_adjustment_test__series(
+        "tas",
+        2061L,
+        c(18, 22, 30, 34),
+        calendar = "all_leap"
+    )
+    component <- bias__delta_change_component()
+    inputs <- bias_adjustment_test__inputs(
+        observed,
+        historical,
+        future
+    )
+    group <- signal__group(
+        key = list(site = "A"),
+        inputs = list(
+            observed_reference = observed,
+            model_historical = historical,
+            model_future = future
+        ),
+        variables = "tas"
+    )
+
+    execution <- component__execute(
+        component,
+        "apply",
+        inputs = inputs,
+        groups = list(group)
+    )
+    adjusted <- execution@values[[1L]]
+
+    expect_true(S7::S7_inherits(execution, SignalExecutionResult))
+    expect_true(S7::S7_inherits(adjusted, DailyAdjustedSeries))
+    expect_equal(adjusted@data$value, c(21, 25, 34, 38))
+    expect_identical(
+        adjusted@data[BIAS_DAILY_SERIES_COLUMNS[-2L]],
+        observed[BIAS_DAILY_SERIES_COLUMNS[-2L]]
+    )
+    expect_equal(
+        diff(adjusted@data$value[c(1L, 2L)]),
+        diff(observed$value[c(1L, 2L)])
+    )
+    expect_equal(
+        diff(adjusted@data$value[c(3L, 4L)]),
+        diff(observed$value[c(3L, 4L)])
+    )
+    expect_identical(adjusted@output_role, "observed_reference")
+    expect_identical(adjusted@transformation, "additive")
+    expect_identical(adjusted@provenance$method, "delta_change")
+    expect_equal(
+        adjusted@provenance$monthly_changes$change,
+        c(11, 14)
+    )
+    expect_identical(adjusted@provenance$group_key, list(site = "A"))
+    expect_identical(execution@diagnostics$status, "ok")
+    expect_identical(
+        execution@profiles$tas$metadata$output_role,
+        "observed_reference"
+    )
+})
+
+test_that("Delta Change has zero-change identity for every CF calendar", {
+    component <- bias__delta_change_component()
+    settings <- component@metadata$signal_profiles$tas$settings
+
+    for (calendar in CF_TIME_CALENDARS) {
+        observed <- bias_adjustment_test__series(
+            "tas",
+            2000L,
+            c(10, 14, 20, 24),
+            calendar = calendar
+        )
+        historical <- bias_adjustment_test__series(
+            "tas",
+            1990L,
+            c(8, 10, 17, 19),
+            calendar = calendar
+        )
+        future <- historical
+        future$cf_year <- rep.int(2060L, nrow(future))
+        coordinates <- cf_time__coordinates(
+            data.frame(
+                year = future$cf_year,
+                month = future$cf_month,
+                day = future$cf_day,
+                hour = rep.int(12, nrow(future)),
+                minute = rep.int(0, nrow(future)),
+                second = rep.int(0, nrow(future))
+            ),
+            calendar
+        )
+        future[names(coordinates)] <- coordinates
+
+        result <- component__execute(
+            component,
+            "apply_group",
+            inputs = list(
+                observed_reference = observed,
+                model_historical = historical,
+                model_future = future
+            ),
+            settings = list(tas = settings),
+            key = list(calendar = calendar)
+        )
+
+        expect_identical(result@data$value, observed$value)
+        expect_identical(result@data$cf_calendar, observed$cf_calendar)
+        expect_equal(result@provenance$monthly_changes$change, c(0, 0))
+    }
+})
+
+test_that("Delta Change transfers multiplicative precipitation changes", {
+    observed <- bias_adjustment_test__series(
+        "pr",
+        2001L,
+        c(0, 4, 2, 6)
+    )
+    historical <- bias_adjustment_test__series(
+        "pr",
+        1991L,
+        c(1, 3, 2, 2)
+    )
+    future <- bias_adjustment_test__series(
+        "pr",
+        2061L,
+        c(2, 6, 6, 2)
+    )
+    component <- bias__delta_change_component()
+    settings <- component@metadata$signal_profiles$pr$settings
+    result <- component__execute(
+        component,
+        "apply_group",
+        inputs = list(
+            observed_reference = observed,
+            model_historical = historical,
+            model_future = future
+        ),
+        settings = list(pr = settings),
+        key = list(site = "A")
+    )
+
+    expect_equal(result@data$value, c(0, 8, 4, 12))
+    expect_identical(
+        result@data$value == 0,
+        observed$value == 0
+    )
+    expect_equal(
+        result@provenance$monthly_changes$change,
+        c(2, 2)
+    )
+    expect_identical(result@settings$bounds, c(0, Inf))
+    expect_identical(result@provenance$clipped_values, 0L)
+})
+
+test_that("Delta Change rejects undefined inputs and records clipping", {
+    observed <- bias_adjustment_test__series(
+        "pr",
+        2001L,
+        c(1, 2, 3, 4)
+    )
+    historical <- bias_adjustment_test__series(
+        "pr",
+        1991L,
+        c(0, 0, 1, 1)
+    )
+    future <- bias_adjustment_test__series(
+        "pr",
+        2061L,
+        c(2, 2, 2, 2)
+    )
+    component <- bias__delta_change_component()
+    settings <- component@metadata$signal_profiles$pr$settings
+    roles <- list(
+        observed_reference = observed,
+        model_historical = historical,
+        model_future = future
+    )
+
+    expect_error(
+        component__execute(
+            component,
+            "apply_group",
+            inputs = roles,
+            settings = list(pr = settings),
+            key = list()
+        ),
+        "historical monthly mean is zero"
+    )
+
+    roles$model_historical$value <- rep.int(1, 4L)
+    incompatible_units <- roles
+    incompatible_units$model_future$units <- rep.int("mm day-1", 4L)
+    expect_error(
+        component__execute(
+            component,
+            "apply_group",
+            inputs = incompatible_units,
+            settings = list(pr = settings),
+            key = list()
+        ),
+        "identical units"
+    )
+
+    negative <- roles
+    negative$model_future$value[[1L]] <- -1
+    expect_error(
+        component__execute(
+            component,
+            "apply_group",
+            inputs = negative,
+            settings = list(pr = settings),
+            key = list()
+        ),
+        "non-negative"
+    )
+
+    bounded <- component__execute(
+        component,
+        "apply_group",
+        inputs = roles,
+        settings = list(
+            pr = utils::modifyList(
+                settings,
+                list(bounds = c(0, 5))
+            )
+        ),
+        key = list()
+    )
+    expect_equal(bounded@data$value, c(2, 4, 5, 5))
+    expect_identical(bounded@provenance$clipped_values, 2L)
+})
+
 test_that("Linear Scaling is a registered package-native signal component", {
     bias__register_linear_scaling_component()
     component <- component__get("signal", "linear_scaling_daily")
@@ -352,6 +596,46 @@ test_that("Linear Scaling is a registered package-native signal component", {
     )
     sequence <- component__spec(
         name = "adjusted_sequence_test",
+        stage = "sequence",
+        input_kinds = "daily_adjusted_series",
+        output_kinds = "weather_sequence",
+        operations = list(generate = identity)
+    )
+    expect_true(component__compatible(calendar, component))
+    expect_true(component__compatible(component, sequence))
+})
+
+test_that("Delta Change is a registered package-native signal component", {
+    bias__register_delta_change_component()
+    component <- component__get("signal", "delta_change_daily")
+
+    expect_true(S7::S7_inherits(component, WeatherComponentSpec))
+    expect_identical(component@stage, "signal")
+    expect_identical(
+        component@input_kinds,
+        "calendar_indexed_daily_series"
+    )
+    expect_identical(component@output_kinds, "daily_adjusted_series")
+    expect_identical(component@scopes, "univariate")
+    expect_false(component@stochastic)
+    expect_identical(
+        sort(names(component@metadata$signal_profiles)),
+        sort(c("tas", "tasmin", "tasmax", "pr"))
+    )
+    expect_identical(
+        component@metadata$signal_profiles$pr$evidence,
+        "published"
+    )
+
+    calendar <- component__spec(
+        name = "delta_calendar_test",
+        stage = "calendar",
+        input_kinds = "preprocessed_daily_series",
+        output_kinds = "calendar_indexed_daily_series",
+        operations = list(apply = identity)
+    )
+    sequence <- component__spec(
+        name = "delta_sequence_test",
         stage = "sequence",
         input_kinds = "daily_adjusted_series",
         output_kinds = "weather_sequence",


### PR DESCRIPTION
## Summary

- Adds a package-native daily Delta Change signal that transfers modeled historical-to-future monthly mean changes onto observed daily data.
- Closes #162.

## Changes

- Applies additive change factors to `tas`, `tasmin`, and `tasmax`, and multiplicative change factors to `pr`.
- Returns a typed `DailyAdjustedSeries` with the `observed_reference` backbone, resolved settings, monthly changes, clipping diagnostics, and published-method provenance.
- Shares calendar-native role, unit, settings, and monthly-summary validation with Linear Scaling while preserving their distinct output semantics.
- Covers equations, identity behavior, CF calendars, input failures, bounds, registration, and component compatibility in package tests.