### PR TITLE
feat: add daily quantile mapping signal

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -90,6 +90,7 @@ Collate:
     'gh.R'
     'import-standalone-schema.R'
     'netcdf.R'
+    'quantile-mapping.R'
     'solr-date.R'
     'query-param.R'
     'query-result.R'

--- a/NEWS.md
+++ b/NEWS.md
@@ -46,6 +46,18 @@
 
 ## New features
 
+* Added the native R `quantile_mapping_daily` signal component. It maps
+  future-model daily values through historical-model and observed-reference
+  empirical distributions in calendar-neutral circular windows, using
+  explicit tie, interpolation, tail, bound, and minimum-sample conventions.
+  Precipitation uses a mixed dry-day/positive-amount hurdle distribution with
+  deterministic group-specific randomization that leaves R's global RNG state
+  untouched. Results preserve the future-model CF-calendar sequence and record
+  resolved settings, sample coverage, tails, clipping, dry-day changes, and
+  provenance. Published method-variable profiles are limited to `tas` and
+  `pr`; implementation-selected defaults for other supported variables remain
+  experimental (#167).
+
 * Added the native R `delta_change_daily` signal component. It transfers
   historical-to-future monthly mean changes onto the observed-reference daily
   sequence: additively for `tas`, `tasmin`, and `tasmax`, and multiplicatively

--- a/R/quantile-mapping.R
+++ b/R/quantile-mapping.R
@@ -1,0 +1,746 @@
+#' @include bias-adjustment.R daily-climatology.R
+NULL
+
+# Quantile Mapping references identify the published transfer equation and
+# the review used to delimit the method's assumptions and evidence.
+QM_REFERENCES <- c(
+    "https://doi.org/10.1175/JCLI-D-14-00754.1",
+    "https://doi.org/10.1007/s40641-016-0050-x"
+)
+
+# A 0.1 mm/day trace threshold is expressed in the native CMIP6 precipitation
+# flux unit kg m-2 s-1; callers using another unit must override the setting.
+QM_PR_DRY_THRESHOLD <- 0.1 / 86400
+
+# The method literature supports direct Quantile Mapping defaults for mean
+# temperature and precipitation. Other variable profiles are implementation
+# choices and therefore remain explicitly experimental.
+QM_PUBLISHED_VARIABLES <- c("pr", "tas")
+QM_EXPERIMENTAL_VARIABLES <- c(
+    "hurs",
+    "psl",
+    "rlds",
+    "sfcWind",
+    "tasmin",
+    "tasmax"
+)
+
+# Construct the complete empirical Quantile Mapping settings record shared by
+# every variable profile, including conventions that publications leave open.
+qm__default_settings <- function(
+    bounds,
+    distribution_model = c("continuous", "precipitation_hurdle"),
+    dry_threshold = 0
+) {
+    distribution_model <- match.arg(distribution_model)
+    list(
+        mapping_type = "nonparametric",
+        detrending = "none",
+        seasonal_window_days = 31L,
+        target_year_days = 365L,
+        min_samples = 10L,
+        cdf_method = "linear_interpolation",
+        inverse_cdf_method = "linear_type_7",
+        tie_method = "average_rank",
+        tail_policy = "clamp",
+        bounds = bounds,
+        distribution_model = distribution_model,
+        dry_threshold = dry_threshold,
+        random_seed = 1L
+    )
+}
+
+# Build published and experimental profiles without assigning literature
+# provenance to implementation-selected variable defaults.
+qm__profiles <- function() {
+    settings <- list(
+        pr = qm__default_settings(
+            c(0, Inf),
+            "precipitation_hurdle",
+            QM_PR_DRY_THRESHOLD
+        ),
+        tas = qm__default_settings(c(-Inf, Inf)),
+        hurs = qm__default_settings(c(0, 100)),
+        psl = qm__default_settings(c(0, Inf)),
+        rlds = qm__default_settings(c(0, Inf)),
+        sfcWind = qm__default_settings(c(0, Inf)),
+        tasmin = qm__default_settings(c(-Inf, Inf)),
+        tasmax = qm__default_settings(c(-Inf, Inf))
+    )
+    variables <- c(QM_PUBLISHED_VARIABLES, QM_EXPERIMENTAL_VARIABLES)
+    lapply(variables, function(variable) {
+        published <- variable %in% QM_PUBLISHED_VARIABLES
+        signal__variable_profile(
+            variable,
+            settings = settings[[variable]],
+            evidence = if (published) "published" else "experimental",
+            references = if (published) QM_REFERENCES else character(),
+            metadata = list(
+                method = "quantile_mapping",
+                output_role = "model_future",
+                default_source = if (published) {
+                    "method_literature"
+                } else {
+                    "package_implementation"
+                }
+            )
+        )
+    })
+}
+
+# Validate all method conventions at the kernel boundary so unsupported
+# empirical-CDF variants cannot be selected silently through an override.
+qm__settings <- function(settings) {
+    if (length(settings) != 1L ||
+        is.null(names(settings)) ||
+        !nzchar(names(settings)[[1L]]) ||
+        !is.list(settings[[1L]])) {
+        cli::cli_abort(
+            "Quantile Mapping requires settings for exactly one variable."
+        )
+    }
+    resolved <- settings[[1L]]
+    expected <- c(
+        "mapping_type",
+        "detrending",
+        "seasonal_window_days",
+        "target_year_days",
+        "min_samples",
+        "cdf_method",
+        "inverse_cdf_method",
+        "tie_method",
+        "tail_policy",
+        "bounds",
+        "distribution_model",
+        "dry_threshold",
+        "random_seed"
+    )
+    missing <- setdiff(expected, names(resolved))
+    unexpected <- setdiff(names(resolved), expected)
+    if (length(missing) || length(unexpected)) {
+        cli::cli_abort(c(
+            "Quantile Mapping settings must use the complete supported schema.",
+            "x" = "Missing setting(s): {.val {missing}}.",
+            "x" = "Unexpected setting(s): {.val {unexpected}}."
+        ))
+    }
+    if (!identical(resolved$mapping_type, "nonparametric")) {
+        cli::cli_abort(
+            "Quantile Mapping currently supports only nonparametric mapping."
+        )
+    }
+    if (!identical(resolved$detrending, "none")) {
+        cli::cli_abort(
+            "Quantile Mapping currently supports only `detrending = \"none\"`."
+        )
+    }
+    if (!identical(resolved$cdf_method, "linear_interpolation") ||
+        !identical(resolved$inverse_cdf_method, "linear_type_7") ||
+        !identical(resolved$tie_method, "average_rank") ||
+        !identical(resolved$tail_policy, "clamp")) {
+        cli::cli_abort(
+            "Quantile Mapping currently requires linear empirical CDF interpolation, type-7 inverse quantiles, average-rank ties, and clamped tails."
+        )
+    }
+    checkmate::assert_integerish(
+        resolved$seasonal_window_days,
+        lower = 1L,
+        len = 1L,
+        any.missing = FALSE
+    )
+    checkmate::assert_integerish(
+        resolved$target_year_days,
+        lower = 3L,
+        len = 1L,
+        any.missing = FALSE
+    )
+    checkmate::assert_integerish(
+        resolved$min_samples,
+        lower = 2L,
+        len = 1L,
+        any.missing = FALSE
+    )
+    # Reuse the calendar-neutral window validator to enforce odd widths and
+    # prevent a wider-than-year seasonal window.
+    daily__window_spec(
+        as.integer(resolved$seasonal_window_days),
+        as.integer(resolved$target_year_days)
+    )
+    checkmate::assert_numeric(
+        resolved$bounds,
+        len = 2L,
+        any.missing = FALSE
+    )
+    if (resolved$bounds[[1L]] > resolved$bounds[[2L]]) {
+        cli::cli_abort(
+            "Quantile Mapping bounds must be ordered from lower to upper."
+        )
+    }
+    checkmate::assert_choice(
+        resolved$distribution_model,
+        c("continuous", "precipitation_hurdle")
+    )
+    checkmate::assert_number(
+        resolved$dry_threshold,
+        lower = 0,
+        finite = TRUE
+    )
+    checkmate::assert_integerish(
+        resolved$random_seed,
+        lower = 0,
+        upper = .Machine$integer.max - 1L,
+        len = 1L,
+        any.missing = FALSE
+    )
+
+    resolved$seasonal_window_days <- as.integer(
+        resolved$seasonal_window_days
+    )
+    resolved$target_year_days <- as.integer(resolved$target_year_days)
+    resolved$min_samples <- as.integer(resolved$min_samples)
+    resolved$random_seed <- as.integer(resolved$random_seed)
+    resolved
+}
+
+# Validate the three role-addressable daily inputs without pairing their native
+# dates or requiring their CF calendars to be identical.
+qm__inputs <- function(inputs, variable, distribution_model) {
+    roles <- c(
+        "observed_reference",
+        "model_historical",
+        "model_future"
+    )
+    if (!identical(sort(names(inputs)), sort(roles))) {
+        cli::cli_abort(
+            "Quantile Mapping requires observed, historical-model, and future-model role payloads."
+        )
+    }
+    series <- lapply(roles, function(role) {
+        bias__daily_table(inputs[[role]], role)
+    })
+    names(series) <- roles
+    for (role in roles) {
+        role_variables <- unique(series[[role]][["variable_id"]])
+        if (!identical(role_variables, variable)) {
+            cli::cli_abort(
+                "Quantile Mapping role {.val {role}} must contain only variable {.val {variable}}."
+            )
+        }
+        if (length(unique(series[[role]][["cf_calendar"]])) != 1L) {
+            cli::cli_abort(
+                "Quantile Mapping role {.val {role}} must contain one native calendar per signal group."
+            )
+        }
+    }
+    units <- vapply(
+        series,
+        function(data) unique(data[["units"]]),
+        character(1L)
+    )
+    if (length(unique(units)) != 1L) {
+        cli::cli_abort(
+            "Quantile Mapping inputs for {.val {variable}} must use identical units."
+        )
+    }
+    if (identical(distribution_model, "precipitation_hurdle") &&
+        any(vapply(
+            series,
+            function(data) any(data[["value"]] < 0),
+            logical(1L)
+        ))) {
+        cli::cli_abort(
+            "Precipitation-hurdle Quantile Mapping requires non-negative input values."
+        )
+    }
+    series
+}
+
+# Define the interpolated empirical CDF with average-rank tie anchors. For a
+# sample x(1)...x(n), each distinct value receives
+# p = (average_rank - 1) / (n - 1), with a constant sample placed at p = 0.5.
+qm__cdf_anchors <- function(sample) {
+    checkmate::assert_numeric(
+        sample,
+        min.len = 1L,
+        finite = TRUE,
+        any.missing = FALSE
+    )
+    ordered <- sort(as.numeric(sample))
+    runs <- rle(ordered)
+    end_rank <- cumsum(runs$lengths)
+    start_rank <- end_rank - runs$lengths + 1L
+    average_rank <- (start_rank + end_rank) / 2
+    probability <- if (length(ordered) == 1L) {
+        0.5
+    } else {
+        (average_rank - 1) / (length(ordered) - 1)
+    }
+    data.frame(
+        value = runs$values,
+        probability = probability
+    )
+}
+
+# Evaluate the explicit empirical CDF and clamp values outside the historical
+# sample to its endpoint probabilities rather than extrapolating a new tail.
+qm__empirical_cdf <- function(sample, values) {
+    checkmate::assert_numeric(
+        values,
+        finite = TRUE,
+        any.missing = FALSE
+    )
+    anchors <- qm__cdf_anchors(sample)
+    probability <- if (nrow(anchors) == 1L) {
+        rep.int(anchors$probability, length(values))
+    } else {
+        stats::approx(
+            x = anchors$value,
+            y = anchors$probability,
+            xout = values,
+            method = "linear",
+            rule = 2,
+            ties = "ordered"
+        )$y
+    }
+    lower_tail <- values < min(anchors$value)
+    upper_tail <- values > max(anchors$value)
+    # Tail clamping means values strictly beyond the calibration range map to
+    # the observed minimum or maximum even when a tied historical endpoint
+    # has an interior average-rank probability.
+    probability[lower_tail] <- 0
+    probability[upper_tail] <- 1
+    list(
+        probability = probability,
+        lower_tail = lower_tail,
+        upper_tail = upper_tail,
+        tied_sample_values = length(sample) - nrow(anchors)
+    )
+}
+
+# Evaluate the inverse empirical CDF with R's type-7 linear quantile rule. This
+# is paired with qm__cdf_anchors() so identical observed and historical samples
+# map their calibration values back to themselves, including tied values.
+qm__inverse_cdf <- function(sample, probability) {
+    checkmate::assert_numeric(
+        probability,
+        lower = 0,
+        upper = 1,
+        finite = TRUE,
+        any.missing = FALSE
+    )
+    as.numeric(stats::quantile(
+        sample,
+        probs = probability,
+        names = FALSE,
+        type = 7
+    ))
+}
+
+# Apply x* = F_obs^{-1}(F_hist(x_future)) with the declared interpolation,
+# tie, and tail conventions to one or more future values.
+qm__map_continuous <- function(historical, observed, future) {
+    cdf <- qm__empirical_cdf(historical, future)
+    list(
+        value = qm__inverse_cdf(observed, cdf$probability),
+        probability = cdf$probability,
+        lower_tail = cdf$lower_tail,
+        upper_tail = cdf$upper_tail,
+        tied_historical_values = cdf$tied_sample_values,
+        tied_observed_values = length(observed) -
+            length(unique(observed))
+    )
+}
+
+# Derive a stable group-specific seed so multiple locations do not receive the
+# same randomized precipitation occurrence sequence under one user seed.
+qm__group_seed <- function(seed, key, variable) {
+    text <- paste(
+        c(
+            variable,
+            unlist(Map(
+                function(name, value) {
+                    paste0(name, "=", as.character(value))
+                },
+                names(key),
+                key
+            ), use.names = FALSE)
+        ),
+        collapse = "\u001f"
+    )
+    modulus <- .Machine$integer.max - 1
+    hash <- (as.double(seed) %% modulus) + 1
+    for (code in utf8ToInt(enc2utf8(text))) {
+        hash <- (hash * 131 + code) %% modulus
+    }
+    as.integer(hash + 1)
+}
+
+# Generate reproducible uniform variates with the Park-Miller minimal-standard
+# recurrence state[i] = 16807 * state[i-1] mod 2147483647. Keeping this small
+# generator method-local makes precipitation results independent of R's global
+# RNG kind and leaves the caller's RNG state untouched.
+qm__uniform <- function(n, seed) {
+    checkmate::assert_count(n)
+    checkmate::assert_int(
+        seed,
+        lower = 1L,
+        upper = .Machine$integer.max - 1L
+    )
+    modulus <- as.double(.Machine$integer.max)
+    state <- as.double(seed)
+    out <- numeric(n)
+    for (index in seq_len(n)) {
+        state <- (16807 * state) %% modulus
+        out[[index]] <- state / modulus
+    }
+    out
+}
+
+# Map a mixed precipitation distribution: values at or below the trace
+# threshold are randomized uniformly across the historical dry-day mass, while
+# positive amounts use empirical conditional CDFs on both sides of the hurdle.
+qm__map_precipitation <- function(
+    historical,
+    observed,
+    future,
+    uniform,
+    dry_threshold
+) {
+    historical_dry <- historical <= dry_threshold
+    observed_dry <- observed <= dry_threshold
+    future_dry <- future <= dry_threshold
+    historical_dry_probability <- mean(historical_dry)
+    observed_dry_probability <- mean(observed_dry)
+    historical_positive <- historical[!historical_dry]
+    observed_positive <- observed[!observed_dry]
+
+    probability <- numeric(length(future))
+    probability[future_dry] <- (
+        uniform[future_dry] * historical_dry_probability
+    )
+    positive <- !future_dry
+    lower_tail <- upper_tail <- rep.int(FALSE, length(future))
+    tied_historical <- 0L
+    if (any(positive)) {
+        if (!length(historical_positive)) {
+            cli::cli_abort(
+                "A precipitation window has positive future values but no positive historical-model calibration values."
+            )
+        }
+        positive_cdf <- qm__empirical_cdf(
+            historical_positive,
+            future[positive]
+        )
+        probability[positive] <- historical_dry_probability +
+            (1 - historical_dry_probability) *
+                positive_cdf$probability
+        lower_tail[positive] <- positive_cdf$lower_tail
+        upper_tail[positive] <- positive_cdf$upper_tail
+        tied_historical <- positive_cdf$tied_sample_values
+    }
+
+    mapped <- numeric(length(future))
+    output_positive <- probability > observed_dry_probability
+    if (any(output_positive)) {
+        if (!length(observed_positive)) {
+            cli::cli_abort(
+                "A precipitation window requires positive output amounts but has no positive observed-reference calibration values."
+            )
+        }
+        conditional_probability <- (
+            probability[output_positive] - observed_dry_probability
+        ) / (1 - observed_dry_probability)
+        mapped[output_positive] <- qm__inverse_cdf(
+            observed_positive,
+            conditional_probability
+        )
+    }
+    list(
+        value = mapped,
+        probability = probability,
+        lower_tail = lower_tail,
+        upper_tail = upper_tail,
+        tied_historical_values = tied_historical,
+        tied_observed_values = length(observed_positive) -
+            length(unique(observed_positive)),
+        historical_dry_probability = historical_dry_probability,
+        observed_dry_probability = observed_dry_probability,
+        randomized_dry_values = sum(future_dry)
+    )
+}
+
+# Summarize sample coverage and mapping behavior without storing one additional
+# provenance row for every day in a multi-decadal future series.
+qm__diagnostics <- function(
+    observed_samples,
+    historical_samples,
+    probability,
+    lower_tail,
+    upper_tail,
+    tied_historical,
+    tied_observed,
+    clipped,
+    precipitation = NULL
+) {
+    diagnostics <- list(
+        observed_window_samples = c(
+            minimum = min(observed_samples),
+            median = stats::median(observed_samples),
+            maximum = max(observed_samples)
+        ),
+        historical_window_samples = c(
+            minimum = min(historical_samples),
+            median = stats::median(historical_samples),
+            maximum = max(historical_samples)
+        ),
+        mapped_probability_range = range(probability),
+        lower_tail_values = sum(lower_tail),
+        upper_tail_values = sum(upper_tail),
+        tied_historical_values = sum(tied_historical),
+        tied_observed_values = sum(tied_observed),
+        clipped_values = clipped
+    )
+    if (!is.null(precipitation)) {
+        diagnostics$precipitation <- precipitation
+    }
+    diagnostics
+}
+
+# Apply the calendar-neutral circular window independently at each future day,
+# retaining the future series as the output backbone.
+qm__adjust_values <- function(series, resolved, key, variable) {
+    observed <- series$observed_reference
+    historical <- series$model_historical
+    future <- series$model_future
+    n_future <- nrow(future)
+    observed_samples <- historical_samples <- integer(n_future)
+    probability <- adjusted <- numeric(n_future)
+    lower_tail <- upper_tail <- logical(n_future)
+    tied_historical <- tied_observed <- integer(n_future)
+    effective_seed <- qm__group_seed(
+        resolved$random_seed,
+        key,
+        variable
+    )
+    uniform <- qm__uniform(n_future, effective_seed)
+    precipitation_diagnostics <- if (identical(
+        resolved$distribution_model,
+        "precipitation_hurdle"
+    )) {
+        list(
+            historical_dry_probability = numeric(n_future),
+            observed_dry_probability = numeric(n_future),
+            randomized_dry_values = 0L,
+            input_dry_values = sum(
+                future[["value"]] <= resolved$dry_threshold
+            )
+        )
+    } else {
+        NULL
+    }
+
+    for (index in seq_len(n_future)) {
+        center <- future[["annual_phase"]][[index]]
+        observed_window <- daily__phase_window(
+            observed[["annual_phase"]],
+            center,
+            resolved$seasonal_window_days,
+            resolved$target_year_days
+        )
+        historical_window <- daily__phase_window(
+            historical[["annual_phase"]],
+            center,
+            resolved$seasonal_window_days,
+            resolved$target_year_days
+        )
+        observed_values <- observed[["value"]][observed_window]
+        historical_values <- historical[["value"]][historical_window]
+        observed_samples[[index]] <- length(observed_values)
+        historical_samples[[index]] <- length(historical_values)
+        if (observed_samples[[index]] < resolved$min_samples ||
+            historical_samples[[index]] < resolved$min_samples) {
+            cli::cli_abort(
+                "Quantile Mapping future row {index} has fewer than {resolved$min_samples} observed or historical calibration values in its circular window."
+            )
+        }
+
+        mapped <- if (identical(
+            resolved$distribution_model,
+            "precipitation_hurdle"
+        )) {
+            qm__map_precipitation(
+                historical_values,
+                observed_values,
+                future[["value"]][[index]],
+                uniform[[index]],
+                resolved$dry_threshold
+            )
+        } else {
+            qm__map_continuous(
+                historical_values,
+                observed_values,
+                future[["value"]][[index]]
+            )
+        }
+        adjusted[[index]] <- mapped$value
+        probability[[index]] <- mapped$probability
+        lower_tail[[index]] <- mapped$lower_tail
+        upper_tail[[index]] <- mapped$upper_tail
+        tied_historical[[index]] <- mapped$tied_historical_values
+        tied_observed[[index]] <- mapped$tied_observed_values
+        if (!is.null(precipitation_diagnostics)) {
+            precipitation_diagnostics$historical_dry_probability[[index]] <-
+                mapped$historical_dry_probability
+            precipitation_diagnostics$observed_dry_probability[[index]] <-
+                mapped$observed_dry_probability
+            precipitation_diagnostics$randomized_dry_values <-
+                precipitation_diagnostics$randomized_dry_values +
+                    mapped$randomized_dry_values
+        }
+    }
+
+    bounded <- pmin(
+        pmax(adjusted, resolved$bounds[[1L]]),
+        resolved$bounds[[2L]]
+    )
+    clipped <- sum(bounded != adjusted)
+    if (!is.null(precipitation_diagnostics)) {
+        precipitation_diagnostics$historical_dry_probability_range <- range(
+            precipitation_diagnostics$historical_dry_probability
+        )
+        precipitation_diagnostics$observed_dry_probability_range <- range(
+            precipitation_diagnostics$observed_dry_probability
+        )
+        precipitation_diagnostics$historical_dry_probability <- NULL
+        precipitation_diagnostics$observed_dry_probability <- NULL
+        precipitation_diagnostics$output_dry_values <- sum(
+            bounded <= resolved$dry_threshold
+        )
+        precipitation_diagnostics$dry_threshold <- resolved$dry_threshold
+        precipitation_diagnostics$random_seed <- resolved$random_seed
+        precipitation_diagnostics$effective_seed <- effective_seed
+        precipitation_diagnostics$random_generator <-
+            "park_miller_16807"
+    }
+    list(
+        value = bounded,
+        diagnostics = qm__diagnostics(
+            observed_samples,
+            historical_samples,
+            probability,
+            lower_tail,
+            upper_tail,
+            tied_historical,
+            tied_observed,
+            clipped,
+            precipitation_diagnostics
+        )
+    )
+}
+
+# Execute empirical Quantile Mapping for one aligned univariate signal group
+# and return the common DailyAdjustedSeries contract.
+qm__apply_group <- function(inputs, settings, key) {
+    resolved <- qm__settings(settings)
+    variable <- names(settings)[[1L]]
+    series <- qm__inputs(
+        inputs,
+        variable,
+        resolved$distribution_model
+    )
+    mapped <- qm__adjust_values(series, resolved, key, variable)
+    future <- series$model_future
+    future[["value"]] <- mapped$value
+
+    bias__daily_adjusted_series(
+        future,
+        output_role = "model_future",
+        transformation = "quantile_mapping",
+        settings = resolved,
+        provenance = list(
+            method = "quantile_mapping",
+            references = QM_REFERENCES,
+            group_key = key,
+            output_backbone = "model_future",
+            diagnostics = mapped$diagnostics
+        )
+    )
+}
+
+# Return one explicit diagnostic string when Quantile Mapping violates the
+# package-native future-model output contract.
+qm__validate_result <- function(value, inputs, key) {
+    if (!S7::S7_inherits(value, DailyAdjustedSeries)) {
+        return(
+            "Quantile Mapping must return a DailyAdjustedSeries object."
+        )
+    }
+    if (!identical(value@output_role, "model_future")) {
+        return(
+            "Quantile Mapping output must retain the `model_future` role."
+        )
+    }
+    TRUE
+}
+
+# Construct the reusable Quantile Mapping signal with three explicit daily
+# input roles and method-evidence-aware variable alternatives.
+qm__component <- function() {
+    alternatives <- as.list(c(
+        QM_PUBLISHED_VARIABLES,
+        QM_EXPERIMENTAL_VARIABLES
+    ))
+    roles <- c(
+        "observed_reference",
+        "model_historical",
+        "model_future"
+    )
+    requirements <- lapply(roles, function(role) {
+        component__input_requirement(
+            role,
+            representations = "series",
+            frequencies = "day",
+            variable_sets = alternatives
+        )
+    })
+    names(requirements) <- roles
+    signal__component(
+        name = "quantile_mapping_daily",
+        label = "Daily Quantile Mapping",
+        required_inputs = requirements,
+        input_kinds = "calendar_indexed_daily_series",
+        output_kinds = "daily_adjusted_series",
+        scopes = "univariate",
+        stochastic = TRUE,
+        profiles = qm__profiles(),
+        apply_group = qm__apply_group,
+        operations = list(validate_result = qm__validate_result),
+        metadata = list(
+            method_family = "bias_adjustment",
+            output_contract = "daily_adjusted_series",
+            references = QM_REFERENCES,
+            stochastic_operation = "precipitation_dry_day_randomization",
+            empirical_conventions = list(
+                cdf = "linear_interpolation",
+                inverse_cdf = "linear_type_7",
+                ties = "average_rank",
+                tails = "clamp"
+            )
+        )
+    )
+}
+
+# Register Quantile Mapping once so package load and repeated tests share one
+# discoverable process-local component.
+qm__register_component <- function() {
+    component <- qm__component()
+    key <- component__registry_key(component@stage, component@name)
+    if (!exists(
+        key,
+        envir = WEATHER_COMPONENT_REGISTRY,
+        inherits = FALSE
+    )) {
+        component__register(component)
+    }
+    invisible(NULL)
+}

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -15,6 +15,7 @@
     # pipelines can resolve them without constructing a complete EPW recipe.
     bias__register_linear_scaling_component()
     bias__register_delta_change_component()
+    qm__register_component()
 
     # set package options
     .opts <- list(

--- a/tests/testthat/test-quantile-mapping.R
+++ b/tests/testthat/test-quantile-mapping.R
@@ -1,0 +1,483 @@
+# Build one calendar-native daily series from consecutive CF-calendar days so
+# Quantile Mapping tests never rely on Gregorian Date coercion.
+qm_test__series <- function(
+    variable_id,
+    year,
+    values,
+    calendar = "noleap",
+    units = if (identical(variable_id, "pr")) {
+        "kg m-2 s-1"
+    } else if (identical(variable_id, "hurs")) {
+        "%"
+    } else {
+        "K"
+    }
+) {
+    origin <- data.frame(
+        year = as.integer(year),
+        month = 1L,
+        day = 1L
+    )
+    fields <- cf_time_offset2date(
+        seq.int(0L, length(values) - 1L),
+        origin,
+        calendar
+    )
+    fields$hour <- 12L
+    fields$minute <- 0L
+    fields$second <- 0
+    data.frame(
+        variable_id = rep.int(variable_id, length(values)),
+        value = as.numeric(values),
+        units = rep.int(units, length(values)),
+        frequency = rep.int("day", length(values)),
+        cf_time__coordinates(fields, calendar),
+        stringsAsFactors = FALSE
+    )
+}
+
+# Construct role metadata and the aligned group from the same three canonical
+# tables, matching the package's standalone signal execution boundary.
+qm_test__execution_inputs <- function(
+    observed,
+    historical,
+    future,
+    key = list(site = "A")
+) {
+    list(
+        inputs = weather__new_inputs(
+            observed_reference = weather__new_input(
+                "observed_reference",
+                observed
+            ),
+            model_historical = weather__new_input(
+                "model_historical",
+                historical
+            ),
+            model_future = weather__new_input(
+                "model_future",
+                future
+            )
+        ),
+        group = signal__group(
+            key = key,
+            inputs = list(
+                observed_reference = observed,
+                model_historical = historical,
+                model_future = future
+            ),
+            variables = unique(future$variable_id)
+        )
+    )
+}
+
+# Execute one variable through the common signal lifecycle while replacing the
+# default seasonal window with a full-cycle window for compact test fixtures.
+qm_test__execute <- function(
+    variable,
+    observed,
+    historical,
+    future,
+    overrides = list(),
+    key = list(site = "A"),
+    warn_experimental = FALSE
+) {
+    boundary <- qm_test__execution_inputs(
+        observed,
+        historical,
+        future,
+        key
+    )
+    settings <- utils::modifyList(
+        list(
+            seasonal_window_days = 365L,
+            target_year_days = 365L,
+            min_samples = 2L
+        ),
+        overrides
+    )
+    component__execute(
+        qm__component(),
+        "apply",
+        inputs = boundary$inputs,
+        groups = list(boundary$group),
+        overrides = stats::setNames(list(settings), variable),
+        warn_experimental = warn_experimental
+    )
+}
+
+# Retrieve one default settings record without relying on profile construction
+# order in tests that call the single-group kernel directly.
+qm_test__settings <- function(variable) {
+    profiles <- qm__profiles()
+    index <- which(vapply(
+        profiles,
+        function(profile) identical(profile@variable_id, variable),
+        logical(1L)
+    ))
+    profiles[[index]]@settings
+}
+
+test_that("empirical CDF conventions make ties and tails explicit", {
+    anchors <- qm__cdf_anchors(c(1, 1, 2, 4))
+
+    expect_equal(anchors$value, c(1, 2, 4))
+    expect_equal(anchors$probability, c(1 / 6, 2 / 3, 1))
+
+    mapped <- qm__map_continuous(
+        historical = c(1, 1, 2, 4),
+        observed = c(10, 20, 30, 40),
+        future = c(-1, 1, 2, 4, 6)
+    )
+    expect_equal(mapped$value, c(10, 15, 30, 40, 40))
+    expect_identical(
+        mapped$lower_tail,
+        c(TRUE, FALSE, FALSE, FALSE, FALSE)
+    )
+    expect_identical(
+        mapped$upper_tail,
+        c(FALSE, FALSE, FALSE, FALSE, TRUE)
+    )
+    expect_identical(mapped$tied_historical_values, 1L)
+    expect_identical(mapped$tied_observed_values, 0L)
+})
+
+test_that("Quantile Mapping returns a typed future-backbone daily series", {
+    observed <- qm_test__series(
+        "tas",
+        2001L,
+        c(10, 20, 30, 40)
+    )
+    historical <- qm_test__series(
+        "tas",
+        1991L,
+        c(0, 10, 20, 30)
+    )
+    future <- qm_test__series(
+        "tas",
+        2061L,
+        c(5, 15, -10, 40)
+    )
+
+    execution <- qm_test__execute(
+        "tas",
+        observed,
+        historical,
+        future
+    )
+    adjusted <- execution@values[[1L]]
+
+    expect_true(S7::S7_inherits(execution, SignalExecutionResult))
+    expect_true(S7::S7_inherits(adjusted, DailyAdjustedSeries))
+    expect_equal(adjusted@data$value, c(15, 25, 10, 40))
+    expect_identical(
+        adjusted@data[BIAS_DAILY_SERIES_COLUMNS[-2L]],
+        future[BIAS_DAILY_SERIES_COLUMNS[-2L]]
+    )
+    expect_identical(adjusted@output_role, "model_future")
+    expect_identical(adjusted@transformation, "quantile_mapping")
+    expect_identical(adjusted@provenance$output_backbone, "model_future")
+    expect_identical(
+        adjusted@provenance$diagnostics$lower_tail_values,
+        1L
+    )
+    expect_identical(
+        adjusted@provenance$diagnostics$upper_tail_values,
+        1L
+    )
+    expect_identical(execution@diagnostics$status, "ok")
+})
+
+test_that("Quantile Mapping preserves identity across native CF calendars", {
+    calendars <- c("360_day", "noleap", "all_leap")
+    values <- c(2, 2, 4, 7, 9)
+
+    for (calendar in calendars) {
+        observed <- qm_test__series(
+            "tas",
+            2000L,
+            values,
+            calendar
+        )
+        historical <- qm_test__series(
+            "tas",
+            1990L,
+            values,
+            calendar
+        )
+        future <- qm_test__series(
+            "tas",
+            2060L,
+            values,
+            calendar
+        )
+        execution <- qm_test__execute(
+            "tas",
+            observed,
+            historical,
+            future
+        )
+
+        expect_equal(
+            execution@values[[1L]]@data$value,
+            values,
+            info = calendar
+        )
+        expect_identical(
+            execution@values[[1L]]@data$cf_calendar,
+            rep.int(calendar, length(values)),
+            info = calendar
+        )
+    }
+})
+
+test_that("circular windows bridge the annual-phase boundary", {
+    observed <- qm_test__series(
+        "tas",
+        2001L,
+        seq_len(365L) + 10
+    )
+    historical <- qm_test__series(
+        "tas",
+        1991L,
+        seq_len(365L)
+    )
+    future <- qm_test__series(
+        "tas",
+        2061L,
+        seq_len(365L)
+    )
+    boundary <- qm_test__execution_inputs(
+        observed,
+        historical,
+        future
+    )
+    settings <- qm_test__settings("tas")
+    settings$seasonal_window_days <- 3L
+    settings$min_samples <- 3L
+
+    adjusted <- component__execute(
+        qm__component(),
+        "apply_group",
+        inputs = boundary$group@inputs,
+        settings = list(tas = settings),
+        key = boundary$group@key
+    )
+
+    expect_equal(adjusted@data$value[c(1L, 365L)], c(11, 375))
+    expect_equal(
+        adjusted@provenance$diagnostics$observed_window_samples,
+        c(minimum = 3, median = 3, maximum = 3)
+    )
+})
+
+test_that("bounds clip mapped values and are retained in diagnostics", {
+    observed <- qm_test__series("hurs", 2001L, c(-10, 25, 75, 120))
+    historical <- qm_test__series("hurs", 1991L, c(0, 1, 2, 3))
+    future <- qm_test__series("hurs", 2061L, c(0, 1, 2, 3))
+
+    execution <- qm_test__execute(
+        "hurs",
+        observed,
+        historical,
+        future
+    )
+    adjusted <- execution@values[[1L]]
+
+    expect_equal(adjusted@data$value, c(0, 25, 75, 100))
+    expect_identical(
+        adjusted@provenance$diagnostics$clipped_values,
+        2L
+    )
+    expect_identical(adjusted@settings$bounds, c(0, 100))
+})
+
+test_that("precipitation hurdle mapping has deterministic dry-day control", {
+    count <- 40L
+    observed <- qm_test__series(
+        "pr",
+        2001L,
+        c(rep.int(0, 8L), seq_len(32L))
+    )
+    historical <- qm_test__series(
+        "pr",
+        1991L,
+        c(rep.int(0, 20L), seq_len(20L))
+    )
+    future <- qm_test__series(
+        "pr",
+        2061L,
+        rep.int(0, count)
+    )
+    set.seed(2026)
+    seed_before <- .Random.seed
+
+    first <- qm_test__execute(
+        "pr",
+        observed,
+        historical,
+        future,
+        overrides = list(dry_threshold = 0, random_seed = 99L)
+    )
+    second <- qm_test__execute(
+        "pr",
+        observed,
+        historical,
+        future,
+        overrides = list(dry_threshold = 0, random_seed = 99L)
+    )
+    different <- qm_test__execute(
+        "pr",
+        observed,
+        historical,
+        future,
+        overrides = list(dry_threshold = 0, random_seed = 100L)
+    )
+
+    first_values <- first@values[[1L]]@data$value
+    expect_identical(.Random.seed, seed_before)
+    expect_identical(first_values, second@values[[1L]]@data$value)
+    expect_false(identical(
+        first_values,
+        different@values[[1L]]@data$value
+    ))
+    expect_true(any(first_values == 0))
+    expect_true(any(first_values > 0))
+    precipitation <- (
+        first@values[[1L]]@provenance$diagnostics$precipitation
+    )
+    expect_identical(precipitation$input_dry_values, count)
+    expect_identical(precipitation$randomized_dry_values, count)
+    expect_true(precipitation$output_dry_values < count)
+    expect_identical(precipitation$random_seed, 99L)
+    expect_identical(
+        precipitation$random_generator,
+        "park_miller_16807"
+    )
+})
+
+test_that("Quantile Mapping rejects unsupported or insufficient inputs", {
+    observed <- qm_test__series("tas", 2001L, c(1, 2, 3, 4))
+    historical <- qm_test__series("tas", 1991L, c(1, 2, 3, 4))
+    future <- qm_test__series("tas", 2061L, c(1, 2, 3, 4))
+    boundary <- qm_test__execution_inputs(
+        observed,
+        historical,
+        future
+    )
+    settings <- qm_test__settings("tas")
+
+    unsupported <- settings
+    unsupported$cdf_method <- "step_function"
+    expect_error(
+        component__execute(
+            qm__component(),
+            "apply_group",
+            inputs = boundary$group@inputs,
+            settings = list(tas = unsupported),
+            key = list()
+        ),
+        "requires linear empirical CDF"
+    )
+
+    expect_error(
+        component__execute(
+            qm__component(),
+            "apply_group",
+            inputs = boundary$group@inputs,
+            settings = list(tas = settings),
+            key = list()
+        ),
+        "fewer than 10"
+    )
+
+    incompatible_units <- boundary$group@inputs
+    incompatible_units$model_future$units <- "degC"
+    expect_error(
+        component__execute(
+            qm__component(),
+            "apply_group",
+            inputs = incompatible_units,
+            settings = list(tas = utils::modifyList(
+                settings,
+                list(
+                    seasonal_window_days = 365L,
+                    min_samples = 2L
+                )
+            )),
+            key = list()
+        ),
+        "identical units"
+    )
+
+    precipitation <- lapply(
+        boundary$group@inputs,
+        function(data) {
+            data$variable_id <- "pr"
+            data$units <- "kg m-2 s-1"
+            data
+        }
+    )
+    precipitation$model_future$value[[1L]] <- -1
+    pr_settings <- qm_test__settings("pr")
+    expect_error(
+        component__execute(
+            qm__component(),
+            "apply_group",
+            inputs = precipitation,
+            settings = list(pr = utils::modifyList(
+                pr_settings,
+                list(
+                    seasonal_window_days = 365L,
+                    min_samples = 2L
+                )
+            )),
+            key = list()
+        ),
+        "non-negative"
+    )
+})
+
+test_that("Quantile Mapping profiles retain evidence and registration", {
+    qm__register_component()
+    component <- component__get("signal", "quantile_mapping_daily")
+    profiles <- component@metadata$signal_profiles
+
+    expect_true(S7::S7_inherits(component, WeatherComponentSpec))
+    expect_identical(component@stage, "signal")
+    expect_identical(
+        component@input_kinds,
+        "calendar_indexed_daily_series"
+    )
+    expect_identical(component@output_kinds, "daily_adjusted_series")
+    expect_identical(component@scopes, "univariate")
+    expect_true(component@stochastic)
+    expect_identical(
+        sort(names(profiles)),
+        sort(c(QM_PUBLISHED_VARIABLES, QM_EXPERIMENTAL_VARIABLES))
+    )
+    expect_identical(profiles$tas$evidence, "published")
+    expect_identical(profiles$pr$evidence, "published")
+    expect_identical(profiles$hurs$evidence, "experimental")
+    expect_identical(
+        profiles$hurs$metadata$default_source,
+        "package_implementation"
+    )
+
+    calendar <- component__spec(
+        name = "qm_calendar_test",
+        stage = "calendar",
+        input_kinds = "preprocessed_daily_series",
+        output_kinds = "calendar_indexed_daily_series",
+        operations = list(apply = identity)
+    )
+    sequence <- component__spec(
+        name = "qm_sequence_test",
+        stage = "sequence",
+        input_kinds = "daily_adjusted_series",
+        output_kinds = "weather_sequence",
+        operations = list(generate = identity)
+    )
+    expect_true(component__compatible(calendar, component))
+    expect_true(component__compatible(component, sequence))
+})

--- a/vignettes-raw/articles/epw-morpher.Rmd
+++ b/vignettes-raw/articles/epw-morpher.Rmd
@@ -500,6 +500,24 @@ interpretation. Group failures either abort or return an explicit diagnostic
 with a `NULL` result; they are never silently converted to missing numeric
 values.
 
+Three package-native standalone signals currently use this contract:
+
+| Registry name | Correction | Output backbone | Variable-profile evidence |
+|:--------------|:-----------|:----------------|:--------------------------|
+| `linear_scaling_daily` | Monthly observed-minus-model mean bias, additive for temperature and multiplicative for precipitation | `model_future` | Published defaults for `tas`, `tasmin`, `tasmax`, and `pr` |
+| `delta_change_daily` | Monthly historical-to-future mean change, additive for temperature and multiplicative for precipitation | `observed_reference` | Published defaults for `tas`, `tasmin`, `tasmax`, and `pr` |
+| `quantile_mapping_daily` | \(F^{-1}_{obs}(F_{hist}(x_{future}))\) in calendar-neutral circular daily windows | `model_future` | Published method-variable profiles for `tas` and `pr`; implementation-selected defaults for `hurs`, `psl`, `rlds`, `sfcWind`, `tasmin`, and `tasmax` remain experimental |
+
+`quantile_mapping_daily` uses linear empirical-CDF interpolation with
+average-rank ties, type-7 inverse quantiles, and endpoint clamping. Its default
+31-day window is selected by canonical annual phase, so 360-, 365-, and
+366-day source calendars are not paired by nominal date. Precipitation uses a
+mixed dry-day/positive-amount hurdle distribution rather than the continuous
+mapping unchanged. Dry-day randomization is controlled by a recorded seed and
+a fixed method-local generator, leaving R's global random-number state
+untouched. Bounds, sample coverage, tail use, clipping, dry-day frequencies,
+and the resolved stochastic settings are retained in result provenance.
+
 The runner returns `epw_morph_result()` with complete hourly EPW weather data.
 `EpwMorpher$run()` writes that data as Parquet and adds the case metadata
 columns needed by `write_epw()`.

--- a/vignettes-raw/precompiled-checksums.csv
+++ b/vignettes-raw/precompiled-checksums.csv
@@ -1,7 +1,7 @@
 "source","output","source_md5","output_md5"
 "vignettes-raw/articles/cli-esgf-store.Rmd","vignettes/articles/cli-esgf-store.Rmd","cac788f79010ad56496939cdde3580bb","e58e5cafa0d3b2218081c25a1098273f"
 "vignettes-raw/articles/downloader.Rmd","vignettes/articles/downloader.Rmd","9668ccb5b39f0ca2f49e146a1a100a7c","4b67e4a9ddaecfe7ce3ac268936e2a2d"
-"vignettes-raw/articles/epw-morpher.Rmd","vignettes/articles/epw-morpher.Rmd","aa65ab8269b3751c6bbd856e0e50499c","b216ea1074066ce0379ca485cb1d066e"
+"vignettes-raw/articles/epw-morpher.Rmd","vignettes/articles/epw-morpher.Rmd","1b431a061f1b698766fbe38b327b24e8","6c39d0c446cad4264771bab82dfc5b2a"
 "vignettes-raw/articles/esg-dictionaries.Rmd","vignettes/articles/esg-dictionaries.Rmd","94eb2513975549a6765afa221a2e10c1","290348d35a29e925f1b3732586e54cfb"
 "vignettes-raw/articles/esg-store.Rmd","vignettes/articles/esg-store.Rmd","c2d810261308c837b84c803a0d2632c5","bb73ddac53598a36b049797782ce3c02"
 "vignettes-raw/articles/esgf-query-results.Rmd","vignettes/articles/esgf-query-results.Rmd","9cb7e909ecc499eba79e4295857101d1","20854ab68644b18addeefcef1baafcfa"

--- a/vignettes/articles/epw-morpher.Rmd
+++ b/vignettes/articles/epw-morpher.Rmd
@@ -508,6 +508,24 @@ interpretation. Group failures either abort or return an explicit diagnostic
 with a `NULL` result; they are never silently converted to missing numeric
 values.
 
+Three package-native standalone signals currently use this contract:
+
+| Registry name | Correction | Output backbone | Variable-profile evidence |
+|:--------------|:-----------|:----------------|:--------------------------|
+| `linear_scaling_daily` | Monthly observed-minus-model mean bias, additive for temperature and multiplicative for precipitation | `model_future` | Published defaults for `tas`, `tasmin`, `tasmax`, and `pr` |
+| `delta_change_daily` | Monthly historical-to-future mean change, additive for temperature and multiplicative for precipitation | `observed_reference` | Published defaults for `tas`, `tasmin`, `tasmax`, and `pr` |
+| `quantile_mapping_daily` | \(F^{-1}_{obs}(F_{hist}(x_{future}))\) in calendar-neutral circular daily windows | `model_future` | Published method-variable profiles for `tas` and `pr`; implementation-selected defaults for `hurs`, `psl`, `rlds`, `sfcWind`, `tasmin`, and `tasmax` remain experimental |
+
+`quantile_mapping_daily` uses linear empirical-CDF interpolation with
+average-rank ties, type-7 inverse quantiles, and endpoint clamping. Its default
+31-day window is selected by canonical annual phase, so 360-, 365-, and
+366-day source calendars are not paired by nominal date. Precipitation uses a
+mixed dry-day/positive-amount hurdle distribution rather than the continuous
+mapping unchanged. Dry-day randomization is controlled by a recorded seed and
+a fixed method-local generator, leaving R's global random-number state
+untouched. Bounds, sample coverage, tail use, clipping, dry-day frequencies,
+and the resolved stochastic settings are retained in result provenance.
+
 The runner returns `epw_morph_result()` with complete hourly EPW weather data.
 `EpwMorpher$run()` writes that data as Parquet and adds the case metadata
 columns needed by `write_epw()`.


### PR DESCRIPTION
## Summary

- Closes #166.
- Adds a package-native daily Quantile Mapping signal through the existing component and adjusted-series contracts.

## Changes

- Implement nonparametric Quantile Mapping with calendar-neutral circular windows, explicit empirical-CDF conventions, bounds, provenance, and future-series backbone preservation.
- Handle precipitation with a mixed dry-day and positive-amount hurdle distribution using deterministic, group-specific randomization that does not modify R's global RNG state.
- Register evidence-aware variable profiles, label implementation-selected defaults as experimental, and document the standalone signal alongside Linear Scaling and Delta Change.
- Cover known mappings, identity, ties, tails, CF calendars, circular boundaries, bounds, precipitation occurrence, input failures, registration, and pipeline compatibility.
