### PR TITLE
feat: add daily quantile delta mapping

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -90,6 +90,8 @@ Collate:
     'gh.R'
     'import-standalone-schema.R'
     'netcdf.R'
+    'quantile-distribution.R'
+    'quantile-delta-mapping.R'
     'quantile-mapping.R'
     'solr-date.R'
     'query-param.R'

--- a/NEWS.md
+++ b/NEWS.md
@@ -46,6 +46,17 @@
 
 ## New features
 
+* Added the native R `quantile_delta_mapping_daily` signal component. It uses
+  each projected value's time-dependent future-model quantile to transfer the
+  corresponding historical-to-future model change onto the observed-reference
+  quantile: absolutely for interval variables and relatively for precipitation.
+  Calendar-neutral 91-day seasonal windows and centered 31-year future windows
+  make both sources of variation explicit. Published precipitation censoring
+  uses deterministic role-specific randomization below 0.05 mm/day without
+  changing R's global RNG state. The future-model sequence, resolved settings,
+  window coverage, quantile changes, bounds, censoring, and provenance are
+  retained in the `DailyAdjustedSeries` result (#169).
+
 * Added the native R `quantile_mapping_daily` signal component. It maps
   future-model daily values through historical-model and observed-reference
   empirical distributions in calendar-neutral circular windows, using

--- a/R/quantile-delta-mapping.R
+++ b/R/quantile-delta-mapping.R
@@ -1,0 +1,684 @@
+#' @include bias-adjustment.R daily-climatology.R quantile-distribution.R
+NULL
+
+# Quantile Delta Mapping follows the original precipitation formulation and
+# its appendix describing the additive form for interval variables.
+QDM_REFERENCES <- c(
+    "https://doi.org/10.1175/JCLI-D-14-00754.1"
+)
+
+# Cannon et al. treat precipitation below 0.05 mm/day as censored dry values.
+# CMIP6 daily precipitation flux uses the equivalent kg m-2 s-1 value.
+QDM_PR_DRY_THRESHOLD <- 0.05 / 86400
+
+# The publication directly supports precipitation and the additive
+# interval-variable form exemplified by temperature. Other variable defaults
+# are retained as explicit package experiments for controlled comparisons.
+QDM_PUBLISHED_VARIABLES <- c("pr", "tas")
+QDM_EXPERIMENTAL_VARIABLES <- c(
+    "hurs",
+    "psl",
+    "rlds",
+    "sfcWind",
+    "tasmin",
+    "tasmax"
+)
+
+# Construct one complete QDM settings record. The 91-day seasonal window
+# represents the published three-month pool, while the odd 31-year future
+# window gives a symmetric discrete-year implementation of its 30-year window.
+qdm__default_settings <- function(
+    bounds,
+    trend_preservation = c("absolute", "relative"),
+    distribution_model = c("continuous", "precipitation_censored"),
+    dry_threshold = 0
+) {
+    trend_preservation <- match.arg(trend_preservation)
+    distribution_model <- match.arg(distribution_model)
+    list(
+        mapping_type = "nonparametric",
+        trend_preservation = trend_preservation,
+        seasonal_window_days = 91L,
+        future_window_years = 31L,
+        target_year_days = 365L,
+        min_samples = 10L,
+        cdf_method = "linear_interpolation",
+        inverse_cdf_method = "linear_type_7",
+        tie_method = "average_rank",
+        tail_policy = "future_window_support",
+        bounds = bounds,
+        distribution_model = distribution_model,
+        dry_threshold = dry_threshold,
+        zero_denominator_policy = "error",
+        random_seed = 1L
+    )
+}
+
+# Build method-evidence-aware variable profiles without attributing
+# implementation-selected transformations to the QDM publication.
+qdm__profiles <- function() {
+    settings <- list(
+        pr = qdm__default_settings(
+            c(0, Inf),
+            "relative",
+            "precipitation_censored",
+            QDM_PR_DRY_THRESHOLD
+        ),
+        tas = qdm__default_settings(c(-Inf, Inf), "absolute"),
+        hurs = qdm__default_settings(c(0, 100), "absolute"),
+        psl = qdm__default_settings(c(0, Inf), "absolute"),
+        rlds = qdm__default_settings(c(0, Inf), "absolute"),
+        sfcWind = qdm__default_settings(c(0, Inf), "absolute"),
+        tasmin = qdm__default_settings(c(-Inf, Inf), "absolute"),
+        tasmax = qdm__default_settings(c(-Inf, Inf), "absolute")
+    )
+    variables <- c(QDM_PUBLISHED_VARIABLES, QDM_EXPERIMENTAL_VARIABLES)
+    lapply(variables, function(variable) {
+        published <- variable %in% QDM_PUBLISHED_VARIABLES
+        signal__variable_profile(
+            variable,
+            settings = settings[[variable]],
+            evidence = if (published) "published" else "experimental",
+            references = if (published) QDM_REFERENCES else character(),
+            metadata = list(
+                method = "quantile_delta_mapping",
+                output_role = "model_future",
+                default_source = if (published) {
+                    "method_literature"
+                } else {
+                    "package_implementation"
+                }
+            )
+        )
+    })
+}
+
+# Validate every QDM convention at the signal-kernel boundary so overrides
+# cannot silently change the published transfer semantics.
+qdm__settings <- function(settings) {
+    if (length(settings) != 1L ||
+        is.null(names(settings)) ||
+        !nzchar(names(settings)[[1L]]) ||
+        !is.list(settings[[1L]])) {
+        cli::cli_abort(
+            "Quantile Delta Mapping requires settings for exactly one variable."
+        )
+    }
+    resolved <- settings[[1L]]
+    expected <- c(
+        "mapping_type",
+        "trend_preservation",
+        "seasonal_window_days",
+        "future_window_years",
+        "target_year_days",
+        "min_samples",
+        "cdf_method",
+        "inverse_cdf_method",
+        "tie_method",
+        "tail_policy",
+        "bounds",
+        "distribution_model",
+        "dry_threshold",
+        "zero_denominator_policy",
+        "random_seed"
+    )
+    missing <- setdiff(expected, names(resolved))
+    unexpected <- setdiff(names(resolved), expected)
+    if (length(missing) || length(unexpected)) {
+        cli::cli_abort(c(
+            "Quantile Delta Mapping settings must use the complete supported schema.",
+            "x" = "Missing setting(s): {.val {missing}}.",
+            "x" = "Unexpected setting(s): {.val {unexpected}}."
+        ))
+    }
+    if (!identical(resolved$mapping_type, "nonparametric")) {
+        cli::cli_abort(
+            "Quantile Delta Mapping currently supports only nonparametric mapping."
+        )
+    }
+    checkmate::assert_choice(
+        resolved$trend_preservation,
+        c("absolute", "relative")
+    )
+    if (!identical(resolved$cdf_method, "linear_interpolation") ||
+        !identical(resolved$inverse_cdf_method, "linear_type_7") ||
+        !identical(resolved$tie_method, "average_rank") ||
+        !identical(resolved$tail_policy, "future_window_support")) {
+        cli::cli_abort(
+            "Quantile Delta Mapping currently requires linear empirical CDF interpolation, type-7 inverse quantiles, average-rank ties, and future-window endpoint support."
+        )
+    }
+    checkmate::assert_integerish(
+        resolved$seasonal_window_days,
+        lower = 1L,
+        len = 1L,
+        any.missing = FALSE
+    )
+    checkmate::assert_integerish(
+        resolved$future_window_years,
+        lower = 1L,
+        len = 1L,
+        any.missing = FALSE
+    )
+    checkmate::assert_integerish(
+        resolved$target_year_days,
+        lower = 3L,
+        len = 1L,
+        any.missing = FALSE
+    )
+    checkmate::assert_integerish(
+        resolved$min_samples,
+        lower = 2L,
+        len = 1L,
+        any.missing = FALSE
+    )
+    daily__window_spec(
+        as.integer(resolved$seasonal_window_days),
+        as.integer(resolved$target_year_days)
+    )
+    if (resolved$future_window_years %% 2L != 1L) {
+        cli::cli_abort(
+            "Quantile Delta Mapping requires an odd `future_window_years` for a symmetric centered window."
+        )
+    }
+    checkmate::assert_numeric(
+        resolved$bounds,
+        len = 2L,
+        any.missing = FALSE
+    )
+    if (resolved$bounds[[1L]] > resolved$bounds[[2L]]) {
+        cli::cli_abort(
+            "Quantile Delta Mapping bounds must be ordered from lower to upper."
+        )
+    }
+    checkmate::assert_choice(
+        resolved$distribution_model,
+        c("continuous", "precipitation_censored")
+    )
+    checkmate::assert_number(
+        resolved$dry_threshold,
+        lower = 0,
+        finite = TRUE
+    )
+    if (identical(
+        resolved$distribution_model,
+        "precipitation_censored"
+    ) && resolved$dry_threshold <= 0) {
+        cli::cli_abort(
+            "Censored-precipitation Quantile Delta Mapping requires a positive `dry_threshold`."
+        )
+    }
+    if (identical(
+        resolved$distribution_model,
+        "precipitation_censored"
+    ) && !identical(resolved$trend_preservation, "relative")) {
+        cli::cli_abort(
+            "Censored-precipitation Quantile Delta Mapping requires relative trend preservation."
+        )
+    }
+    if (!identical(resolved$zero_denominator_policy, "error")) {
+        cli::cli_abort(
+            "Quantile Delta Mapping currently requires `zero_denominator_policy = \"error\"`."
+        )
+    }
+    checkmate::assert_integerish(
+        resolved$random_seed,
+        lower = 0,
+        upper = .Machine$integer.max - 1L,
+        len = 1L,
+        any.missing = FALSE
+    )
+
+    resolved$seasonal_window_days <- as.integer(
+        resolved$seasonal_window_days
+    )
+    resolved$future_window_years <- as.integer(
+        resolved$future_window_years
+    )
+    resolved$target_year_days <- as.integer(resolved$target_year_days)
+    resolved$min_samples <- as.integer(resolved$min_samples)
+    resolved$random_seed <- as.integer(resolved$random_seed)
+    resolved
+}
+
+# Validate the three role-addressable daily inputs while preserving their
+# independent CF calendars and date coordinates.
+qdm__inputs <- function(inputs, variable, distribution_model) {
+    roles <- c(
+        "observed_reference",
+        "model_historical",
+        "model_future"
+    )
+    if (!identical(sort(names(inputs)), sort(roles))) {
+        cli::cli_abort(
+            "Quantile Delta Mapping requires observed, historical-model, and future-model role payloads."
+        )
+    }
+    series <- lapply(roles, function(role) {
+        bias__daily_table(inputs[[role]], role)
+    })
+    names(series) <- roles
+    for (role in roles) {
+        role_variables <- unique(series[[role]][["variable_id"]])
+        if (!identical(role_variables, variable)) {
+            cli::cli_abort(
+                "Quantile Delta Mapping role {.val {role}} must contain only variable {.val {variable}}."
+            )
+        }
+        if (length(unique(series[[role]][["cf_calendar"]])) != 1L) {
+            cli::cli_abort(
+                "Quantile Delta Mapping role {.val {role}} must contain one native calendar per signal group."
+            )
+        }
+    }
+    units <- vapply(
+        series,
+        function(data) unique(data[["units"]]),
+        character(1L)
+    )
+    if (length(unique(units)) != 1L) {
+        cli::cli_abort(
+            "Quantile Delta Mapping inputs for {.val {variable}} must use identical units."
+        )
+    }
+    if (identical(distribution_model, "precipitation_censored") &&
+        any(vapply(
+            series,
+            function(data) any(data[["value"]] < 0),
+            logical(1L)
+        ))) {
+        cli::cli_abort(
+            "Censored-precipitation Quantile Delta Mapping requires non-negative input values."
+        )
+    }
+    series
+}
+
+# Select a symmetric discrete-year window around one projected row. Seasonal
+# filtering is applied separately on the calendar-neutral annual phase.
+qdm__future_year_window <- function(year, center, width) {
+    half_width <- width %/% 2L
+    year >= center - half_width & year <= center + half_width
+}
+
+# Replace censored precipitation values with deterministic positive uniforms
+# below the trace threshold, following the published dry-day treatment.
+qdm__randomize_censored <- function(values, threshold, uniform) {
+    censored <- values <= threshold
+    randomized <- as.numeric(values)
+    randomized[censored] <- uniform[censored] * threshold
+    list(
+        value = randomized,
+        censored = censored,
+        randomized_values = sum(censored)
+    )
+}
+
+# Preprocess each role once so a source row receives one reproducible censored
+# value even when it contributes to several overlapping QDM windows.
+qdm__prepared_values <- function(series, resolved, key, variable) {
+    if (!identical(
+        resolved$distribution_model,
+        "precipitation_censored"
+    )) {
+        return(list(
+            values = lapply(series, `[[`, "value"),
+            precipitation = NULL
+        ))
+    }
+
+    values <- vector("list", length(series))
+    names(values) <- names(series)
+    randomized <- integer(length(series))
+    names(randomized) <- names(series)
+    seeds <- integer(length(series))
+    names(seeds) <- names(series)
+    for (role in names(series)) {
+        role_key <- c(key, list(input_role = role))
+        seeds[[role]] <- quantile__group_seed(
+            resolved$random_seed,
+            role_key,
+            variable
+        )
+        uniform <- quantile__uniform(nrow(series[[role]]), seeds[[role]])
+        prepared <- qdm__randomize_censored(
+            series[[role]][["value"]],
+            resolved$dry_threshold,
+            uniform
+        )
+        values[[role]] <- prepared$value
+        randomized[[role]] <- prepared$randomized_values
+    }
+    list(
+        values = values,
+        precipitation = list(
+            input_censored_values = randomized,
+            random_seed = resolved$random_seed,
+            effective_seeds = seeds,
+            random_generator = "park_miller_16807",
+            dry_threshold = resolved$dry_threshold
+        )
+    )
+}
+
+# Apply the Cannon et al. QDM equations at one future value. The future CDF
+# supplies p, then observed and historical quantiles at p define the absolute
+# delta or relative ratio transferred to the observed quantile.
+qdm__map_value <- function(
+    observed,
+    historical,
+    future_sample,
+    future_value,
+    trend_preservation
+) {
+    future_cdf <- quantile__empirical_cdf(
+        future_sample,
+        future_value
+    )
+    probability <- future_cdf$probability
+    historical_quantile <- quantile__inverse_cdf(
+        historical,
+        probability
+    )
+    observed_quantile <- quantile__inverse_cdf(
+        observed,
+        probability
+    )
+    if (identical(trend_preservation, "absolute")) {
+        change <- future_value - historical_quantile
+        adjusted <- observed_quantile + change
+    } else {
+        if (historical_quantile == 0) {
+            cli::cli_abort(
+                "Relative Quantile Delta Mapping encountered a zero historical-model quantile."
+            )
+        }
+        change <- future_value / historical_quantile
+        adjusted <- observed_quantile * change
+    }
+    list(
+        value = adjusted,
+        probability = probability,
+        change = change,
+        future_lower_tail = future_cdf$lower_tail,
+        future_upper_tail = future_cdf$upper_tail,
+        tied_observed_values = length(observed) -
+            length(unique(observed)),
+        tied_historical_values = length(historical) -
+            length(unique(historical)),
+        tied_future_values = future_cdf$tied_sample_values
+    )
+}
+
+# Summarize window coverage and transfer behavior without retaining one
+# provenance record for every adjusted day.
+qdm__diagnostics <- function(
+    observed_samples,
+    historical_samples,
+    future_samples,
+    future_year_counts,
+    probability,
+    change,
+    future_lower_tail,
+    future_upper_tail,
+    tied_observed,
+    tied_historical,
+    tied_future,
+    clipped,
+    precipitation
+) {
+    diagnostics <- list(
+        observed_window_samples = c(
+            minimum = min(observed_samples),
+            median = stats::median(observed_samples),
+            maximum = max(observed_samples)
+        ),
+        historical_window_samples = c(
+            minimum = min(historical_samples),
+            median = stats::median(historical_samples),
+            maximum = max(historical_samples)
+        ),
+        future_window_samples = c(
+            minimum = min(future_samples),
+            median = stats::median(future_samples),
+            maximum = max(future_samples)
+        ),
+        future_window_years = c(
+            minimum = min(future_year_counts),
+            median = stats::median(future_year_counts),
+            maximum = max(future_year_counts)
+        ),
+        mapped_probability_range = range(probability),
+        transferred_change_range = range(change),
+        future_lower_tail_values = sum(future_lower_tail),
+        future_upper_tail_values = sum(future_upper_tail),
+        tied_observed_values = sum(tied_observed),
+        tied_historical_values = sum(tied_historical),
+        tied_future_values = sum(tied_future),
+        zero_historical_quantiles = 0L,
+        clipped_values = clipped
+    )
+    if (!is.null(precipitation)) {
+        diagnostics$precipitation <- precipitation
+    }
+    diagnostics
+}
+
+# Apply seasonal and future-period windows independently at each projected day
+# while retaining the future-model sequence as the adjusted output backbone.
+qdm__adjust_values <- function(series, resolved, key, variable) {
+    observed <- series$observed_reference
+    historical <- series$model_historical
+    future <- series$model_future
+    prepared <- qdm__prepared_values(series, resolved, key, variable)
+    observed_value <- prepared$values$observed_reference
+    historical_value <- prepared$values$model_historical
+    future_value <- prepared$values$model_future
+    n_future <- nrow(future)
+    observed_samples <- historical_samples <- future_samples <-
+        future_year_counts <- integer(n_future)
+    probability <- change <- adjusted <- numeric(n_future)
+    future_lower_tail <- future_upper_tail <- logical(n_future)
+    tied_observed <- tied_historical <- tied_future <- integer(n_future)
+
+    for (index in seq_len(n_future)) {
+        center_phase <- future[["annual_phase"]][[index]]
+        observed_window <- daily__phase_window(
+            observed[["annual_phase"]],
+            center_phase,
+            resolved$seasonal_window_days,
+            resolved$target_year_days
+        )
+        historical_window <- daily__phase_window(
+            historical[["annual_phase"]],
+            center_phase,
+            resolved$seasonal_window_days,
+            resolved$target_year_days
+        )
+        future_season <- daily__phase_window(
+            future[["annual_phase"]],
+            center_phase,
+            resolved$seasonal_window_days,
+            resolved$target_year_days
+        )
+        future_year <- qdm__future_year_window(
+            future[["cf_year"]],
+            future[["cf_year"]][[index]],
+            resolved$future_window_years
+        )
+        future_window <- future_season & future_year
+        observed_values <- observed_value[observed_window]
+        historical_values <- historical_value[historical_window]
+        future_values <- future_value[future_window]
+        observed_samples[[index]] <- length(observed_values)
+        historical_samples[[index]] <- length(historical_values)
+        future_samples[[index]] <- length(future_values)
+        future_year_counts[[index]] <- length(unique(
+            future[["cf_year"]][future_window]
+        ))
+        if (observed_samples[[index]] < resolved$min_samples ||
+            historical_samples[[index]] < resolved$min_samples ||
+            future_samples[[index]] < resolved$min_samples) {
+            cli::cli_abort(
+                "Quantile Delta Mapping future row {index} has fewer than {resolved$min_samples} observed, historical, or future values in its seasonal and future-period windows."
+            )
+        }
+
+        mapped <- qdm__map_value(
+            observed_values,
+            historical_values,
+            future_values,
+            future_value[[index]],
+            resolved$trend_preservation
+        )
+        adjusted[[index]] <- mapped$value
+        probability[[index]] <- mapped$probability
+        change[[index]] <- mapped$change
+        future_lower_tail[[index]] <- mapped$future_lower_tail
+        future_upper_tail[[index]] <- mapped$future_upper_tail
+        tied_observed[[index]] <- mapped$tied_observed_values
+        tied_historical[[index]] <- mapped$tied_historical_values
+        tied_future[[index]] <- mapped$tied_future_values
+    }
+
+    if (!is.null(prepared$precipitation)) {
+        recensored <- adjusted <= resolved$dry_threshold
+        adjusted[recensored] <- 0
+        prepared$precipitation$output_censored_values <- sum(recensored)
+    }
+    bounded <- pmin(
+        pmax(adjusted, resolved$bounds[[1L]]),
+        resolved$bounds[[2L]]
+    )
+    clipped <- sum(bounded != adjusted)
+    list(
+        value = bounded,
+        diagnostics = qdm__diagnostics(
+            observed_samples,
+            historical_samples,
+            future_samples,
+            future_year_counts,
+            probability,
+            change,
+            future_lower_tail,
+            future_upper_tail,
+            tied_observed,
+            tied_historical,
+            tied_future,
+            clipped,
+            prepared$precipitation
+        )
+    )
+}
+
+# Execute QDM for one aligned univariate signal group and return the common
+# DailyAdjustedSeries contract with resolved settings and provenance.
+qdm__apply_group <- function(inputs, settings, key) {
+    resolved <- qdm__settings(settings)
+    variable <- names(settings)[[1L]]
+    series <- qdm__inputs(
+        inputs,
+        variable,
+        resolved$distribution_model
+    )
+    mapped <- qdm__adjust_values(series, resolved, key, variable)
+    future <- series$model_future
+    future[["value"]] <- mapped$value
+
+    bias__daily_adjusted_series(
+        future,
+        output_role = "model_future",
+        transformation = "quantile_delta_mapping",
+        settings = resolved,
+        provenance = list(
+            method = "quantile_delta_mapping",
+            references = QDM_REFERENCES,
+            group_key = key,
+            output_backbone = "model_future",
+            diagnostics = mapped$diagnostics
+        )
+    )
+}
+
+# Return one explicit diagnostic string when QDM violates the package-native
+# future-model output contract.
+qdm__validate_result <- function(value, inputs, key) {
+    if (!S7::S7_inherits(value, DailyAdjustedSeries)) {
+        return(
+            "Quantile Delta Mapping must return a DailyAdjustedSeries object."
+        )
+    }
+    if (!identical(value@output_role, "model_future")) {
+        return(
+            "Quantile Delta Mapping output must retain the `model_future` role."
+        )
+    }
+    TRUE
+}
+
+# Construct the reusable QDM signal with explicit daily roles and
+# method-evidence-aware variable alternatives.
+qdm__component <- function() {
+    alternatives <- as.list(c(
+        QDM_PUBLISHED_VARIABLES,
+        QDM_EXPERIMENTAL_VARIABLES
+    ))
+    roles <- c(
+        "observed_reference",
+        "model_historical",
+        "model_future"
+    )
+    requirements <- lapply(roles, function(role) {
+        component__input_requirement(
+            role,
+            representations = "series",
+            frequencies = "day",
+            variable_sets = alternatives
+        )
+    })
+    names(requirements) <- roles
+    signal__component(
+        name = "quantile_delta_mapping_daily",
+        label = "Daily Quantile Delta Mapping",
+        required_inputs = requirements,
+        input_kinds = "calendar_indexed_daily_series",
+        output_kinds = "daily_adjusted_series",
+        scopes = "univariate",
+        stochastic = TRUE,
+        profiles = qdm__profiles(),
+        apply_group = qdm__apply_group,
+        operations = list(validate_result = qdm__validate_result),
+        metadata = list(
+            method_family = "bias_adjustment",
+            output_contract = "daily_adjusted_series",
+            references = QDM_REFERENCES,
+            stochastic_operation = "precipitation_censor_randomization",
+            empirical_conventions = list(
+                cdf = "linear_interpolation",
+                inverse_cdf = "linear_type_7",
+                ties = "average_rank",
+                tails = "future_window_support"
+            ),
+            window_defaults = list(
+                seasonal_days = 91L,
+                future_years = 31L,
+                future_step_years = 1L
+            )
+        )
+    )
+}
+
+# Register QDM once so package load and repeated tests share one discoverable
+# process-local component.
+qdm__register_component <- function() {
+    component <- qdm__component()
+    key <- component__registry_key(component@stage, component@name)
+    if (!exists(
+        key,
+        envir = WEATHER_COMPONENT_REGISTRY,
+        inherits = FALSE
+    )) {
+        component__register(component)
+    }
+    invisible(NULL)
+}

--- a/R/quantile-distribution.R
+++ b/R/quantile-distribution.R
@@ -1,0 +1,123 @@
+# The empirical distribution primitives in this module are shared by
+# quantile-based signals while leaving each method's transfer equation intact.
+
+# Define interpolated empirical-CDF anchors with average-rank ties. For a
+# sample x(1)...x(n), each distinct value receives
+# p = (average_rank - 1) / (n - 1), with a constant sample placed at p = 0.5.
+quantile__cdf_anchors <- function(sample) {
+    checkmate::assert_numeric(
+        sample,
+        min.len = 1L,
+        finite = TRUE,
+        any.missing = FALSE
+    )
+    ordered <- sort(as.numeric(sample))
+    runs <- rle(ordered)
+    end_rank <- cumsum(runs$lengths)
+    start_rank <- end_rank - runs$lengths + 1L
+    average_rank <- (start_rank + end_rank) / 2
+    probability <- if (length(ordered) == 1L) {
+        0.5
+    } else {
+        (average_rank - 1) / (length(ordered) - 1)
+    }
+    data.frame(
+        value = runs$values,
+        probability = probability
+    )
+}
+
+# Evaluate the explicit empirical CDF and clamp values outside the sample to
+# endpoint probabilities rather than extrapolating a new tail.
+quantile__empirical_cdf <- function(sample, values) {
+    checkmate::assert_numeric(
+        values,
+        finite = TRUE,
+        any.missing = FALSE
+    )
+    anchors <- quantile__cdf_anchors(sample)
+    probability <- if (nrow(anchors) == 1L) {
+        rep.int(anchors$probability, length(values))
+    } else {
+        stats::approx(
+            x = anchors$value,
+            y = anchors$probability,
+            xout = values,
+            method = "linear",
+            rule = 2,
+            ties = "ordered"
+        )$y
+    }
+    lower_tail <- values < min(anchors$value)
+    upper_tail <- values > max(anchors$value)
+    # Strictly external values receive endpoint probabilities even when tied
+    # sample endpoints have interior average-rank probabilities.
+    probability[lower_tail] <- 0
+    probability[upper_tail] <- 1
+    list(
+        probability = probability,
+        lower_tail = lower_tail,
+        upper_tail = upper_tail,
+        tied_sample_values = length(sample) - nrow(anchors)
+    )
+}
+
+# Evaluate an inverse empirical CDF with R's type-7 linear quantile rule.
+quantile__inverse_cdf <- function(sample, probability) {
+    checkmate::assert_numeric(
+        probability,
+        lower = 0,
+        upper = 1,
+        finite = TRUE,
+        any.missing = FALSE
+    )
+    as.numeric(stats::quantile(
+        sample,
+        probs = probability,
+        names = FALSE,
+        type = 7
+    ))
+}
+
+# Derive a stable group-specific seed so stochastic preprocessing remains
+# reproducible without assigning identical sequences to every location.
+quantile__group_seed <- function(seed, key, variable) {
+    text <- paste(
+        c(
+            variable,
+            unlist(Map(
+                function(name, value) {
+                    paste0(name, "=", as.character(value))
+                },
+                names(key),
+                key
+            ), use.names = FALSE)
+        ),
+        collapse = "\u001f"
+    )
+    modulus <- .Machine$integer.max - 1
+    hash <- (as.double(seed) %% modulus) + 1
+    for (code in utf8ToInt(enc2utf8(text))) {
+        hash <- (hash * 131 + code) %% modulus
+    }
+    as.integer(hash + 1)
+}
+
+# Generate reproducible uniform variates with the Park-Miller
+# state[i] = 16807 * state[i-1] mod 2147483647 recurrence.
+quantile__uniform <- function(n, seed) {
+    checkmate::assert_count(n)
+    checkmate::assert_int(
+        seed,
+        lower = 1L,
+        upper = .Machine$integer.max - 1L
+    )
+    modulus <- as.double(.Machine$integer.max)
+    state <- as.double(seed)
+    out <- numeric(n)
+    for (index in seq_len(n)) {
+        state <- (16807 * state) %% modulus
+        out[[index]] <- state / modulus
+    }
+    out
+}

--- a/R/quantile-mapping.R
+++ b/R/quantile-mapping.R
@@ -1,4 +1,4 @@
-#' @include bias-adjustment.R daily-climatology.R
+#' @include bias-adjustment.R daily-climatology.R quantile-distribution.R
 NULL
 
 # Quantile Mapping references identify the published transfer equation and
@@ -255,93 +255,12 @@ qm__inputs <- function(inputs, variable, distribution_model) {
     series
 }
 
-# Define the interpolated empirical CDF with average-rank tie anchors. For a
-# sample x(1)...x(n), each distinct value receives
-# p = (average_rank - 1) / (n - 1), with a constant sample placed at p = 0.5.
-qm__cdf_anchors <- function(sample) {
-    checkmate::assert_numeric(
-        sample,
-        min.len = 1L,
-        finite = TRUE,
-        any.missing = FALSE
-    )
-    ordered <- sort(as.numeric(sample))
-    runs <- rle(ordered)
-    end_rank <- cumsum(runs$lengths)
-    start_rank <- end_rank - runs$lengths + 1L
-    average_rank <- (start_rank + end_rank) / 2
-    probability <- if (length(ordered) == 1L) {
-        0.5
-    } else {
-        (average_rank - 1) / (length(ordered) - 1)
-    }
-    data.frame(
-        value = runs$values,
-        probability = probability
-    )
-}
-
-# Evaluate the explicit empirical CDF and clamp values outside the historical
-# sample to its endpoint probabilities rather than extrapolating a new tail.
-qm__empirical_cdf <- function(sample, values) {
-    checkmate::assert_numeric(
-        values,
-        finite = TRUE,
-        any.missing = FALSE
-    )
-    anchors <- qm__cdf_anchors(sample)
-    probability <- if (nrow(anchors) == 1L) {
-        rep.int(anchors$probability, length(values))
-    } else {
-        stats::approx(
-            x = anchors$value,
-            y = anchors$probability,
-            xout = values,
-            method = "linear",
-            rule = 2,
-            ties = "ordered"
-        )$y
-    }
-    lower_tail <- values < min(anchors$value)
-    upper_tail <- values > max(anchors$value)
-    # Tail clamping means values strictly beyond the calibration range map to
-    # the observed minimum or maximum even when a tied historical endpoint
-    # has an interior average-rank probability.
-    probability[lower_tail] <- 0
-    probability[upper_tail] <- 1
-    list(
-        probability = probability,
-        lower_tail = lower_tail,
-        upper_tail = upper_tail,
-        tied_sample_values = length(sample) - nrow(anchors)
-    )
-}
-
-# Evaluate the inverse empirical CDF with R's type-7 linear quantile rule. This
-# is paired with qm__cdf_anchors() so identical observed and historical samples
-# map their calibration values back to themselves, including tied values.
-qm__inverse_cdf <- function(sample, probability) {
-    checkmate::assert_numeric(
-        probability,
-        lower = 0,
-        upper = 1,
-        finite = TRUE,
-        any.missing = FALSE
-    )
-    as.numeric(stats::quantile(
-        sample,
-        probs = probability,
-        names = FALSE,
-        type = 7
-    ))
-}
-
 # Apply x* = F_obs^{-1}(F_hist(x_future)) with the declared interpolation,
 # tie, and tail conventions to one or more future values.
 qm__map_continuous <- function(historical, observed, future) {
-    cdf <- qm__empirical_cdf(historical, future)
+    cdf <- quantile__empirical_cdf(historical, future)
     list(
-        value = qm__inverse_cdf(observed, cdf$probability),
+        value = quantile__inverse_cdf(observed, cdf$probability),
         probability = cdf$probability,
         lower_tail = cdf$lower_tail,
         upper_tail = cdf$upper_tail,
@@ -349,51 +268,6 @@ qm__map_continuous <- function(historical, observed, future) {
         tied_observed_values = length(observed) -
             length(unique(observed))
     )
-}
-
-# Derive a stable group-specific seed so multiple locations do not receive the
-# same randomized precipitation occurrence sequence under one user seed.
-qm__group_seed <- function(seed, key, variable) {
-    text <- paste(
-        c(
-            variable,
-            unlist(Map(
-                function(name, value) {
-                    paste0(name, "=", as.character(value))
-                },
-                names(key),
-                key
-            ), use.names = FALSE)
-        ),
-        collapse = "\u001f"
-    )
-    modulus <- .Machine$integer.max - 1
-    hash <- (as.double(seed) %% modulus) + 1
-    for (code in utf8ToInt(enc2utf8(text))) {
-        hash <- (hash * 131 + code) %% modulus
-    }
-    as.integer(hash + 1)
-}
-
-# Generate reproducible uniform variates with the Park-Miller minimal-standard
-# recurrence state[i] = 16807 * state[i-1] mod 2147483647. Keeping this small
-# generator method-local makes precipitation results independent of R's global
-# RNG kind and leaves the caller's RNG state untouched.
-qm__uniform <- function(n, seed) {
-    checkmate::assert_count(n)
-    checkmate::assert_int(
-        seed,
-        lower = 1L,
-        upper = .Machine$integer.max - 1L
-    )
-    modulus <- as.double(.Machine$integer.max)
-    state <- as.double(seed)
-    out <- numeric(n)
-    for (index in seq_len(n)) {
-        state <- (16807 * state) %% modulus
-        out[[index]] <- state / modulus
-    }
-    out
 }
 
 # Map a mixed precipitation distribution: values at or below the trace
@@ -427,7 +301,7 @@ qm__map_precipitation <- function(
                 "A precipitation window has positive future values but no positive historical-model calibration values."
             )
         }
-        positive_cdf <- qm__empirical_cdf(
+        positive_cdf <- quantile__empirical_cdf(
             historical_positive,
             future[positive]
         )
@@ -450,7 +324,7 @@ qm__map_precipitation <- function(
         conditional_probability <- (
             probability[output_positive] - observed_dry_probability
         ) / (1 - observed_dry_probability)
-        mapped[output_positive] <- qm__inverse_cdf(
+        mapped[output_positive] <- quantile__inverse_cdf(
             observed_positive,
             conditional_probability
         )
@@ -517,12 +391,12 @@ qm__adjust_values <- function(series, resolved, key, variable) {
     probability <- adjusted <- numeric(n_future)
     lower_tail <- upper_tail <- logical(n_future)
     tied_historical <- tied_observed <- integer(n_future)
-    effective_seed <- qm__group_seed(
+    effective_seed <- quantile__group_seed(
         resolved$random_seed,
         key,
         variable
     )
-    uniform <- qm__uniform(n_future, effective_seed)
+    uniform <- quantile__uniform(n_future, effective_seed)
     precipitation_diagnostics <- if (identical(
         resolved$distribution_model,
         "precipitation_hurdle"

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -16,6 +16,7 @@
     bias__register_linear_scaling_component()
     bias__register_delta_change_component()
     qm__register_component()
+    qdm__register_component()
 
     # set package options
     .opts <- list(

--- a/tests/testthat/test-quantile-delta-mapping.R
+++ b/tests/testthat/test-quantile-delta-mapping.R
@@ -1,6 +1,6 @@
-# Build one calendar-native daily series from consecutive CF-calendar days so
-# Quantile Mapping tests never rely on Gregorian Date coercion.
-qm_test__series <- function(
+# Build calendar-native daily rows without coercing non-Gregorian dates through
+# base Date, matching the package signal boundary.
+qdm_test__series <- function(
     variable_id,
     year,
     values,
@@ -36,9 +36,8 @@ qm_test__series <- function(
     )
 }
 
-# Construct role metadata and the aligned group from the same three canonical
-# tables, matching the package's standalone signal execution boundary.
-qm_test__execution_inputs <- function(
+# Construct canonical role metadata and one aligned QDM signal group.
+qdm_test__execution_inputs <- function(
     observed,
     historical,
     future,
@@ -71,9 +70,9 @@ qm_test__execution_inputs <- function(
     )
 }
 
-# Execute one variable through the common signal lifecycle while replacing the
-# default seasonal window with a full-cycle window for compact test fixtures.
-qm_test__execute <- function(
+# Execute compact fixtures through the common signal lifecycle with a
+# full-annual seasonal pool and an explicit minimum sample count.
+qdm_test__execute <- function(
     variable,
     observed,
     historical,
@@ -82,7 +81,7 @@ qm_test__execute <- function(
     key = list(site = "A"),
     warn_experimental = FALSE
 ) {
-    boundary <- qm_test__execution_inputs(
+    boundary <- qdm_test__execution_inputs(
         observed,
         historical,
         future,
@@ -91,13 +90,14 @@ qm_test__execute <- function(
     settings <- utils::modifyList(
         list(
             seasonal_window_days = 365L,
+            future_window_years = 31L,
             target_year_days = 365L,
             min_samples = 2L
         ),
         overrides
     )
     component__execute(
-        qm__component(),
+        qdm__component(),
         "apply",
         inputs = boundary$inputs,
         groups = list(boundary$group),
@@ -106,10 +106,9 @@ qm_test__execute <- function(
     )
 }
 
-# Retrieve one default settings record without relying on profile construction
-# order in tests that call the single-group kernel directly.
-qm_test__settings <- function(variable) {
-    profiles <- qm__profiles()
+# Retrieve one default profile by variable for direct kernel validation tests.
+qdm_test__settings <- function(variable) {
+    profiles <- qdm__profiles()
     index <- which(vapply(
         profiles,
         function(profile) identical(profile@variable_id, variable),
@@ -118,48 +117,48 @@ qm_test__settings <- function(variable) {
     profiles[[index]]@settings
 }
 
-test_that("empirical CDF conventions make ties and tails explicit", {
-    anchors <- quantile__cdf_anchors(c(1, 1, 2, 4))
+test_that("QDM transfers absolute and relative quantile changes", {
+    absolute <- qdm__map_value(
+        observed = c(10, 20, 30),
+        historical = c(0, 10, 20),
+        future_sample = c(5, 15, 25),
+        future_value = 15,
+        trend_preservation = "absolute"
+    )
+    relative <- qdm__map_value(
+        observed = c(2, 4, 8),
+        historical = c(1, 2, 4),
+        future_sample = c(2, 4, 8),
+        future_value = 4,
+        trend_preservation = "relative"
+    )
 
-    expect_equal(anchors$value, c(1, 2, 4))
-    expect_equal(anchors$probability, c(1 / 6, 2 / 3, 1))
-
-    mapped <- qm__map_continuous(
-        historical = c(1, 1, 2, 4),
-        observed = c(10, 20, 30, 40),
-        future = c(-1, 1, 2, 4, 6)
-    )
-    expect_equal(mapped$value, c(10, 15, 30, 40, 40))
-    expect_identical(
-        mapped$lower_tail,
-        c(TRUE, FALSE, FALSE, FALSE, FALSE)
-    )
-    expect_identical(
-        mapped$upper_tail,
-        c(FALSE, FALSE, FALSE, FALSE, TRUE)
-    )
-    expect_identical(mapped$tied_historical_values, 1L)
-    expect_identical(mapped$tied_observed_values, 0L)
+    expect_equal(absolute$probability, 0.5)
+    expect_equal(absolute$change, 5)
+    expect_equal(absolute$value, 25)
+    expect_equal(relative$probability, 0.5)
+    expect_equal(relative$change, 2)
+    expect_equal(relative$value, 8)
 })
 
-test_that("Quantile Mapping returns a typed future-backbone daily series", {
-    observed <- qm_test__series(
+test_that("QDM returns a typed future-backbone daily series", {
+    observed <- qdm_test__series(
         "tas",
         2001L,
         c(10, 20, 30, 40)
     )
-    historical <- qm_test__series(
+    historical <- qdm_test__series(
         "tas",
         1991L,
         c(0, 10, 20, 30)
     )
-    future <- qm_test__series(
+    future <- qdm_test__series(
         "tas",
         2061L,
-        c(5, 15, -10, 40)
+        c(5, 15, 25, 35)
     )
 
-    execution <- qm_test__execute(
+    execution <- qdm_test__execute(
         "tas",
         observed,
         historical,
@@ -169,49 +168,88 @@ test_that("Quantile Mapping returns a typed future-backbone daily series", {
 
     expect_true(S7::S7_inherits(execution, SignalExecutionResult))
     expect_true(S7::S7_inherits(adjusted, DailyAdjustedSeries))
-    expect_equal(adjusted@data$value, c(15, 25, 10, 40))
+    expect_equal(adjusted@data$value, c(15, 25, 35, 45))
     expect_identical(
         adjusted@data[BIAS_DAILY_SERIES_COLUMNS[-2L]],
         future[BIAS_DAILY_SERIES_COLUMNS[-2L]]
     )
     expect_identical(adjusted@output_role, "model_future")
-    expect_identical(adjusted@transformation, "quantile_mapping")
-    expect_identical(adjusted@provenance$output_backbone, "model_future")
     expect_identical(
-        adjusted@provenance$diagnostics$lower_tail_values,
-        1L
+        adjusted@transformation,
+        "quantile_delta_mapping"
     )
     expect_identical(
-        adjusted@provenance$diagnostics$upper_tail_values,
-        1L
+        adjusted@provenance$output_backbone,
+        "model_future"
+    )
+    expect_identical(
+        adjusted@provenance$diagnostics$future_lower_tail_values,
+        0L
+    )
+    expect_identical(
+        adjusted@provenance$diagnostics$future_upper_tail_values,
+        0L
     )
     expect_identical(execution@diagnostics$status, "ok")
 })
 
-test_that("Quantile Mapping preserves identity across native CF calendars", {
+test_that("QDM preserves modeled quantile deltas that QM changes", {
+    observed <- qdm_test__series("tas", 2001L, c(0, 20, 40))
+    historical <- qdm_test__series("tas", 1991L, c(0, 10, 20))
+    future <- qdm_test__series("tas", 2061L, c(10, 20, 30))
+    qdm <- qdm_test__execute(
+        "tas",
+        observed,
+        historical,
+        future
+    )@values[[1L]]@data$value
+    boundary <- qdm_test__execution_inputs(
+        observed,
+        historical,
+        future
+    )
+    qm <- component__execute(
+        qm__component(),
+        "apply",
+        inputs = boundary$inputs,
+        groups = list(boundary$group),
+        overrides = list(tas = list(
+            seasonal_window_days = 365L,
+            target_year_days = 365L,
+            min_samples = 2L
+        )),
+        warn_experimental = FALSE
+    )@values[[1L]]@data$value
+
+    expect_equal(future$value - historical$value, rep.int(10, 3L))
+    expect_equal(qdm - observed$value, rep.int(10, 3L))
+    expect_false(isTRUE(all.equal(qm - observed$value, rep.int(10, 3L))))
+})
+
+test_that("QDM preserves identity across native CF calendars", {
     calendars <- c("360_day", "noleap", "all_leap")
     values <- c(2, 2, 4, 7, 9)
 
     for (calendar in calendars) {
-        observed <- qm_test__series(
+        observed <- qdm_test__series(
             "tas",
             2000L,
             values,
             calendar
         )
-        historical <- qm_test__series(
+        historical <- qdm_test__series(
             "tas",
             1990L,
             values,
             calendar
         )
-        future <- qm_test__series(
+        future <- qdm_test__series(
             "tas",
             2060L,
             values,
             calendar
         )
-        execution <- qm_test__execute(
+        execution <- qdm_test__execute(
             "tas",
             observed,
             historical,
@@ -231,33 +269,33 @@ test_that("Quantile Mapping preserves identity across native CF calendars", {
     }
 })
 
-test_that("circular windows bridge the annual-phase boundary", {
-    observed <- qm_test__series(
+test_that("QDM circular windows bridge the annual-phase boundary", {
+    observed <- qdm_test__series(
         "tas",
         2001L,
         seq_len(365L) + 10
     )
-    historical <- qm_test__series(
+    historical <- qdm_test__series(
         "tas",
         1991L,
         seq_len(365L)
     )
-    future <- qm_test__series(
+    future <- qdm_test__series(
         "tas",
         2061L,
         seq_len(365L)
     )
-    boundary <- qm_test__execution_inputs(
+    boundary <- qdm_test__execution_inputs(
         observed,
         historical,
         future
     )
-    settings <- qm_test__settings("tas")
+    settings <- qdm_test__settings("tas")
     settings$seasonal_window_days <- 3L
     settings$min_samples <- 3L
 
     adjusted <- component__execute(
-        qm__component(),
+        qdm__component(),
         "apply_group",
         inputs = boundary$group@inputs,
         settings = list(tas = settings),
@@ -266,72 +304,85 @@ test_that("circular windows bridge the annual-phase boundary", {
 
     expect_equal(adjusted@data$value[c(1L, 365L)], c(11, 375))
     expect_equal(
-        adjusted@provenance$diagnostics$observed_window_samples,
+        adjusted@provenance$diagnostics$future_window_samples,
         c(minimum = 3, median = 3, maximum = 3)
     )
 })
 
-test_that("bounds clip mapped values and are retained in diagnostics", {
-    observed <- qm_test__series("hurs", 2001L, c(-10, 25, 75, 120))
-    historical <- qm_test__series("hurs", 1991L, c(0, 1, 2, 3))
-    future <- qm_test__series("hurs", 2061L, c(0, 1, 2, 3))
+test_that("QDM future windows are centered and truncate at series edges", {
+    years <- 2040:2070
 
-    execution <- qm_test__execute(
-        "hurs",
+    expect_true(all(qdm__future_year_window(years, 2055L, 31L)))
+    expect_identical(
+        years[qdm__future_year_window(years, 2040L, 31L)],
+        2040:2055
+    )
+})
+
+test_that("relative QDM preserves positive precipitation quantile ratios", {
+    observed <- qdm_test__series("pr", 2001L, c(2, 4, 8, 16))
+    historical <- qdm_test__series("pr", 1991L, c(1, 2, 4, 8))
+    future <- qdm_test__series("pr", 2061L, c(2, 4, 8, 16))
+
+    adjusted <- qdm_test__execute(
+        "pr",
         observed,
         historical,
         future
-    )
-    adjusted <- execution@values[[1L]]
+    )@values[[1L]]
 
-    expect_equal(adjusted@data$value, c(0, 25, 75, 100))
-    expect_identical(
-        adjusted@provenance$diagnostics$clipped_values,
-        2L
+    expect_equal(adjusted@data$value, c(4, 8, 16, 32))
+    expect_equal(
+        adjusted@data$value / observed$value,
+        future$value / historical$value
     )
-    expect_identical(adjusted@settings$bounds, c(0, 100))
+    expect_identical(
+        adjusted@settings$trend_preservation,
+        "relative"
+    )
 })
 
-test_that("precipitation hurdle mapping has deterministic dry-day control", {
+test_that("precipitation censoring is deterministic and RNG-independent", {
     count <- 40L
-    observed <- qm_test__series(
+    observed <- qdm_test__series(
         "pr",
         2001L,
         c(rep.int(0, 8L), seq_len(32L))
     )
-    historical <- qm_test__series(
+    historical <- qdm_test__series(
         "pr",
         1991L,
         c(rep.int(0, 20L), seq_len(20L))
     )
-    future <- qm_test__series(
+    future <- qdm_test__series(
         "pr",
         2061L,
         rep.int(0, count)
     )
     set.seed(2026)
     seed_before <- .Random.seed
+    overrides <- list(dry_threshold = 0.5, random_seed = 99L)
 
-    first <- qm_test__execute(
+    first <- qdm_test__execute(
         "pr",
         observed,
         historical,
         future,
-        overrides = list(dry_threshold = 0, random_seed = 99L)
+        overrides = overrides
     )
-    second <- qm_test__execute(
+    second <- qdm_test__execute(
         "pr",
         observed,
         historical,
         future,
-        overrides = list(dry_threshold = 0, random_seed = 99L)
+        overrides = overrides
     )
-    different <- qm_test__execute(
+    different <- qdm_test__execute(
         "pr",
         observed,
         historical,
         future,
-        overrides = list(dry_threshold = 0, random_seed = 100L)
+        overrides = list(dry_threshold = 0.5, random_seed = 100L)
     )
 
     first_values <- first@values[[1L]]@data$value
@@ -346,9 +397,15 @@ test_that("precipitation hurdle mapping has deterministic dry-day control", {
     precipitation <- (
         first@values[[1L]]@provenance$diagnostics$precipitation
     )
-    expect_identical(precipitation$input_dry_values, count)
-    expect_identical(precipitation$randomized_dry_values, count)
-    expect_true(precipitation$output_dry_values < count)
+    expect_identical(
+        precipitation$input_censored_values,
+        c(
+            observed_reference = 8L,
+            model_historical = 20L,
+            model_future = count
+        )
+    )
+    expect_true(precipitation$output_censored_values > 0L)
     expect_identical(precipitation$random_seed, 99L)
     expect_identical(
         precipitation$random_generator,
@@ -356,33 +413,33 @@ test_that("precipitation hurdle mapping has deterministic dry-day control", {
     )
 })
 
-test_that("Quantile Mapping rejects unsupported or insufficient inputs", {
-    observed <- qm_test__series("tas", 2001L, c(1, 2, 3, 4))
-    historical <- qm_test__series("tas", 1991L, c(1, 2, 3, 4))
-    future <- qm_test__series("tas", 2061L, c(1, 2, 3, 4))
-    boundary <- qm_test__execution_inputs(
+test_that("QDM rejects unsupported, insufficient, or invalid settings", {
+    observed <- qdm_test__series("tas", 2001L, c(1, 2, 3, 4))
+    historical <- qdm_test__series("tas", 1991L, c(1, 2, 3, 4))
+    future <- qdm_test__series("tas", 2061L, c(1, 2, 3, 4))
+    boundary <- qdm_test__execution_inputs(
         observed,
         historical,
         future
     )
-    settings <- qm_test__settings("tas")
+    settings <- qdm_test__settings("tas")
 
-    unsupported <- settings
-    unsupported$cdf_method <- "step_function"
+    even_window <- settings
+    even_window$future_window_years <- 30L
     expect_error(
         component__execute(
-            qm__component(),
+            qdm__component(),
             "apply_group",
             inputs = boundary$group@inputs,
-            settings = list(tas = unsupported),
+            settings = list(tas = even_window),
             key = list()
         ),
-        "requires linear empirical CDF"
+        "requires an odd"
     )
 
     expect_error(
         component__execute(
-            qm__component(),
+            qdm__component(),
             "apply_group",
             inputs = boundary$group@inputs,
             settings = list(tas = settings),
@@ -391,56 +448,64 @@ test_that("Quantile Mapping rejects unsupported or insufficient inputs", {
         "fewer than 10"
     )
 
-    incompatible_units <- boundary$group@inputs
-    incompatible_units$model_future$units <- "degC"
+    expect_error(
+        qdm__map_value(
+            observed = c(1, 2),
+            historical = c(0, 0),
+            future_sample = c(1, 2),
+            future_value = 1,
+            trend_preservation = "relative"
+        ),
+        "zero historical-model quantile"
+    )
+})
+
+test_that("QDM validates precipitation thresholds and non-negative inputs", {
+    observed <- qdm_test__series("pr", 2001L, c(0, 1, 2, 3))
+    historical <- qdm_test__series("pr", 1991L, c(0, 1, 2, 3))
+    future <- qdm_test__series("pr", 2061L, c(0, 1, 2, 3))
+    boundary <- qdm_test__execution_inputs(
+        observed,
+        historical,
+        future
+    )
+    settings <- qdm_test__settings("pr")
+    settings$seasonal_window_days <- 365L
+    settings$min_samples <- 2L
+
+    zero_threshold <- settings
+    zero_threshold$dry_threshold <- 0
     expect_error(
         component__execute(
-            qm__component(),
+            qdm__component(),
             "apply_group",
-            inputs = incompatible_units,
-            settings = list(tas = utils::modifyList(
-                settings,
-                list(
-                    seasonal_window_days = 365L,
-                    min_samples = 2L
-                )
-            )),
+            inputs = boundary$group@inputs,
+            settings = list(pr = zero_threshold),
             key = list()
         ),
-        "identical units"
+        "positive `dry_threshold`"
     )
 
-    precipitation <- lapply(
-        boundary$group@inputs,
-        function(data) {
-            data$variable_id <- "pr"
-            data$units <- "kg m-2 s-1"
-            data
-        }
-    )
-    precipitation$model_future$value[[1L]] <- -1
-    pr_settings <- qm_test__settings("pr")
+    negative <- boundary$group@inputs
+    negative$model_future$value[[1L]] <- -1
     expect_error(
         component__execute(
-            qm__component(),
+            qdm__component(),
             "apply_group",
-            inputs = precipitation,
-            settings = list(pr = utils::modifyList(
-                pr_settings,
-                list(
-                    seasonal_window_days = 365L,
-                    min_samples = 2L
-                )
-            )),
+            inputs = negative,
+            settings = list(pr = settings),
             key = list()
         ),
         "non-negative"
     )
 })
 
-test_that("Quantile Mapping profiles retain evidence and registration", {
-    qm__register_component()
-    component <- component__get("signal", "quantile_mapping_daily")
+test_that("QDM profiles retain evidence and component registration", {
+    qdm__register_component()
+    component <- component__get(
+        "signal",
+        "quantile_delta_mapping_daily"
+    )
     profiles <- component@metadata$signal_profiles
 
     expect_true(S7::S7_inherits(component, WeatherComponentSpec))
@@ -454,7 +519,10 @@ test_that("Quantile Mapping profiles retain evidence and registration", {
     expect_true(component@stochastic)
     expect_identical(
         sort(names(profiles)),
-        sort(c(QM_PUBLISHED_VARIABLES, QM_EXPERIMENTAL_VARIABLES))
+        sort(c(
+            QDM_PUBLISHED_VARIABLES,
+            QDM_EXPERIMENTAL_VARIABLES
+        ))
     )
     expect_identical(profiles$tas$evidence, "published")
     expect_identical(profiles$pr$evidence, "published")
@@ -465,14 +533,14 @@ test_that("Quantile Mapping profiles retain evidence and registration", {
     )
 
     calendar <- component__spec(
-        name = "qm_calendar_test",
+        name = "qdm_calendar_test",
         stage = "calendar",
         input_kinds = "preprocessed_daily_series",
         output_kinds = "calendar_indexed_daily_series",
         operations = list(apply = identity)
     )
     sequence <- component__spec(
-        name = "qm_sequence_test",
+        name = "qdm_sequence_test",
         stage = "sequence",
         input_kinds = "daily_adjusted_series",
         output_kinds = "weather_sequence",

--- a/vignettes-raw/articles/epw-morpher.Rmd
+++ b/vignettes-raw/articles/epw-morpher.Rmd
@@ -500,13 +500,14 @@ interpretation. Group failures either abort or return an explicit diagnostic
 with a `NULL` result; they are never silently converted to missing numeric
 values.
 
-Three package-native standalone signals currently use this contract:
+Four package-native standalone signals currently use this contract:
 
 | Registry name | Correction | Output backbone | Variable-profile evidence |
 |:--------------|:-----------|:----------------|:--------------------------|
 | `linear_scaling_daily` | Monthly observed-minus-model mean bias, additive for temperature and multiplicative for precipitation | `model_future` | Published defaults for `tas`, `tasmin`, `tasmax`, and `pr` |
 | `delta_change_daily` | Monthly historical-to-future mean change, additive for temperature and multiplicative for precipitation | `observed_reference` | Published defaults for `tas`, `tasmin`, `tasmax`, and `pr` |
 | `quantile_mapping_daily` | \(F^{-1}_{obs}(F_{hist}(x_{future}))\) in calendar-neutral circular daily windows | `model_future` | Published method-variable profiles for `tas` and `pr`; implementation-selected defaults for `hurs`, `psl`, `rlds`, `sfcWind`, `tasmin`, and `tasmax` remain experimental |
+| `quantile_delta_mapping_daily` | Transfer \(x_{future} - F^{-1}_{hist}(p)\) or \(x_{future} / F^{-1}_{hist}(p)\) onto \(F^{-1}_{obs}(p)\), where \(p = F_{future,t}(x_{future})\) | `model_future` | Published absolute-change temperature and relative-change precipitation profiles; implementation-selected defaults for other supported variables remain experimental |
 
 `quantile_mapping_daily` uses linear empirical-CDF interpolation with
 average-rank ties, type-7 inverse quantiles, and endpoint clamping. Its default
@@ -517,6 +518,18 @@ mapping unchanged. Dry-day randomization is controlled by a recorded seed and
 a fixed method-local generator, leaving R's global random-number state
 untouched. Bounds, sample coverage, tail use, clipping, dry-day frequencies,
 and the resolved stochastic settings are retained in result provenance.
+
+`quantile_delta_mapping_daily` differs from ordinary Quantile Mapping by
+estimating each projected value's probability from a time-dependent future
+distribution. Its default calendar-neutral 91-day seasonal window represents
+the published three-month pool, while a symmetric 31-year future window makes
+the publication's 30-year moving-period calculation executable on whole model
+years. Temperature transfers absolute changes in quantiles and precipitation
+transfers relative changes. Precipitation values at or below the published
+0.05 mm/day trace threshold are replaced by deterministic positive uniforms
+before adjustment and censored back to zero afterward. Window sample counts,
+transferred changes, clipping, censoring, and effective seeds are retained in
+provenance.
 
 The runner returns `epw_morph_result()` with complete hourly EPW weather data.
 `EpwMorpher$run()` writes that data as Parquet and adds the case metadata

--- a/vignettes-raw/precompiled-checksums.csv
+++ b/vignettes-raw/precompiled-checksums.csv
@@ -1,7 +1,7 @@
 "source","output","source_md5","output_md5"
 "vignettes-raw/articles/cli-esgf-store.Rmd","vignettes/articles/cli-esgf-store.Rmd","cac788f79010ad56496939cdde3580bb","e58e5cafa0d3b2218081c25a1098273f"
 "vignettes-raw/articles/downloader.Rmd","vignettes/articles/downloader.Rmd","9668ccb5b39f0ca2f49e146a1a100a7c","4b67e4a9ddaecfe7ce3ac268936e2a2d"
-"vignettes-raw/articles/epw-morpher.Rmd","vignettes/articles/epw-morpher.Rmd","1b431a061f1b698766fbe38b327b24e8","6c39d0c446cad4264771bab82dfc5b2a"
+"vignettes-raw/articles/epw-morpher.Rmd","vignettes/articles/epw-morpher.Rmd","bebe1863da4e210d5c5fc0b5b36d52f8","d921b2bc743bf9c0ac6a691abcf17404"
 "vignettes-raw/articles/esg-dictionaries.Rmd","vignettes/articles/esg-dictionaries.Rmd","94eb2513975549a6765afa221a2e10c1","290348d35a29e925f1b3732586e54cfb"
 "vignettes-raw/articles/esg-store.Rmd","vignettes/articles/esg-store.Rmd","c2d810261308c837b84c803a0d2632c5","bb73ddac53598a36b049797782ce3c02"
 "vignettes-raw/articles/esgf-query-results.Rmd","vignettes/articles/esgf-query-results.Rmd","9cb7e909ecc499eba79e4295857101d1","20854ab68644b18addeefcef1baafcfa"

--- a/vignettes/articles/epw-morpher.Rmd
+++ b/vignettes/articles/epw-morpher.Rmd
@@ -508,13 +508,14 @@ interpretation. Group failures either abort or return an explicit diagnostic
 with a `NULL` result; they are never silently converted to missing numeric
 values.
 
-Three package-native standalone signals currently use this contract:
+Four package-native standalone signals currently use this contract:
 
 | Registry name | Correction | Output backbone | Variable-profile evidence |
 |:--------------|:-----------|:----------------|:--------------------------|
 | `linear_scaling_daily` | Monthly observed-minus-model mean bias, additive for temperature and multiplicative for precipitation | `model_future` | Published defaults for `tas`, `tasmin`, `tasmax`, and `pr` |
 | `delta_change_daily` | Monthly historical-to-future mean change, additive for temperature and multiplicative for precipitation | `observed_reference` | Published defaults for `tas`, `tasmin`, `tasmax`, and `pr` |
 | `quantile_mapping_daily` | \(F^{-1}_{obs}(F_{hist}(x_{future}))\) in calendar-neutral circular daily windows | `model_future` | Published method-variable profiles for `tas` and `pr`; implementation-selected defaults for `hurs`, `psl`, `rlds`, `sfcWind`, `tasmin`, and `tasmax` remain experimental |
+| `quantile_delta_mapping_daily` | Transfer \(x_{future} - F^{-1}_{hist}(p)\) or \(x_{future} / F^{-1}_{hist}(p)\) onto \(F^{-1}_{obs}(p)\), where \(p = F_{future,t}(x_{future})\) | `model_future` | Published absolute-change temperature and relative-change precipitation profiles; implementation-selected defaults for other supported variables remain experimental |
 
 `quantile_mapping_daily` uses linear empirical-CDF interpolation with
 average-rank ties, type-7 inverse quantiles, and endpoint clamping. Its default
@@ -525,6 +526,18 @@ mapping unchanged. Dry-day randomization is controlled by a recorded seed and
 a fixed method-local generator, leaving R's global random-number state
 untouched. Bounds, sample coverage, tail use, clipping, dry-day frequencies,
 and the resolved stochastic settings are retained in result provenance.
+
+`quantile_delta_mapping_daily` differs from ordinary Quantile Mapping by
+estimating each projected value's probability from a time-dependent future
+distribution. Its default calendar-neutral 91-day seasonal window represents
+the published three-month pool, while a symmetric 31-year future window makes
+the publication's 30-year moving-period calculation executable on whole model
+years. Temperature transfers absolute changes in quantiles and precipitation
+transfers relative changes. Precipitation values at or below the published
+0.05 mm/day trace threshold are replaced by deterministic positive uniforms
+before adjustment and censored back to zero afterward. Window sample counts,
+transferred changes, clipping, censoring, and effective seeds are retained in
+provenance.
 
 The runner returns `epw_morph_result()` with complete hourly EPW weather data.
 `EpwMorpher$run()` writes that data as Parquet and adds the case metadata


### PR DESCRIPTION
## Summary

- Closes #168.
- Adds package-native daily Quantile Delta Mapping through the existing signal and adjusted-series contracts.

## Changes

- Implement nonparametric absolute and relative quantile-change transfer using calendar-neutral seasonal windows and centered future-year windows.
- Apply the published precipitation trace-threshold censoring with deterministic role-specific randomization that leaves R's global RNG state unchanged.
- Extract empirical CDF, inverse-CDF, and deterministic random primitives shared with `quantile_mapping_daily`.
- Record resolved windows, sample coverage, transferred changes, bounds, censoring, provenance, and diagnostics.
- Cover the published equations, QM/QDM trend differences, ties, native CF calendars, circular boundaries, precipitation ratios and dry days, invalid inputs, and component compatibility.
