### PR TITLE
feat: add native daily CDF transform

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -92,6 +92,7 @@ Collate:
     'netcdf.R'
     'parametric-distribution.R'
     'quantile-distribution.R'
+    'cdf-transform.R'
     'quantile-delta-mapping.R'
     'quantile-mapping.R'
     'solr-date.R'

--- a/NEWS.md
+++ b/NEWS.md
@@ -51,13 +51,15 @@
   \(F_{obs,hist}(F^{-1}_{model,hist}(F_{model,future}(x)))\), then quantile
   matches the future-model sequence onto that target. The method uses the
   authors' additive-mean range alignment, explicit empirical-grid and
-  constant-correction tail conventions, and the published native
-  calendar-month 17-year fitting windows with disjoint central 9-year output
-  blocks. Precipitation uses deterministic Singularity Stochastic Removal
-  below \(10^{-8}\) kg m-2 s-1 without changing R's global RNG state. Results
-  retain future-model CF-calendar coordinates and record window coverage,
-  target-CDF ranges, tail extensions, clipping, SSR seeds, and resolved
-  settings for the six variables in the published daily application (#173).
+  constant-correction tail conventions. Following the Famien et al. (2018)
+  daily Africa application, native calendar months use 17-year fitting
+  windows with disjoint central 9-year output blocks. The package-selected
+  boundary policy truncates unavailable four-year flanks and records that
+  provenance explicitly. Precipitation uses deterministic Singularity
+  Stochastic Removal below \(10^{-8}\) kg m-2 s-1 without changing R's global
+  RNG state. Results retain future-model CF-calendar coordinates and record
+  window coverage, target-CDF ranges, tail extensions, clipping, SSR seeds,
+  and resolved settings for the six variables in that application (#173).
 
 * Added the native R `scaled_distribution_mapping_daily` signal component. It
   implements the published absolute temperature branch with linear detrending,

--- a/NEWS.md
+++ b/NEWS.md
@@ -46,6 +46,19 @@
 
 ## New features
 
+* Added the native R `cdf_transform_daily` signal component. It estimates the
+  future target CDF through the CDF-t chain
+  \(F_{obs,hist}(F^{-1}_{model,hist}(F_{model,future}(x)))\), then quantile
+  matches the future-model sequence onto that target. The method uses the
+  authors' additive-mean range alignment, explicit empirical-grid and
+  constant-correction tail conventions, and the published native
+  calendar-month 17-year fitting windows with disjoint central 9-year output
+  blocks. Precipitation uses deterministic Singularity Stochastic Removal
+  below \(10^{-8}\) kg m-2 s-1 without changing R's global RNG state. Results
+  retain future-model CF-calendar coordinates and record window coverage,
+  target-CDF ranges, tail extensions, clipping, SSR seeds, and resolved
+  settings for the six variables in the published daily application (#173).
+
 * Added the native R `scaled_distribution_mapping_daily` signal component. It
   implements the published absolute temperature branch with linear detrending,
   Normal fits, and two-tailed recurrence intervals, plus the relative

--- a/R/cdf-transform.R
+++ b/R/cdf-transform.R
@@ -1,18 +1,22 @@
 #' @include bias-adjustment.R quantile-distribution.R
 NULL
 
+# Identify the daily Africa application separately because it supplies the
+# temporal-window defaults, not the underlying CDF-t transformation.
+CDFT_FAMIEN_REFERENCE <- "https://doi.org/10.5194/esd-9-313-2018"
+
 # CDF-t references separate the original transformation, its empirical daily
 # application, precipitation SSR, and the method authors' maintained R code.
 CDFT_REFERENCES <- c(
     "https://doi.org/10.1029/2009GL038401",
     "https://doi.org/10.5194/nhess-12-2769-2012",
     "https://doi.org/10.1002/2015JD024511",
-    "https://doi.org/10.5194/esd-9-313-2018",
+    CDFT_FAMIEN_REFERENCE,
     "https://CRAN.R-project.org/package=CDFt"
 )
 
 # Famien et al. apply CDF-t directly to these six daily climate variables.
-CDFT_PUBLISHED_VARIABLES <- c(
+CDFT_FAMIEN_VARIABLES <- c(
     "pr",
     "tas",
     "tasmin",
@@ -25,10 +29,10 @@ CDFT_PUBLISHED_VARIABLES <- c(
 # precipitation flux has the numerically equivalent kg m-2 s-1 unit.
 CDFT_PR_SSR_THRESHOLD <- 1e-8
 
-# Construct the complete settings record shared by the published daily
-# profiles. The 17-year fitting window and central 9-year output block follow
-# the daily Africa application, while the empirical-grid choices follow the
-# method authors' R implementation.
+# Construct the complete settings record shared by the Famien et al. daily
+# profiles. Their Africa application supplies the 17-year fitting window and
+# central 9-year output block; edge truncation is an epwshiftr policy because
+# that application does not specify how to handle missing boundary flanks.
 cdft__default_settings <- function(
   bounds,
   distribution_model = c("continuous", "precipitation_ssr"),
@@ -70,7 +74,7 @@ cdft__profiles <- function() {
         rsds = cdft__default_settings(c(0, Inf)),
         sfcWind = cdft__default_settings(c(0, Inf))
     )
-    lapply(CDFT_PUBLISHED_VARIABLES, function(variable) {
+    lapply(CDFT_FAMIEN_VARIABLES, function(variable) {
         signal__variable_profile(
             variable,
             settings = settings[[variable]],
@@ -79,8 +83,11 @@ cdft__profiles <- function() {
             metadata = list(
                 method = "cdf_transform",
                 output_role = "model_future",
-                default_source = "method_literature_and_author_implementation",
-                temporal_policy_source = "method_literature"
+                method_settings_source =
+                    "method_literature_and_author_implementation",
+                temporal_window_source = "famien_2018_application",
+                temporal_window_reference = CDFT_FAMIEN_REFERENCE,
+                edge_policy_source = "epwshiftr_implementation"
             )
         )
     })
@@ -281,8 +288,9 @@ cdft__inputs <- function(inputs, variable, distribution_model) {
     series
 }
 
-# Partition future years into the published disjoint output blocks and their
-# symmetric fitting windows, truncating only where the requested data end.
+# Partition future years into disjoint output blocks and symmetric fitting
+# windows. The Famien et al. defaults use 17/9 years; epwshiftr truncates a
+# missing four-year flank when the requested series starts or ends too soon.
 cdft__future_blocks <- function(
   year,
   future_window_years,
@@ -617,9 +625,9 @@ cdft__window_record <- function(
     )
 }
 
-# Apply native-calendar monthly CDF-t fits on the published 17/9 year policy.
-# Each future row is written by exactly one output block even though fitting
-# windows overlap.
+# Apply native-calendar monthly CDF-t fits on the configured temporal policy.
+# The defaults reproduce the Famien et al. 17/9-year application schedule, and
+# each row is written once even though adjacent fitting windows overlap.
 cdft__adjust_values <- function(series, resolved, key, variable) {
     observed <- series$observed_reference
     historical <- series$model_historical
@@ -798,14 +806,24 @@ cdft__apply_group <- function(inputs, settings, key) {
                 future_window_years = resolved$future_window_years,
                 output_block_years = resolved$output_block_years,
                 edge_policy = resolved$edge_policy,
-                source = if (
+                seasonal_grouping_source = "famien_2018_application",
+                window_source = if (
                     resolved$future_window_years == 17L &&
                         resolved$output_block_years == 9L
                 ) {
-                    "method_literature"
+                    "famien_2018_application"
                 } else {
                     "user_override"
-                }
+                },
+                window_reference = if (
+                    resolved$future_window_years == 17L &&
+                        resolved$output_block_years == 9L
+                ) {
+                    CDFT_FAMIEN_REFERENCE
+                } else {
+                    NA_character_
+                },
+                edge_policy_source = "epwshiftr_implementation"
             ),
             diagnostics = mapped$diagnostics
         )
@@ -824,10 +842,10 @@ cdft__validate_result <- function(value, inputs, key) {
     TRUE
 }
 
-# Construct the reusable daily CDF-t signal with the six published variable
-# alternatives and the package-native three-role contract.
+# Construct the reusable daily CDF-t signal with the six variables used by
+# Famien et al. and the package-native three-role contract.
 cdft__component <- function() {
-    alternatives <- as.list(CDFT_PUBLISHED_VARIABLES)
+    alternatives <- as.list(CDFT_FAMIEN_VARIABLES)
     roles <- c(
         "observed_reference",
         "model_historical",
@@ -865,7 +883,16 @@ cdft__component <- function() {
                 ties = "left_endpoint",
                 tails = "constant_correction"
             ),
-            temporal_policy = "calendar_month_17_year_window_9_year_block"
+            temporal_policy = list(
+                seasonal_grouping = "calendar_month",
+                seasonal_grouping_source = "famien_2018_application",
+                future_window_years = 17L,
+                output_block_years = 9L,
+                window_source = "famien_2018_application",
+                window_reference = CDFT_FAMIEN_REFERENCE,
+                edge_policy = "truncate",
+                edge_policy_source = "epwshiftr_implementation"
+            )
         )
     )
 }

--- a/R/cdf-transform.R
+++ b/R/cdf-transform.R
@@ -1,0 +1,876 @@
+#' @include bias-adjustment.R quantile-distribution.R
+NULL
+
+# CDF-t references separate the original transformation, its empirical daily
+# application, precipitation SSR, and the method authors' maintained R code.
+CDFT_REFERENCES <- c(
+    "https://doi.org/10.1029/2009GL038401",
+    "https://doi.org/10.5194/nhess-12-2769-2012",
+    "https://doi.org/10.1002/2015JD024511",
+    "https://doi.org/10.5194/esd-9-313-2018",
+    "https://CRAN.R-project.org/package=CDFt"
+)
+
+# Famien et al. apply CDF-t directly to these six daily climate variables.
+CDFT_PUBLISHED_VARIABLES <- c(
+    "pr",
+    "tas",
+    "tasmin",
+    "tasmax",
+    "rsds",
+    "sfcWind"
+)
+
+# Vrac et al. use 10^-8 mm/s for the precipitation SSR application. CMIP daily
+# precipitation flux has the numerically equivalent kg m-2 s-1 unit.
+CDFT_PR_SSR_THRESHOLD <- 1e-8
+
+# Construct the complete settings record shared by the published daily
+# profiles. The 17-year fitting window and central 9-year output block follow
+# the daily Africa application, while the empirical-grid choices follow the
+# method authors' R implementation.
+cdft__default_settings <- function(
+  bounds,
+  distribution_model = c("continuous", "precipitation_ssr"),
+  ssr_threshold = 0
+) {
+    distribution_model <- match.arg(distribution_model)
+    list(
+        range_alignment = "additive_mean",
+        seasonal_grouping = "calendar_month",
+        future_window_years = 17L,
+        output_block_years = 9L,
+        edge_policy = "truncate",
+        min_samples = 10L,
+        cdf_method = "empirical_step",
+        inverse_cdf_method = "linear_type_7",
+        tie_method = "left_endpoint",
+        tail_policy = "constant_correction",
+        target_grid_points = 1000L,
+        tail_development_factor = 2,
+        bounds = bounds,
+        distribution_model = distribution_model,
+        ssr_threshold = ssr_threshold,
+        random_seed = 1L
+    )
+}
+
+# Build only literature-supported variable profiles; unlike more generic
+# quantile methods, no unvalidated variable alternatives are added here.
+cdft__profiles <- function() {
+    settings <- list(
+        pr = cdft__default_settings(
+            c(0, Inf),
+            "precipitation_ssr",
+            CDFT_PR_SSR_THRESHOLD
+        ),
+        tas = cdft__default_settings(c(-Inf, Inf)),
+        tasmin = cdft__default_settings(c(-Inf, Inf)),
+        tasmax = cdft__default_settings(c(-Inf, Inf)),
+        rsds = cdft__default_settings(c(0, Inf)),
+        sfcWind = cdft__default_settings(c(0, Inf))
+    )
+    lapply(CDFT_PUBLISHED_VARIABLES, function(variable) {
+        signal__variable_profile(
+            variable,
+            settings = settings[[variable]],
+            evidence = "published",
+            references = CDFT_REFERENCES,
+            metadata = list(
+                method = "cdf_transform",
+                output_role = "model_future",
+                default_source = "method_literature_and_author_implementation",
+                temporal_policy_source = "method_literature"
+            )
+        )
+    })
+}
+
+# Validate every CDF-t numerical convention at the signal-kernel boundary so
+# user overrides cannot silently select an unimplemented empirical variant.
+cdft__settings <- function(settings) {
+    if (length(settings) != 1L ||
+        is.null(names(settings)) ||
+        !nzchar(names(settings)[[1L]]) ||
+        !is.list(settings[[1L]])) {
+        cli::cli_abort(
+            "CDF-t requires settings for exactly one variable."
+        )
+    }
+    resolved <- settings[[1L]]
+    expected <- c(
+        "range_alignment",
+        "seasonal_grouping",
+        "future_window_years",
+        "output_block_years",
+        "edge_policy",
+        "min_samples",
+        "cdf_method",
+        "inverse_cdf_method",
+        "tie_method",
+        "tail_policy",
+        "target_grid_points",
+        "tail_development_factor",
+        "bounds",
+        "distribution_model",
+        "ssr_threshold",
+        "random_seed"
+    )
+    missing <- setdiff(expected, names(resolved))
+    unexpected <- setdiff(names(resolved), expected)
+    if (length(missing) || length(unexpected)) {
+        cli::cli_abort(c(
+            "CDF-t settings must use the complete supported schema.",
+            "x" = "Missing setting(s): {.val {missing}}.",
+            "x" = "Unexpected setting(s): {.val {unexpected}}."
+        ))
+    }
+    if (!identical(resolved$range_alignment, "additive_mean") ||
+        !identical(resolved$seasonal_grouping, "calendar_month") ||
+        !identical(resolved$edge_policy, "truncate") ||
+        !identical(resolved$cdf_method, "empirical_step") ||
+        !identical(resolved$inverse_cdf_method, "linear_type_7") ||
+        !identical(resolved$tie_method, "left_endpoint") ||
+        !identical(resolved$tail_policy, "constant_correction")) {
+        cli::cli_abort(
+            "CDF-t currently requires additive-mean range alignment, native calendar-month grouping, truncated edge windows, empirical step CDFs, type-7 inverse quantiles, left-endpoint target inversion, and constant-correction tails."
+        )
+    }
+    checkmate::assert_integerish(
+        resolved$future_window_years,
+        lower = 1L,
+        len = 1L,
+        any.missing = FALSE
+    )
+    checkmate::assert_integerish(
+        resolved$output_block_years,
+        lower = 1L,
+        len = 1L,
+        any.missing = FALSE
+    )
+    if (resolved$output_block_years > resolved$future_window_years ||
+        (resolved$future_window_years -
+            resolved$output_block_years) %% 2L != 0L) {
+        cli::cli_abort(
+            "`future_window_years` must exceed `output_block_years` by an even, non-negative number of years."
+        )
+    }
+    checkmate::assert_integerish(
+        resolved$min_samples,
+        lower = 2L,
+        len = 1L,
+        any.missing = FALSE
+    )
+    checkmate::assert_integerish(
+        resolved$target_grid_points,
+        lower = 100L,
+        len = 1L,
+        any.missing = FALSE
+    )
+    checkmate::assert_number(
+        resolved$tail_development_factor,
+        lower = 0,
+        finite = TRUE
+    )
+    if (resolved$tail_development_factor <= 0) {
+        cli::cli_abort("`tail_development_factor` must be positive.")
+    }
+    checkmate::assert_numeric(
+        resolved$bounds,
+        len = 2L,
+        any.missing = FALSE
+    )
+    if (resolved$bounds[[1L]] > resolved$bounds[[2L]]) {
+        cli::cli_abort(
+            "CDF-t bounds must be ordered from lower to upper."
+        )
+    }
+    checkmate::assert_choice(
+        resolved$distribution_model,
+        c("continuous", "precipitation_ssr")
+    )
+    checkmate::assert_number(
+        resolved$ssr_threshold,
+        lower = 0,
+        finite = TRUE
+    )
+    if (identical(resolved$distribution_model, "precipitation_ssr") &&
+        resolved$ssr_threshold <= 0) {
+        cli::cli_abort(
+            "Precipitation CDF-t requires a positive `ssr_threshold`."
+        )
+    }
+    if (identical(resolved$distribution_model, "continuous") &&
+        resolved$ssr_threshold != 0) {
+        cli::cli_abort(
+            "Continuous CDF-t requires `ssr_threshold = 0`."
+        )
+    }
+    checkmate::assert_integerish(
+        resolved$random_seed,
+        lower = 0,
+        upper = .Machine$integer.max - 1L,
+        len = 1L,
+        any.missing = FALSE
+    )
+
+    resolved$future_window_years <- as.integer(
+        resolved$future_window_years
+    )
+    resolved$output_block_years <- as.integer(
+        resolved$output_block_years
+    )
+    resolved$min_samples <- as.integer(resolved$min_samples)
+    resolved$target_grid_points <- as.integer(
+        resolved$target_grid_points
+    )
+    resolved$random_seed <- as.integer(resolved$random_seed)
+    resolved
+}
+
+# Validate the three role-addressable daily inputs while retaining every
+# source's native CF calendar and future-model row order.
+cdft__inputs <- function(inputs, variable, distribution_model) {
+    roles <- c(
+        "observed_reference",
+        "model_historical",
+        "model_future"
+    )
+    if (!identical(sort(names(inputs)), sort(roles))) {
+        cli::cli_abort(
+            "CDF-t requires observed, historical-model, and future-model role payloads."
+        )
+    }
+    series <- lapply(roles, function(role) {
+        bias__daily_table(inputs[[role]], role)
+    })
+    names(series) <- roles
+    for (role in roles) {
+        role_variables <- unique(series[[role]][["variable_id"]])
+        if (!identical(role_variables, variable)) {
+            cli::cli_abort(
+                "CDF-t role {.val {role}} must contain only variable {.val {variable}}."
+            )
+        }
+        if (length(unique(series[[role]][["cf_calendar"]])) != 1L) {
+            cli::cli_abort(
+                "CDF-t role {.val {role}} must contain one native calendar per signal group."
+            )
+        }
+    }
+    units <- vapply(
+        series,
+        function(data) unique(data[["units"]]),
+        character(1L)
+    )
+    if (length(unique(units)) != 1L) {
+        cli::cli_abort(
+            "CDF-t inputs for {.val {variable}} must use identical units."
+        )
+    }
+    if (identical(distribution_model, "precipitation_ssr") &&
+        any(vapply(
+            series,
+            function(data) any(data[["value"]] < 0),
+            logical(1L)
+        ))) {
+        cli::cli_abort(
+            "Precipitation CDF-t requires non-negative input values."
+        )
+    }
+    series
+}
+
+# Partition future years into the published disjoint output blocks and their
+# symmetric fitting windows, truncating only where the requested data end.
+cdft__future_blocks <- function(
+  year,
+  future_window_years,
+  output_block_years
+) {
+    checkmate::assert_integerish(
+        year,
+        min.len = 1L,
+        any.missing = FALSE
+    )
+    years <- sort(unique(as.integer(year)))
+    if (length(years) > 1L && any(diff(years) != 1L)) {
+        cli::cli_abort(
+            "CDF-t requires contiguous future model years."
+        )
+    }
+    flank <- (future_window_years - output_block_years) %/% 2L
+    starts <- seq.int(1L, length(years), by = output_block_years)
+    lapply(starts, function(start) {
+        stop <- min(start + output_block_years - 1L, length(years))
+        output_years <- years[start:stop]
+        requested_start <- min(output_years) - flank
+        requested_end <- max(output_years) + flank
+        window_years <- years[
+            years >= requested_start & years <= requested_end
+        ]
+        list(
+            output_years = output_years,
+            window_years = window_years,
+            requested_start = requested_start,
+            requested_end = requested_end,
+            truncated_left = min(window_years) > requested_start,
+            truncated_right = max(window_years) < requested_end
+        )
+    })
+}
+
+# Evaluate the empirical step CDF used by the method authors' implementation.
+cdft__empirical_cdf <- function(sample, values) {
+    checkmate::assert_numeric(
+        sample,
+        min.len = 2L,
+        finite = TRUE,
+        any.missing = FALSE
+    )
+    checkmate::assert_numeric(
+        values,
+        finite = TRUE,
+        any.missing = FALSE
+    )
+    as.numeric(stats::ecdf(sample)(values))
+}
+
+# Extend the lower and upper plateaus of the transformed future CDF by the
+# constant-correction construction in Michelangeli et al. and the authors' R
+# implementation. The reference CDF supplies the added tail shape.
+cdft__extend_target_tails <- function(
+  grid,
+  probability,
+  observed_probability,
+  observed,
+  future
+) {
+    extended <- probability
+    lower_points <- 0L
+    upper_points <- 0L
+
+    if (min(observed) < min(future)) {
+        reference_limit <- quantile__inverse_cdf(
+            observed,
+            extended[[1L]]
+        )
+        reference_index <- which(grid > reference_limit)[[1L]]
+        future_index <- which(grid >= min(future))[[1L]]
+        while (future_index > 0L && reference_index > 0L) {
+            extended[[future_index]] <- observed_probability[[
+                reference_index
+            ]]
+            lower_points <- lower_points + 1L
+            future_index <- future_index - 1L
+            reference_index <- reference_index - 1L
+        }
+        if (future_index > 0L) {
+            extended[seq_len(future_index)] <- 0
+            lower_points <- lower_points + future_index
+        }
+    }
+
+    last <- length(grid)
+    if (extended[[last]] < 1) {
+        reference_limit <- quantile__inverse_cdf(
+            observed,
+            extended[[last]]
+        )
+        below <- which(grid < reference_limit)
+        reference_index <- if (length(below)) {
+            max(below) + 1L
+        } else {
+            1L
+        }
+        non_plateau <- which(extended < extended[[last]])
+        if (!length(non_plateau)) {
+            cli::cli_abort(
+                "CDF-t could not resolve the upper target-CDF plateau; increase `tail_development_factor`."
+            )
+        }
+        future_index <- max(non_plateau)
+        count <- min(last - future_index, last - reference_index)
+        source <- seq.int(reference_index, reference_index + count)
+        target <- seq.int(future_index, future_index + count)
+        extended[target] <- observed_probability[source]
+        upper_points <- length(target)
+        endpoint <- future_index + count
+        if (endpoint < last) {
+            extended[endpoint:last] <- 1
+            upper_points <- upper_points + last - endpoint
+        }
+    }
+
+    # Floating-point and repeated empirical probabilities can introduce tiny
+    # downward steps; a cumulative maximum restores the defining CDF property.
+    monotone <- cummax(pmin(pmax(extended, 0), 1))
+    list(
+        probability = monotone,
+        lower_extended_points = lower_points,
+        upper_extended_points = upper_points,
+        monotonicity_repairs = sum(monotone != extended)
+    )
+}
+
+# Estimate F_Sf(x) = F_Sh(F_Gh^-1(F_Gf(x))) on the explicit empirical grid.
+# Model historical and future values receive the same observed-minus-historical
+# mean shift before the CDFs are fitted, matching the authors' maintained code.
+cdft__target_cdf <- function(
+  observed,
+  historical,
+  future,
+  target_grid_points,
+  tail_development_factor
+) {
+    checkmate::assert_numeric(
+        observed,
+        min.len = 2L,
+        finite = TRUE,
+        any.missing = FALSE
+    )
+    checkmate::assert_numeric(
+        historical,
+        min.len = 2L,
+        finite = TRUE,
+        any.missing = FALSE
+    )
+    checkmate::assert_numeric(
+        future,
+        min.len = 2L,
+        finite = TRUE,
+        any.missing = FALSE
+    )
+    shift <- mean(observed) - mean(historical)
+    historical_aligned <- historical + shift
+    future_aligned <- future + shift
+    development <- tail_development_factor *
+        abs(mean(future) - mean(historical))
+    lower <- min(observed, historical_aligned, future_aligned) -
+        development
+    upper <- max(observed, historical_aligned, future_aligned) +
+        development
+    if (!is.finite(lower) || !is.finite(upper) || lower >= upper) {
+        cli::cli_abort(
+            "CDF-t requires a non-degenerate observed, historical, or future fitting range."
+        )
+    }
+    grid <- seq(lower, upper, length.out = target_grid_points)
+    future_probability <- cdft__empirical_cdf(
+        future_aligned,
+        grid
+    )
+    historical_quantile <- quantile__inverse_cdf(
+        historical_aligned,
+        future_probability
+    )
+    target_probability <- cdft__empirical_cdf(
+        observed,
+        historical_quantile
+    )
+    observed_probability <- cdft__empirical_cdf(observed, grid)
+    tails <- cdft__extend_target_tails(
+        grid,
+        target_probability,
+        observed_probability,
+        observed,
+        future_aligned
+    )
+    if (length(unique(tails$probability)) < 2L) {
+        cli::cli_abort(
+            "CDF-t produced a degenerate future target CDF."
+        )
+    }
+    list(
+        grid = grid,
+        probability = tails$probability,
+        shift = shift,
+        historical_aligned = historical_aligned,
+        future_aligned = future_aligned,
+        diagnostics = list(
+            range_alignment_shift = shift,
+            target_grid_range = range(grid),
+            target_probability_range = range(tails$probability),
+            lower_extended_points = tails$lower_extended_points,
+            upper_extended_points = tails$upper_extended_points,
+            monotonicity_repairs = tails$monotonicity_repairs,
+            tied_observed_values = length(observed) -
+                length(unique(observed)),
+            tied_historical_values = length(historical) -
+                length(unique(historical)),
+            tied_future_values = length(future) -
+                length(unique(future))
+        )
+    )
+}
+
+# Generate the corrected future sequence by quantile matching F_Gf to the
+# transformed target CDF. The future input order is retained unchanged.
+cdft__map_window <- function(observed, historical, future, resolved) {
+    target <- cdft__target_cdf(
+        observed,
+        historical,
+        future,
+        resolved$target_grid_points,
+        resolved$tail_development_factor
+    )
+    future_probability <- cdft__empirical_cdf(
+        target$future_aligned,
+        target$future_aligned
+    )
+    mapped <- stats::approx(
+        x = target$probability,
+        y = target$grid,
+        xout = future_probability,
+        method = "linear",
+        rule = 2,
+        # A CDF quantile is the leftmost x at which the requested probability
+        # is attained; choosing the left endpoint also avoids averaging across
+        # a flat probability-one tail.
+        ties = min
+    )$y
+    list(
+        value = as.numeric(mapped),
+        diagnostics = c(
+            target$diagnostics,
+            list(
+                mapped_probability_range = range(future_probability)
+            )
+        )
+    )
+}
+
+# Replace sub-threshold precipitation singularities once per source role using
+# a reproducible method-local generator, leaving R's global RNG untouched.
+cdft__prepared_values <- function(series, resolved, key, variable) {
+    if (!identical(
+        resolved$distribution_model,
+        "precipitation_ssr"
+    )) {
+        return(list(
+            values = lapply(series, `[[`, "value"),
+            precipitation = NULL
+        ))
+    }
+
+    values <- vector("list", length(series))
+    names(values) <- names(series)
+    randomized <- integer(length(series))
+    names(randomized) <- names(series)
+    seeds <- integer(length(series))
+    names(seeds) <- names(series)
+    for (role in names(series)) {
+        role_key <- c(key, list(input_role = role))
+        seeds[[role]] <- quantile__group_seed(
+            resolved$random_seed,
+            role_key,
+            variable
+        )
+        uniform <- quantile__uniform(nrow(series[[role]]), seeds[[role]])
+        source <- series[[role]][["value"]]
+        singular <- source < resolved$ssr_threshold
+        source[singular] <- uniform[singular] *
+            resolved$ssr_threshold
+        values[[role]] <- source
+        randomized[[role]] <- sum(singular)
+    }
+    list(
+        values = values,
+        precipitation = list(
+            ssr_threshold = resolved$ssr_threshold,
+            input_randomized_values = randomized,
+            random_seed = resolved$random_seed,
+            effective_seeds = seeds,
+            random_generator = "park_miller_16807"
+        )
+    )
+}
+
+# Record one month/block fit without retaining full empirical arrays in result
+# provenance.
+cdft__window_record <- function(
+  month,
+  block,
+  observed_samples,
+  historical_samples,
+  future_samples,
+  output_values,
+  diagnostics
+) {
+    c(
+        list(
+            month = month,
+            output_years = range(block$output_years),
+            fitting_years = range(block$window_years),
+            requested_years = c(
+                block$requested_start,
+                block$requested_end
+            ),
+            truncated_left = block$truncated_left,
+            truncated_right = block$truncated_right,
+            observed_samples = observed_samples,
+            historical_samples = historical_samples,
+            future_samples = future_samples,
+            output_values = output_values
+        ),
+        diagnostics
+    )
+}
+
+# Apply native-calendar monthly CDF-t fits on the published 17/9 year policy.
+# Each future row is written by exactly one output block even though fitting
+# windows overlap.
+cdft__adjust_values <- function(series, resolved, key, variable) {
+    observed <- series$observed_reference
+    historical <- series$model_historical
+    future <- series$model_future
+    prepared <- cdft__prepared_values(
+        series,
+        resolved,
+        key,
+        variable
+    )
+    blocks <- cdft__future_blocks(
+        future[["cf_year"]],
+        resolved$future_window_years,
+        resolved$output_block_years
+    )
+    adjusted <- rep.int(NA_real_, nrow(future))
+    records <- list()
+    record_index <- 0L
+
+    for (block in blocks) {
+        output_year <- future[["cf_year"]] %in% block$output_years
+        months <- sort(unique(future[["cf_month"]][output_year]))
+        for (month in months) {
+            observed_rows <- observed[["cf_month"]] == month
+            historical_rows <- historical[["cf_month"]] == month
+            future_rows <- future[["cf_month"]] == month &
+                future[["cf_year"]] %in% block$window_years
+            output_rows <- which(
+                future[["cf_month"]] == month & output_year
+            )
+            observed_values <- prepared$values$observed_reference[
+                observed_rows
+            ]
+            historical_values <- prepared$values$model_historical[
+                historical_rows
+            ]
+            future_values <- prepared$values$model_future[future_rows]
+            sample_counts <- c(
+                observed = length(observed_values),
+                historical = length(historical_values),
+                future = length(future_values)
+            )
+            if (any(sample_counts < resolved$min_samples)) {
+                cli::cli_abort(
+                    "CDF-t month {month} and output years {min(block$output_years)}-{max(block$output_years)} have fewer than {resolved$min_samples} observed, historical, or future values."
+                )
+            }
+            transformed <- cdft__map_window(
+                observed_values,
+                historical_values,
+                future_values,
+                resolved
+            )
+            if (!is.null(prepared$precipitation)) {
+                recensored <- transformed$value <
+                    resolved$ssr_threshold
+                transformed$value[recensored] <- 0
+                transformed$diagnostics$output_recensored_values <-
+                    sum(recensored)
+            }
+            future_window_rows <- which(future_rows)
+            output_positions <- match(output_rows, future_window_rows)
+            adjusted[output_rows] <- transformed$value[
+                output_positions
+            ]
+            record_index <- record_index + 1L
+            records[[record_index]] <- cdft__window_record(
+                month,
+                block,
+                length(observed_values),
+                length(historical_values),
+                length(future_values),
+                length(output_rows),
+                transformed$diagnostics
+            )
+        }
+    }
+    if (anyNA(adjusted)) {
+        cli::cli_abort(
+            "CDF-t did not assign every future-model daily row exactly once."
+        )
+    }
+    bounded <- pmin(
+        pmax(adjusted, resolved$bounds[[1L]]),
+        resolved$bounds[[2L]]
+    )
+    observed_samples <- vapply(
+        records,
+        `[[`,
+        numeric(1L),
+        "observed_samples"
+    )
+    historical_samples <- vapply(
+        records,
+        `[[`,
+        numeric(1L),
+        "historical_samples"
+    )
+    future_samples <- vapply(
+        records,
+        `[[`,
+        numeric(1L),
+        "future_samples"
+    )
+    diagnostics <- list(
+        window_count = length(records),
+        observed_window_samples = c(
+            minimum = min(observed_samples),
+            median = stats::median(observed_samples),
+            maximum = max(observed_samples)
+        ),
+        historical_window_samples = c(
+            minimum = min(historical_samples),
+            median = stats::median(historical_samples),
+            maximum = max(historical_samples)
+        ),
+        future_window_samples = c(
+            minimum = min(future_samples),
+            median = stats::median(future_samples),
+            maximum = max(future_samples)
+        ),
+        truncated_edge_windows = sum(vapply(
+            records,
+            function(record) {
+                isTRUE(record$truncated_left) ||
+                    isTRUE(record$truncated_right)
+            },
+            logical(1L)
+        )),
+        clipped_values = sum(bounded != adjusted),
+        windows = records
+    )
+    if (!is.null(prepared$precipitation)) {
+        prepared$precipitation$output_dry_values <- sum(bounded == 0)
+        prepared$precipitation$output_positive_below_threshold_values <-
+            sum(
+                bounded > 0 &
+                    bounded < resolved$ssr_threshold
+            )
+        diagnostics$precipitation <- prepared$precipitation
+    }
+    list(value = bounded, diagnostics = diagnostics)
+}
+
+# Execute CDF-t for one aligned univariate signal group and return the common
+# future-backbone DailyAdjustedSeries contract.
+cdft__apply_group <- function(inputs, settings, key) {
+    resolved <- cdft__settings(settings)
+    variable <- names(settings)[[1L]]
+    series <- cdft__inputs(
+        inputs,
+        variable,
+        resolved$distribution_model
+    )
+    mapped <- cdft__adjust_values(
+        series,
+        resolved,
+        key,
+        variable
+    )
+    future <- series$model_future
+    future[["value"]] <- mapped$value
+
+    bias__daily_adjusted_series(
+        future,
+        output_role = "model_future",
+        transformation = "cdf_transform",
+        settings = resolved,
+        provenance = list(
+            method = "cdf_transform",
+            references = CDFT_REFERENCES,
+            group_key = key,
+            output_backbone = "model_future",
+            temporal_policy = list(
+                seasonal_grouping = "calendar_month",
+                future_window_years = resolved$future_window_years,
+                output_block_years = resolved$output_block_years,
+                edge_policy = resolved$edge_policy,
+                source = if (
+                    resolved$future_window_years == 17L &&
+                        resolved$output_block_years == 9L
+                ) {
+                    "method_literature"
+                } else {
+                    "user_override"
+                }
+            ),
+            diagnostics = mapped$diagnostics
+        )
+    )
+}
+
+# Return one explicit diagnostic string when CDF-t violates the package-native
+# future-model output contract.
+cdft__validate_result <- function(value, inputs, key) {
+    if (!S7::S7_inherits(value, DailyAdjustedSeries)) {
+        return("CDF-t must return a DailyAdjustedSeries object.")
+    }
+    if (!identical(value@output_role, "model_future")) {
+        return("CDF-t output must retain the `model_future` role.")
+    }
+    TRUE
+}
+
+# Construct the reusable daily CDF-t signal with the six published variable
+# alternatives and the package-native three-role contract.
+cdft__component <- function() {
+    alternatives <- as.list(CDFT_PUBLISHED_VARIABLES)
+    roles <- c(
+        "observed_reference",
+        "model_historical",
+        "model_future"
+    )
+    requirements <- lapply(roles, function(role) {
+        component__input_requirement(
+            role,
+            representations = "series",
+            frequencies = "day",
+            variable_sets = alternatives
+        )
+    })
+    names(requirements) <- roles
+    signal__component(
+        name = "cdf_transform_daily",
+        label = "Daily CDF-t",
+        required_inputs = requirements,
+        input_kinds = "calendar_indexed_daily_series",
+        output_kinds = "daily_adjusted_series",
+        scopes = "univariate",
+        stochastic = TRUE,
+        profiles = cdft__profiles(),
+        apply_group = cdft__apply_group,
+        operations = list(validate_result = cdft__validate_result),
+        metadata = list(
+            method_family = "future_target_distribution_mapping",
+            output_contract = "daily_adjusted_series",
+            references = CDFT_REFERENCES,
+            reference_implementation = "CRAN CDFt",
+            stochastic_operation = "precipitation_ssr",
+            empirical_conventions = list(
+                cdf = "empirical_step",
+                inverse_cdf = "linear_type_7",
+                ties = "left_endpoint",
+                tails = "constant_correction"
+            ),
+            temporal_policy = "calendar_month_17_year_window_9_year_block"
+        )
+    )
+}
+
+# Register the native CDF-t component during package load.
+cdft__register_component <- function() {
+    component__register(cdft__component(), overwrite = TRUE)
+}

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -18,6 +18,7 @@
     qm__register_component()
     qdm__register_component()
     sdm__register_component()
+    cdft__register_component()
 
     # set package options
     .opts <- list(

--- a/tests/testthat/test-cdf-transform.R
+++ b/tests/testthat/test-cdf-transform.R
@@ -1,0 +1,456 @@
+# Build native-calendar daily rows for CDF-t fixtures without coercing dates
+# through Gregorian base Date semantics.
+cdft_test__series <- function(
+  variable_id,
+  year,
+  values,
+  calendar = "noleap",
+  units = if (identical(variable_id, "pr")) {
+      "kg m-2 s-1"
+  } else {
+      "K"
+  }
+) {
+    origin <- data.frame(
+        year = as.integer(year),
+        month = 1L,
+        day = 1L
+    )
+    fields <- cf_time_offset2date(
+        seq.int(0L, length(values) - 1L),
+        origin,
+        calendar
+    )
+    fields$hour <- 12L
+    fields$minute <- 0L
+    fields$second <- 0
+    data.frame(
+        variable_id = rep.int(variable_id, length(values)),
+        value = as.numeric(values),
+        units = rep.int(units, length(values)),
+        frequency = rep.int("day", length(values)),
+        cf_time__coordinates(fields, calendar),
+        stringsAsFactors = FALSE
+    )
+}
+
+# Construct the package role metadata and aligned signal group used by CDF-t
+# component-execution tests.
+cdft_test__execution_inputs <- function(
+  observed,
+  historical,
+  future,
+  key = list(site = "A")
+) {
+    list(
+        inputs = weather__new_inputs(
+            observed_reference = weather__new_input(
+                "observed_reference",
+                observed
+            ),
+            model_historical = weather__new_input(
+                "model_historical",
+                historical
+            ),
+            model_future = weather__new_input(
+                "model_future",
+                future
+            )
+        ),
+        group = signal__group(
+            key = key,
+            inputs = list(
+                observed_reference = observed,
+                model_historical = historical,
+                model_future = future
+            ),
+            variables = unique(future$variable_id)
+        )
+    )
+}
+
+# Execute compact one-year fixtures through the common signal lifecycle while
+# retaining the method defaults for empirical-CDF and SSR behavior.
+cdft_test__execute <- function(
+  variable,
+  observed,
+  historical,
+  future,
+  overrides = list(),
+  key = list(site = "A")
+) {
+    boundary <- cdft_test__execution_inputs(
+        observed,
+        historical,
+        future,
+        key
+    )
+    settings <- utils::modifyList(
+        list(
+            future_window_years = 1L,
+            output_block_years = 1L,
+            min_samples = 2L
+        ),
+        overrides
+    )
+    component__execute(
+        cdft__component(),
+        "apply",
+        inputs = boundary$inputs,
+        groups = list(boundary$group),
+        overrides = stats::setNames(list(settings), variable),
+        warn_experimental = FALSE
+    )
+}
+
+# Retrieve one complete default profile for direct settings validation.
+cdft_test__settings <- function(variable) {
+    profiles <- cdft__profiles()
+    index <- which(vapply(
+        profiles,
+        function(profile) identical(profile@variable_id, variable),
+        logical(1L)
+    ))
+    profiles[[index]]@settings
+}
+
+test_that("CDF-t constructs the future target CDF from the published chain", {
+    values <- c(1, 2, 4, 7, 11, 16)
+    target <- cdft__target_cdf(
+        values,
+        values,
+        values,
+        target_grid_points = 1000L,
+        tail_development_factor = 2
+    )
+
+    expect_equal(
+        target$probability,
+        cdft__empirical_cdf(values, target$grid)
+    )
+    expect_equal(target$shift, 0)
+    expect_identical(
+        target$diagnostics$lower_extended_points,
+        0L
+    )
+    expect_identical(
+        target$diagnostics$upper_extended_points,
+        0L
+    )
+})
+
+test_that("CDF-t uses published future windows and retained blocks", {
+    blocks <- cdft__future_blocks(
+        2001:2035,
+        future_window_years = 17L,
+        output_block_years = 9L
+    )
+
+    expect_identical(blocks[[1L]]$output_years, 2001:2009)
+    expect_identical(blocks[[1L]]$window_years, 2001:2013)
+    expect_true(blocks[[1L]]$truncated_left)
+    expect_identical(blocks[[2L]]$output_years, 2010:2018)
+    expect_identical(blocks[[2L]]$window_years, 2006:2022)
+    expect_false(blocks[[2L]]$truncated_left)
+    expect_false(blocks[[2L]]$truncated_right)
+    expect_identical(blocks[[4L]]$output_years, 2028:2035)
+    expect_identical(blocks[[4L]]$window_years, 2024:2035)
+    expect_true(blocks[[4L]]$truncated_right)
+    expect_error(
+        cdft__future_blocks(2001:2003 * 2L, 3L, 1L),
+        "contiguous"
+    )
+})
+
+test_that("CDF-t transfers a location bias onto the future-model backbone", {
+    observed <- cdft_test__series("tas", 2001L, 1:20)
+    historical <- cdft_test__series("tas", 1991L, 6:25)
+    future <- cdft_test__series("tas", 2061L, 11:30)
+
+    execution <- cdft_test__execute(
+        "tas",
+        observed,
+        historical,
+        future
+    )
+    adjusted <- execution@values[[1L]]
+    window <- adjusted@provenance$diagnostics$windows[[1L]]
+
+    expect_true(S7::S7_inherits(execution, SignalExecutionResult))
+    expect_true(S7::S7_inherits(adjusted, DailyAdjustedSeries))
+    expect_equal(
+        adjusted@data$value,
+        future$value - 5,
+        tolerance = 1
+    )
+    expect_identical(
+        adjusted@data[BIAS_DAILY_SERIES_COLUMNS[-2L]],
+        future[BIAS_DAILY_SERIES_COLUMNS[-2L]]
+    )
+    expect_identical(adjusted@output_role, "model_future")
+    expect_identical(adjusted@transformation, "cdf_transform")
+    expect_identical(
+        adjusted@provenance$output_backbone,
+        "model_future"
+    )
+    expect_identical(
+        adjusted@provenance$temporal_policy$source,
+        "user_override"
+    )
+    expect_equal(window$range_alignment_shift, -5)
+    expect_identical(execution@diagnostics$status, "ok")
+})
+
+test_that("CDF-t preserves identity across native CF calendars", {
+    calendars <- c("360_day", "noleap", "all_leap")
+    values <- c(1, 3, 2, 5, 4, 8, 7, 6, 10, 9, 12, 11)
+
+    for (calendar in calendars) {
+        observed <- cdft_test__series(
+            "tas",
+            2001L,
+            values,
+            calendar
+        )
+        historical <- cdft_test__series(
+            "tas",
+            1991L,
+            values,
+            calendar
+        )
+        future <- cdft_test__series(
+            "tas",
+            2061L,
+            values,
+            calendar
+        )
+        adjusted <- cdft_test__execute(
+            "tas",
+            observed,
+            historical,
+            future
+        )@values[[1L]]
+
+        expect_equal(
+            adjusted@data$value,
+            future$value,
+            tolerance = 0.02
+        )
+        expect_identical(
+            adjusted@data$cf_calendar,
+            future$cf_calendar
+        )
+    }
+})
+
+test_that("precipitation SSR is deterministic without changing global RNG", {
+    values <- c(0, 0, 0, 2e-7, 3e-7, 4e-7)
+    series <- list(
+        observed_reference = cdft_test__series(
+            "pr",
+            2001L,
+            values
+        ),
+        model_historical = cdft_test__series(
+            "pr",
+            1991L,
+            values
+        ),
+        model_future = cdft_test__series(
+            "pr",
+            2061L,
+            values
+        )
+    )
+    settings <- cdft__settings(list(
+        pr = cdft_test__settings("pr")
+    ))
+    set.seed(2026)
+    seed_before <- .Random.seed
+
+    first <- cdft__prepared_values(
+        series,
+        settings,
+        list(site = "A"),
+        "pr"
+    )
+    second <- cdft__prepared_values(
+        series,
+        settings,
+        list(site = "A"),
+        "pr"
+    )
+
+    expect_identical(.Random.seed, seed_before)
+    expect_identical(first, second)
+    expect_identical(
+        first$precipitation$input_randomized_values,
+        c(
+            observed_reference = 3L,
+            model_historical = 3L,
+            model_future = 3L
+        )
+    )
+    expect_true(all(vapply(
+        first$values,
+        function(value) {
+            all(value > 0) &&
+                all(value[seq_len(3L)] < CDFT_PR_SSR_THRESHOLD)
+        },
+        logical(1L)
+    )))
+})
+
+test_that("precipitation CDF-t restores a strict dry-day singularity", {
+    observed <- cdft_test__series(
+        "pr",
+        2001L,
+        c(rep.int(0, 8L), seq.int(2L, 13L) * 1e-7)
+    )
+    historical <- cdft_test__series(
+        "pr",
+        1991L,
+        c(rep.int(0, 5L), seq.int(2L, 16L) * 1e-7)
+    )
+    future <- cdft_test__series(
+        "pr",
+        2061L,
+        c(rep.int(0, 10L), seq.int(2L, 11L) * 1e-7)
+    )
+    set.seed(2027)
+    seed_before <- .Random.seed
+
+    execution <- cdft_test__execute(
+        "pr",
+        observed,
+        historical,
+        future,
+        overrides = list(min_samples = 5L)
+    )
+    adjusted <- execution@values[[1L]]
+    precipitation <- adjusted@provenance$diagnostics$precipitation
+
+    expect_identical(.Random.seed, seed_before)
+    expect_true(all(
+        adjusted@data$value == 0 |
+            adjusted@data$value >= CDFT_PR_SSR_THRESHOLD
+    ))
+    expect_identical(
+        precipitation$output_positive_below_threshold_values,
+        0L
+    )
+    expect_identical(
+        precipitation$random_generator,
+        "park_miller_16807"
+    )
+    expect_identical(
+        precipitation$ssr_threshold,
+        CDFT_PR_SSR_THRESHOLD
+    )
+})
+
+test_that("CDF-t rejects incompatible settings and invalid inputs", {
+    settings <- cdft_test__settings("tas")
+    invalid <- settings
+    invalid$future_window_years <- 4L
+    invalid$output_block_years <- 1L
+    expect_error(
+        cdft__settings(list(tas = invalid)),
+        "even, non-negative"
+    )
+
+    invalid <- settings
+    invalid$tie_method <- "mean"
+    expect_error(
+        cdft__settings(list(tas = invalid)),
+        "left-endpoint"
+    )
+
+    observed <- cdft_test__series("tas", 2001L, 1:5)
+    historical <- cdft_test__series("tas", 1991L, 1:5)
+    future <- cdft_test__series("tas", 2061L, 1:5)
+    boundary <- cdft_test__execution_inputs(
+        observed,
+        historical,
+        future
+    )
+    expect_error(
+        component__execute(
+            cdft__component(),
+            "apply_group",
+            inputs = boundary$group@inputs,
+            settings = list(tas = settings),
+            key = list()
+        ),
+        "fewer than 10"
+    )
+
+    precipitation <- lapply(
+        boundary$group@inputs,
+        function(data) {
+            data$variable_id <- "pr"
+            data$units <- "kg m-2 s-1"
+            data$value <- abs(data$value) * 1e-7
+            data
+        }
+    )
+    precipitation$model_future$value[[1L]] <- -1
+    expect_error(
+        cdft__inputs(
+            precipitation,
+            "pr",
+            "precipitation_ssr"
+        ),
+        "non-negative"
+    )
+})
+
+test_that("CDF-t profiles retain published evidence and registration", {
+    cdft__register_component()
+    component <- component__get("signal", "cdf_transform_daily")
+    profiles <- component@metadata$signal_profiles
+
+    expect_true(S7::S7_inherits(component, WeatherComponentSpec))
+    expect_identical(component@stage, "signal")
+    expect_identical(
+        component@input_kinds,
+        "calendar_indexed_daily_series"
+    )
+    expect_identical(component@output_kinds, "daily_adjusted_series")
+    expect_identical(component@scopes, "univariate")
+    expect_true(component@stochastic)
+    expect_identical(
+        sort(names(profiles)),
+        sort(CDFT_PUBLISHED_VARIABLES)
+    )
+    expect_true(all(vapply(
+        profiles,
+        function(profile) identical(profile$evidence, "published"),
+        logical(1L)
+    )))
+    expect_identical(
+        profiles$pr$settings$distribution_model,
+        "precipitation_ssr"
+    )
+    expect_identical(
+        profiles$tas$settings$distribution_model,
+        "continuous"
+    )
+
+    calendar <- component__spec(
+        name = "cdft_calendar_test",
+        stage = "calendar",
+        input_kinds = "preprocessed_daily_series",
+        output_kinds = "calendar_indexed_daily_series",
+        operations = list(apply = identity)
+    )
+    sequence <- component__spec(
+        name = "cdft_sequence_test",
+        stage = "sequence",
+        input_kinds = "daily_adjusted_series",
+        output_kinds = "weather_sequence",
+        operations = list(generate = identity)
+    )
+    expect_true(component__compatible(calendar, component))
+    expect_true(component__compatible(component, sequence))
+})

--- a/tests/testthat/test-cdf-transform.R
+++ b/tests/testthat/test-cdf-transform.R
@@ -139,7 +139,7 @@ test_that("CDF-t constructs the future target CDF from the published chain", {
     )
 })
 
-test_that("CDF-t uses published future windows and retained blocks", {
+test_that("CDF-t reproduces the Famien 17/9 schedule and package edges", {
     blocks <- cdft__future_blocks(
         2001:2035,
         future_window_years = 17L,
@@ -194,8 +194,15 @@ test_that("CDF-t transfers a location bias onto the future-model backbone", {
         "model_future"
     )
     expect_identical(
-        adjusted@provenance$temporal_policy$source,
+        adjusted@provenance$temporal_policy$window_source,
         "user_override"
+    )
+    expect_true(is.na(
+        adjusted@provenance$temporal_policy$window_reference
+    ))
+    expect_identical(
+        adjusted@provenance$temporal_policy$edge_policy_source,
+        "epwshiftr_implementation"
     )
     expect_equal(window$range_alignment_shift, -5)
     expect_identical(execution@diagnostics$status, "ok")
@@ -405,7 +412,7 @@ test_that("CDF-t rejects incompatible settings and invalid inputs", {
     )
 })
 
-test_that("CDF-t profiles retain published evidence and registration", {
+test_that("CDF-t profiles separate published and package provenance", {
     cdft__register_component()
     component <- component__get("signal", "cdf_transform_daily")
     profiles <- component@metadata$signal_profiles
@@ -421,7 +428,7 @@ test_that("CDF-t profiles retain published evidence and registration", {
     expect_true(component@stochastic)
     expect_identical(
         sort(names(profiles)),
-        sort(CDFT_PUBLISHED_VARIABLES)
+        sort(CDFT_FAMIEN_VARIABLES)
     )
     expect_true(all(vapply(
         profiles,
@@ -435,6 +442,30 @@ test_that("CDF-t profiles retain published evidence and registration", {
     expect_identical(
         profiles$tas$settings$distribution_model,
         "continuous"
+    )
+    expect_identical(
+        profiles$tas$metadata$temporal_window_source,
+        "famien_2018_application"
+    )
+    expect_identical(
+        profiles$tas$metadata$temporal_window_reference,
+        CDFT_FAMIEN_REFERENCE
+    )
+    expect_identical(
+        profiles$tas$metadata$edge_policy_source,
+        "epwshiftr_implementation"
+    )
+    expect_identical(
+        component@metadata$temporal_policy$window_source,
+        "famien_2018_application"
+    )
+    expect_identical(
+        component@metadata$temporal_policy$window_reference,
+        CDFT_FAMIEN_REFERENCE
+    )
+    expect_identical(
+        component@metadata$temporal_policy$edge_policy_source,
+        "epwshiftr_implementation"
     )
 
     calendar <- component__spec(

--- a/vignettes-raw/articles/epw-morpher.Rmd
+++ b/vignettes-raw/articles/epw-morpher.Rmd
@@ -500,7 +500,7 @@ interpretation. Group failures either abort or return an explicit diagnostic
 with a `NULL` result; they are never silently converted to missing numeric
 values.
 
-Five package-native standalone signals currently use this contract:
+Six package-native standalone signals currently use this contract:
 
 | Registry name | Correction | Output backbone | Variable-profile evidence |
 |:--------------|:-----------|:----------------|:--------------------------|
@@ -509,6 +509,7 @@ Five package-native standalone signals currently use this contract:
 | `quantile_mapping_daily` | \(F^{-1}_{obs}(F_{hist}(x_{future}))\) in calendar-neutral circular daily windows | `model_future` | Published method-variable profiles for `tas` and `pr`; implementation-selected defaults for `hurs`, `psl`, `rlds`, `sfcWind`, `tasmin`, and `tasmax` remain experimental |
 | `quantile_delta_mapping_daily` | Transfer \(x_{future} - F^{-1}_{hist}(p)\) or \(x_{future} / F^{-1}_{hist}(p)\) onto \(F^{-1}_{obs}(p)\), where \(p = F_{future,t}(x_{future})\) | `model_future` | Published absolute-change temperature and relative-change precipitation profiles; implementation-selected defaults for other supported variables remain experimental |
 | `scaled_distribution_mapping_daily` | Parametric distribution and recurrence-interval scaling, absolute for temperature and relative for precipitation | `model_future` | Published profiles for `tas` and `pr`; applying the Normal branch to `tasmin` and `tasmax` remains experimental |
+| `cdf_transform_daily` | Construct \(F_{obs,future}(x) = F_{obs,hist}(F^{-1}_{model,hist}(F_{model,future}(x)))\), then quantile match the future-model sequence to that target CDF | `model_future` | Published daily profiles for `pr`, `tas`, `tasmin`, `tasmax`, `rsds`, and `sfcWind` |
 
 `quantile_mapping_daily` uses linear empirical-CDF interpolation with
 average-rank ties, type-7 inverse quantiles, and endpoint clamping. Its default
@@ -546,6 +547,22 @@ parameters, sample coverage, corrected wet counts, and the method's inability
 to turn additional dry projected days into wet days are explicit in result
 provenance. Native 360-, 365-, and 366-day calendars contribute samples to
 their own calendar months without Gregorian date coercion.
+
+`cdf_transform_daily` differs from both ordinary Quantile Mapping and QDM by
+first estimating a complete future observed-reference CDF from the historical
+observed/model relation and the future-model CDF. The implementation aligns
+the historical and future model samples by the same
+observed-minus-historical-model mean shift used in the method authors' R
+package. It then evaluates the chained empirical CDF on an explicit grid,
+extends unsupported tails through the published constant-correction rule, and
+uses the left endpoint of CDF plateaus as the generalized inverse. Each native
+calendar month is fitted in a 17-year future window and writes only its central
+9-year block, with truncated edge windows recorded explicitly. For
+precipitation, Singularity Stochastic Removal replaces sub-threshold values
+with deterministic uniforms below \(10^{-8}\) kg m-2 s-1 before CDF-t and
+returns adjusted sub-threshold values to zero afterward. The generator and
+effective role-specific seeds are recorded without changing R's global random
+state.
 
 The runner returns `epw_morph_result()` with complete hourly EPW weather data.
 `EpwMorpher$run()` writes that data as Parquet and adds the case metadata

--- a/vignettes-raw/articles/epw-morpher.Rmd
+++ b/vignettes-raw/articles/epw-morpher.Rmd
@@ -555,14 +555,18 @@ the historical and future model samples by the same
 observed-minus-historical-model mean shift used in the method authors' R
 package. It then evaluates the chained empirical CDF on an explicit grid,
 extends unsupported tails through the published constant-correction rule, and
-uses the left endpoint of CDF plateaus as the generalized inverse. Each native
-calendar month is fitted in a 17-year future window and writes only its central
-9-year block, with truncated edge windows recorded explicitly. For
-precipitation, Singularity Stochastic Removal replaces sub-threshold values
-with deterministic uniforms below \(10^{-8}\) kg m-2 s-1 before CDF-t and
-returns adjusted sub-threshold values to zero afterward. The generator and
-effective role-specific seeds are recorded without changing R's global random
-state.
+uses the left endpoint of CDF plateaus as the generalized inverse. Following
+the Famien et al. (2018) daily Africa application, each native calendar month
+is fitted in a 17-year future window and writes only its central 9-year block.
+Those numbers are application defaults rather than requirements of the
+original CDF-t transformation. Famien et al. do not specify how to supply the
+four-year flanks at the start and end of a requested series, so epwshiftr
+truncates unavailable flanks and records this package-selected edge policy
+explicitly. For precipitation, Singularity Stochastic Removal replaces
+sub-threshold values with deterministic uniforms below \(10^{-8}\) kg m-2 s-1
+before CDF-t and returns adjusted sub-threshold values to zero afterward. The
+generator and effective role-specific seeds are recorded without changing R's
+global random state.
 
 The runner returns `epw_morph_result()` with complete hourly EPW weather data.
 `EpwMorpher$run()` writes that data as Parquet and adds the case metadata

--- a/vignettes-raw/precompiled-checksums.csv
+++ b/vignettes-raw/precompiled-checksums.csv
@@ -1,7 +1,7 @@
 "source","output","source_md5","output_md5"
 "vignettes-raw/articles/cli-esgf-store.Rmd","vignettes/articles/cli-esgf-store.Rmd","cac788f79010ad56496939cdde3580bb","e58e5cafa0d3b2218081c25a1098273f"
 "vignettes-raw/articles/downloader.Rmd","vignettes/articles/downloader.Rmd","9668ccb5b39f0ca2f49e146a1a100a7c","4b67e4a9ddaecfe7ce3ac268936e2a2d"
-"vignettes-raw/articles/epw-morpher.Rmd","vignettes/articles/epw-morpher.Rmd","bf110fb60d6e74c85d1ec75cc9277c35","c87b6ade785e6a9b6aac8b11728beb2b"
+"vignettes-raw/articles/epw-morpher.Rmd","vignettes/articles/epw-morpher.Rmd","c263be217d7ee057ae16213bd8f07307","f5f784538f6ea25e3f8b7e53c629c7fd"
 "vignettes-raw/articles/esg-dictionaries.Rmd","vignettes/articles/esg-dictionaries.Rmd","94eb2513975549a6765afa221a2e10c1","290348d35a29e925f1b3732586e54cfb"
 "vignettes-raw/articles/esg-store.Rmd","vignettes/articles/esg-store.Rmd","c2d810261308c837b84c803a0d2632c5","bb73ddac53598a36b049797782ce3c02"
 "vignettes-raw/articles/esgf-query-results.Rmd","vignettes/articles/esgf-query-results.Rmd","9cb7e909ecc499eba79e4295857101d1","20854ab68644b18addeefcef1baafcfa"

--- a/vignettes-raw/precompiled-checksums.csv
+++ b/vignettes-raw/precompiled-checksums.csv
@@ -1,7 +1,7 @@
 "source","output","source_md5","output_md5"
 "vignettes-raw/articles/cli-esgf-store.Rmd","vignettes/articles/cli-esgf-store.Rmd","cac788f79010ad56496939cdde3580bb","e58e5cafa0d3b2218081c25a1098273f"
 "vignettes-raw/articles/downloader.Rmd","vignettes/articles/downloader.Rmd","9668ccb5b39f0ca2f49e146a1a100a7c","4b67e4a9ddaecfe7ce3ac268936e2a2d"
-"vignettes-raw/articles/epw-morpher.Rmd","vignettes/articles/epw-morpher.Rmd","3b9a9583b96d2feb5f1ca70ec44d37eb","d60342448f57bd076a3596855b4f92b7"
+"vignettes-raw/articles/epw-morpher.Rmd","vignettes/articles/epw-morpher.Rmd","bf110fb60d6e74c85d1ec75cc9277c35","c87b6ade785e6a9b6aac8b11728beb2b"
 "vignettes-raw/articles/esg-dictionaries.Rmd","vignettes/articles/esg-dictionaries.Rmd","94eb2513975549a6765afa221a2e10c1","290348d35a29e925f1b3732586e54cfb"
 "vignettes-raw/articles/esg-store.Rmd","vignettes/articles/esg-store.Rmd","c2d810261308c837b84c803a0d2632c5","bb73ddac53598a36b049797782ce3c02"
 "vignettes-raw/articles/esgf-query-results.Rmd","vignettes/articles/esgf-query-results.Rmd","9cb7e909ecc499eba79e4295857101d1","20854ab68644b18addeefcef1baafcfa"

--- a/vignettes/articles/epw-morpher.Rmd
+++ b/vignettes/articles/epw-morpher.Rmd
@@ -508,7 +508,7 @@ interpretation. Group failures either abort or return an explicit diagnostic
 with a `NULL` result; they are never silently converted to missing numeric
 values.
 
-Five package-native standalone signals currently use this contract:
+Six package-native standalone signals currently use this contract:
 
 | Registry name | Correction | Output backbone | Variable-profile evidence |
 |:--------------|:-----------|:----------------|:--------------------------|
@@ -517,6 +517,7 @@ Five package-native standalone signals currently use this contract:
 | `quantile_mapping_daily` | \(F^{-1}_{obs}(F_{hist}(x_{future}))\) in calendar-neutral circular daily windows | `model_future` | Published method-variable profiles for `tas` and `pr`; implementation-selected defaults for `hurs`, `psl`, `rlds`, `sfcWind`, `tasmin`, and `tasmax` remain experimental |
 | `quantile_delta_mapping_daily` | Transfer \(x_{future} - F^{-1}_{hist}(p)\) or \(x_{future} / F^{-1}_{hist}(p)\) onto \(F^{-1}_{obs}(p)\), where \(p = F_{future,t}(x_{future})\) | `model_future` | Published absolute-change temperature and relative-change precipitation profiles; implementation-selected defaults for other supported variables remain experimental |
 | `scaled_distribution_mapping_daily` | Parametric distribution and recurrence-interval scaling, absolute for temperature and relative for precipitation | `model_future` | Published profiles for `tas` and `pr`; applying the Normal branch to `tasmin` and `tasmax` remains experimental |
+| `cdf_transform_daily` | Construct \(F_{obs,future}(x) = F_{obs,hist}(F^{-1}_{model,hist}(F_{model,future}(x)))\), then quantile match the future-model sequence to that target CDF | `model_future` | Published daily profiles for `pr`, `tas`, `tasmin`, `tasmax`, `rsds`, and `sfcWind` |
 
 `quantile_mapping_daily` uses linear empirical-CDF interpolation with
 average-rank ties, type-7 inverse quantiles, and endpoint clamping. Its default
@@ -554,6 +555,22 @@ parameters, sample coverage, corrected wet counts, and the method's inability
 to turn additional dry projected days into wet days are explicit in result
 provenance. Native 360-, 365-, and 366-day calendars contribute samples to
 their own calendar months without Gregorian date coercion.
+
+`cdf_transform_daily` differs from both ordinary Quantile Mapping and QDM by
+first estimating a complete future observed-reference CDF from the historical
+observed/model relation and the future-model CDF. The implementation aligns
+the historical and future model samples by the same
+observed-minus-historical-model mean shift used in the method authors' R
+package. It then evaluates the chained empirical CDF on an explicit grid,
+extends unsupported tails through the published constant-correction rule, and
+uses the left endpoint of CDF plateaus as the generalized inverse. Each native
+calendar month is fitted in a 17-year future window and writes only its central
+9-year block, with truncated edge windows recorded explicitly. For
+precipitation, Singularity Stochastic Removal replaces sub-threshold values
+with deterministic uniforms below \(10^{-8}\) kg m-2 s-1 before CDF-t and
+returns adjusted sub-threshold values to zero afterward. The generator and
+effective role-specific seeds are recorded without changing R's global random
+state.
 
 The runner returns `epw_morph_result()` with complete hourly EPW weather data.
 `EpwMorpher$run()` writes that data as Parquet and adds the case metadata

--- a/vignettes/articles/epw-morpher.Rmd
+++ b/vignettes/articles/epw-morpher.Rmd
@@ -563,14 +563,18 @@ the historical and future model samples by the same
 observed-minus-historical-model mean shift used in the method authors' R
 package. It then evaluates the chained empirical CDF on an explicit grid,
 extends unsupported tails through the published constant-correction rule, and
-uses the left endpoint of CDF plateaus as the generalized inverse. Each native
-calendar month is fitted in a 17-year future window and writes only its central
-9-year block, with truncated edge windows recorded explicitly. For
-precipitation, Singularity Stochastic Removal replaces sub-threshold values
-with deterministic uniforms below \(10^{-8}\) kg m-2 s-1 before CDF-t and
-returns adjusted sub-threshold values to zero afterward. The generator and
-effective role-specific seeds are recorded without changing R's global random
-state.
+uses the left endpoint of CDF plateaus as the generalized inverse. Following
+the Famien et al. (2018) daily Africa application, each native calendar month
+is fitted in a 17-year future window and writes only its central 9-year block.
+Those numbers are application defaults rather than requirements of the
+original CDF-t transformation. Famien et al. do not specify how to supply the
+four-year flanks at the start and end of a requested series, so epwshiftr
+truncates unavailable flanks and records this package-selected edge policy
+explicitly. For precipitation, Singularity Stochastic Removal replaces
+sub-threshold values with deterministic uniforms below \(10^{-8}\) kg m-2 s-1
+before CDF-t and returns adjusted sub-threshold values to zero afterward. The
+generator and effective role-specific seeds are recorded without changing R's
+global random state.
 
 The runner returns `epw_morph_result()` with complete hourly EPW weather data.
 `EpwMorpher$run()` writes that data as Parquet and adds the case metadata


### PR DESCRIPTION
## Summary

Add a package-native daily CDF-t signal that constructs a future target distribution from observed-reference, historical-model, and future-model empirical CDFs while preserving the future-model sequence and CF calendar.

## Changes

- Register `cdf_transform_daily` for the six daily variables used by Famien et al. (2018).
- Apply native calendar-month fits using the Famien et al. (2018) `17`-year fitting window and central `9`-year output block as application defaults.
- Record boundary truncation separately as an epwshiftr implementation policy because the application does not specify how to supply missing four-year flanks.
- Implement additive-mean range alignment, empirical target-CDF construction, constant-correction tails, and explicit diagnostics.
- Implement deterministic precipitation Singularity Stochastic Removal without changing R's global random state.
- Add formula, window, CF-calendar, SSR, settings, profile, provenance, and component-contract tests.
- Update NEWS and the locally precompiled raw vignette with freshness metadata.
- Closes #172
