### PR TITLE
feat: add daily equidistant CDF matching

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -93,6 +93,7 @@ Collate:
     'parametric-distribution.R'
     'quantile-distribution.R'
     'cdf-transform.R'
+    'equidistant-cdf-matching.R'
     'quantile-delta-mapping.R'
     'quantile-mapping.R'
     'solr-date.R'

--- a/NEWS.md
+++ b/NEWS.md
@@ -46,6 +46,19 @@
 
 ## New features
 
+* Added the native R `equidistant_cdf_matching_daily` signal component for
+  `tas` and `pr`. It applies the Li et al. additive equidistant equation using
+  four-parameter Beta temperature distributions and mixed dry-mass/Gamma
+  precipitation distributions. Although the transfer equation is
+  mathematically equivalent to absolute Quantile Delta Mapping, this
+  implementation retains the distributions and range convention of the
+  original method. Because Li et al. applied it to monthly fields, fitting
+  separate distributions from daily values in each native CF-calendar month
+  is recorded and warned about as an experimental epwshiftr adaptation.
+  Results preserve the future-model sequence and record fitted parameters,
+  sample coverage, probability clamping, precipitation dry counts and
+  non-negative clipping, resolved settings, and frequency provenance (#175).
+
 * Added the native R `cdf_transform_daily` signal component. It estimates the
   future target CDF through the CDF-t chain
   \(F_{obs,hist}(F^{-1}_{model,hist}(F_{model,future}(x)))\), then quantile

--- a/R/equidistant-cdf-matching.R
+++ b/R/equidistant-cdf-matching.R
@@ -1,0 +1,875 @@
+#' @include bias-adjustment.R parametric-distribution.R
+NULL
+
+# Equidistant CDF Matching uses the Li et al. monthly method and the Cannon et
+# al. proof that its additive equation is equivalent to absolute QDM.
+EDCDF_REFERENCES <- c(
+    "https://doi.org/10.1029/2009JD012882",
+    "https://doi.org/10.1175/JCLI-D-14-00754.1"
+)
+
+# Li et al. fit their method to monthly temperature and precipitation. The
+# package profiles retain those variables but label daily pooling as adapted.
+EDCDF_LI_VARIABLES <- c("pr", "tas")
+
+# Construct one complete settings record for the fixed Li distribution
+# families and the package-selected native-calendar daily adaptation.
+edcdf__default_settings <- function(
+  bounds,
+  distribution_model = c("beta_four_parameter", "mixed_gamma")
+) {
+    distribution_model <- match.arg(distribution_model)
+    list(
+        mapping = "additive_equidistant",
+        seasonal_grouping = "calendar_month",
+        projection_grouping = "complete_requested_period",
+        distribution_model = distribution_model,
+        range_extension_sd = 0.5,
+        beta_fit_method = "maximum_likelihood_fixed_range",
+        gamma_fit_method = "maximum_likelihood_zero_location",
+        cdf_epsilon = 1e-10,
+        min_samples = 10L,
+        min_positive_samples = 2L,
+        dry_threshold = 0,
+        bounds = bounds,
+        negative_precipitation_policy = "clip_zero",
+        fit_tolerance = 1e-10,
+        fit_max_iterations = 1000L
+    )
+}
+
+# Build conservative daily profiles: the method-variable pairs are published
+# at monthly frequency, while daily calendar-month pooling is a package
+# adaptation and therefore remains visibly experimental.
+edcdf__profiles <- function() {
+    settings <- list(
+        pr = edcdf__default_settings(c(0, Inf), "mixed_gamma"),
+        tas = edcdf__default_settings(
+            c(-Inf, Inf),
+            "beta_four_parameter"
+        )
+    )
+    lapply(EDCDF_LI_VARIABLES, function(variable) {
+        signal__variable_profile(
+            variable,
+            settings = settings[[variable]],
+            evidence = "experimental",
+            references = EDCDF_REFERENCES,
+            metadata = list(
+                method = "equidistant_cdf_matching",
+                output_role = "model_future",
+                method_variable_source = "li_2010_monthly",
+                frequency_source = "epwshiftr_daily_adaptation",
+                equation_equivalence =
+                    "absolute_quantile_delta_mapping"
+            )
+        )
+    })
+}
+
+# Validate the complete numerical policy at the method boundary so a user
+# override cannot silently select a distribution or temporal variant that the
+# native kernel does not implement.
+edcdf__settings <- function(settings) {
+    if (length(settings) != 1L ||
+        is.null(names(settings)) ||
+        !nzchar(names(settings)[[1L]]) ||
+        !is.list(settings[[1L]])) {
+        cli::cli_abort(
+            "Equidistant CDF Matching requires settings for exactly one variable."
+        )
+    }
+    resolved <- settings[[1L]]
+    expected <- c(
+        "mapping",
+        "seasonal_grouping",
+        "projection_grouping",
+        "distribution_model",
+        "range_extension_sd",
+        "beta_fit_method",
+        "gamma_fit_method",
+        "cdf_epsilon",
+        "min_samples",
+        "min_positive_samples",
+        "dry_threshold",
+        "bounds",
+        "negative_precipitation_policy",
+        "fit_tolerance",
+        "fit_max_iterations"
+    )
+    missing <- setdiff(expected, names(resolved))
+    unexpected <- setdiff(names(resolved), expected)
+    if (length(missing) || length(unexpected)) {
+        cli::cli_abort(c(
+            "Equidistant CDF Matching settings must use the complete supported schema.",
+            "x" = "Missing setting(s): {.val {missing}}.",
+            "x" = "Unexpected setting(s): {.val {unexpected}}."
+        ))
+    }
+    if (!identical(resolved$mapping, "additive_equidistant") ||
+        !identical(resolved$seasonal_grouping, "calendar_month") ||
+        !identical(
+            resolved$projection_grouping,
+            "complete_requested_period"
+        ) ||
+        !identical(
+            resolved$beta_fit_method,
+            "maximum_likelihood_fixed_range"
+        ) ||
+        !identical(
+            resolved$gamma_fit_method,
+            "maximum_likelihood_zero_location"
+        ) ||
+        !identical(
+            resolved$negative_precipitation_policy,
+            "clip_zero"
+        )) {
+        cli::cli_abort(
+            "Equidistant CDF Matching currently requires the additive Li equation, native calendar-month pooling, complete requested projection periods, fixed-range Beta maximum likelihood, zero-location Gamma maximum likelihood, and zero clipping for negative precipitation."
+        )
+    }
+    checkmate::assert_choice(
+        resolved$distribution_model,
+        c("beta_four_parameter", "mixed_gamma")
+    )
+    checkmate::assert_number(
+        resolved$range_extension_sd,
+        lower = 0,
+        finite = TRUE
+    )
+    if (resolved$range_extension_sd <= 0) {
+        cli::cli_abort("`range_extension_sd` must be positive.")
+    }
+    checkmate::assert_number(
+        resolved$cdf_epsilon,
+        lower = 0,
+        upper = 0.5,
+        finite = TRUE
+    )
+    if (resolved$cdf_epsilon <= 0 ||
+        resolved$cdf_epsilon >= 0.5) {
+        cli::cli_abort(
+            "`cdf_epsilon` must lie strictly between zero and 0.5."
+        )
+    }
+    checkmate::assert_integerish(
+        resolved$min_samples,
+        lower = 2L,
+        len = 1L,
+        any.missing = FALSE
+    )
+    checkmate::assert_integerish(
+        resolved$min_positive_samples,
+        lower = 2L,
+        len = 1L,
+        any.missing = FALSE
+    )
+    checkmate::assert_number(
+        resolved$dry_threshold,
+        lower = 0,
+        finite = TRUE
+    )
+    checkmate::assert_numeric(
+        resolved$bounds,
+        len = 2L,
+        any.missing = FALSE
+    )
+    if (resolved$bounds[[1L]] > resolved$bounds[[2L]]) {
+        cli::cli_abort(
+            "Equidistant CDF Matching bounds must be ordered."
+        )
+    }
+    checkmate::assert_number(
+        resolved$fit_tolerance,
+        lower = 0,
+        finite = TRUE
+    )
+    if (resolved$fit_tolerance <= 0) {
+        cli::cli_abort("`fit_tolerance` must be positive.")
+    }
+    checkmate::assert_integerish(
+        resolved$fit_max_iterations,
+        lower = 1L,
+        len = 1L,
+        any.missing = FALSE
+    )
+    if (identical(
+        resolved$distribution_model,
+        "beta_four_parameter"
+    ) && resolved$dry_threshold != 0) {
+        cli::cli_abort(
+            "Temperature Equidistant CDF Matching requires `dry_threshold = 0`."
+        )
+    }
+
+    resolved$min_samples <- as.integer(resolved$min_samples)
+    resolved$min_positive_samples <- as.integer(
+        resolved$min_positive_samples
+    )
+    resolved$fit_max_iterations <- as.integer(
+        resolved$fit_max_iterations
+    )
+    resolved
+}
+
+# Resolve and validate the three role-addressable daily series without
+# coercing their native CF calendars to Gregorian dates.
+edcdf__inputs <- function(inputs, variable, distribution_model) {
+    roles <- c(
+        "observed_reference",
+        "model_historical",
+        "model_future"
+    )
+    if (!is.list(inputs) || !all(roles %in% names(inputs))) {
+        cli::cli_abort(
+            "Equidistant CDF Matching requires observed, historical-model, and future-model role payloads."
+        )
+    }
+    series <- lapply(roles, function(role) {
+        bias__daily_table(inputs[[role]], role)
+    })
+    names(series) <- roles
+    for (role in roles) {
+        role_variables <- unique(series[[role]][["variable_id"]])
+        if (!identical(role_variables, variable)) {
+            cli::cli_abort(
+                "Equidistant CDF Matching role {.val {role}} must contain only variable {.val {variable}}."
+            )
+        }
+        if (length(unique(series[[role]][["cf_calendar"]])) != 1L) {
+            cli::cli_abort(
+                "Equidistant CDF Matching role {.val {role}} must contain one native calendar per signal group."
+            )
+        }
+    }
+    units <- vapply(
+        series,
+        function(data) unique(data[["units"]]),
+        character(1L)
+    )
+    if (length(unique(units)) != 1L) {
+        cli::cli_abort(
+            "Equidistant CDF Matching inputs for {.val {variable}} must use identical units."
+        )
+    }
+    if (identical(distribution_model, "mixed_gamma") &&
+        any(vapply(
+            series,
+            function(data) any(data[["value"]] < 0),
+            logical(1L)
+        ))) {
+        cli::cli_abort(
+            "Mixed-Gamma Equidistant CDF Matching requires non-negative input values."
+        )
+    }
+    series
+}
+
+# Validate the method-local four-parameter Beta or mixed-Gamma fit record
+# before evaluating its CDF or generalized inverse.
+edcdf__validate_fit <- function(fit) {
+    required <- c(
+        "family",
+        "parameters",
+        "sample_size",
+        "method",
+        "log_likelihood"
+    )
+    if (!is.list(fit) || !all(required %in% names(fit))) {
+        cli::cli_abort(
+            "An Equidistant CDF Matching fit must contain its family, parameters, sample size, method, and log likelihood."
+        )
+    }
+    checkmate::assert_choice(
+        fit$family,
+        c("beta_four_parameter", "mixed_gamma")
+    )
+    checkmate::assert_list(fit$parameters, names = "unique")
+    checkmate::assert_count(fit$sample_size, positive = TRUE)
+    checkmate::assert_string(fit$method, min.chars = 1L)
+    checkmate::assert_number(fit$log_likelihood, finite = TRUE)
+    if (identical(fit$family, "beta_four_parameter")) {
+        expected <- c("lower", "shape1", "shape2", "upper")
+        if (!identical(sort(names(fit$parameters)), sort(expected))) {
+            cli::cli_abort(
+                "A four-parameter Beta fit requires lower, upper, shape1, and shape2 parameters."
+            )
+        }
+        if (fit$parameters$lower >= fit$parameters$upper ||
+            fit$parameters$shape1 <= 0 ||
+            fit$parameters$shape2 <= 0) {
+            cli::cli_abort(
+                "A four-parameter Beta fit requires ordered bounds and positive shapes."
+            )
+        }
+        return(invisible(TRUE))
+    }
+    expected <- c(
+        "dry_probability",
+        "dry_threshold",
+        "scale",
+        "shape",
+        "wet_probability"
+    )
+    if (!identical(sort(names(fit$parameters)), sort(expected))) {
+        cli::cli_abort(
+            "A mixed-Gamma fit requires dry and wet probabilities, dry threshold, shape, and scale."
+        )
+    }
+    if (fit$parameters$dry_probability < 0 ||
+        fit$parameters$wet_probability <= 0 ||
+        abs(
+            fit$parameters$dry_probability +
+                fit$parameters$wet_probability - 1
+        ) > sqrt(.Machine$double.eps) ||
+        fit$parameters$shape <= 0 ||
+        fit$parameters$scale <= 0) {
+        cli::cli_abort(
+            "A mixed-Gamma fit requires valid mixture probabilities and positive Gamma parameters."
+        )
+    }
+    invisible(TRUE)
+}
+
+# Fit the Li et al. four-parameter Beta distribution. The range endpoints are
+# fixed at the sample extrema plus or minus one-half standard deviation by
+# default, then the two shape parameters are estimated by maximum likelihood.
+edcdf__fit_beta4 <- function(
+  values,
+  range_extension_sd,
+  tolerance,
+  max_iterations
+) {
+    checkmate::assert_numeric(
+        values,
+        min.len = 2L,
+        finite = TRUE,
+        any.missing = FALSE
+    )
+    spread <- stats::sd(values)
+    if (!is.finite(spread) || spread <= 0) {
+        cli::cli_abort(
+            "A four-parameter Beta distribution cannot be fitted to a constant sample."
+        )
+    }
+    lower <- min(values) - range_extension_sd * spread
+    upper <- max(values) + range_extension_sd * spread
+    scaled <- (values - lower) / (upper - lower)
+    scaled_mean <- mean(scaled)
+    scaled_variance <- stats::var(scaled)
+    concentration <- (
+        scaled_mean * (1 - scaled_mean) / scaled_variance
+    ) - 1
+    if (!is.finite(concentration) || concentration <= 0) {
+        initial_shape <- c(1, 1)
+    } else {
+        initial_shape <- c(
+            scaled_mean * concentration,
+            (1 - scaled_mean) * concentration
+        )
+    }
+    initial_shape <- pmin(pmax(initial_shape, 1e-3), 1e3)
+
+    # Optimizing log-shapes guarantees positive parameters without changing
+    # the fixed range selected from the publication.
+    objective <- function(log_shape) {
+        shape <- exp(log_shape)
+        value <- -sum(stats::dbeta(
+            scaled,
+            shape1 = shape[[1L]],
+            shape2 = shape[[2L]],
+            log = TRUE
+        ))
+        if (is.finite(value)) value else .Machine$double.xmax
+    }
+    optimization <- stats::optim(
+        par = log(initial_shape),
+        fn = objective,
+        method = "L-BFGS-B",
+        lower = log(c(1e-6, 1e-6)),
+        upper = log(c(1e6, 1e6)),
+        control = list(
+            factr = max(
+                1,
+                tolerance / .Machine$double.eps
+            ),
+            maxit = max_iterations
+        )
+    )
+    if (optimization$convergence != 0L ||
+        !is.finite(optimization$value)) {
+        cli::cli_abort(
+            "Four-parameter Beta maximum-likelihood fitting did not converge."
+        )
+    }
+    shape <- exp(optimization$par)
+    fit <- list(
+        family = "beta_four_parameter",
+        parameters = list(
+            lower = lower,
+            upper = upper,
+            shape1 = shape[[1L]],
+            shape2 = shape[[2L]]
+        ),
+        sample_size = length(values),
+        method = "maximum_likelihood_fixed_range",
+        log_likelihood = -optimization$value -
+            length(values) * log(upper - lower)
+    )
+    edcdf__validate_fit(fit)
+    fit
+}
+
+# Fit the Li et al. precipitation mixture: an empirical point mass for dry
+# values and a zero-location Gamma maximum-likelihood fit for wet amounts.
+edcdf__fit_mixed_gamma <- function(
+  values,
+  dry_threshold,
+  min_positive_samples,
+  tolerance,
+  max_iterations
+) {
+    checkmate::assert_numeric(
+        values,
+        min.len = 2L,
+        lower = 0,
+        finite = TRUE,
+        any.missing = FALSE
+    )
+    wet <- values > dry_threshold
+    positive <- values[wet]
+    if (length(positive) < min_positive_samples) {
+        cli::cli_abort(
+            "Mixed-Gamma fitting requires at least {min_positive_samples} positive values above the dry threshold."
+        )
+    }
+    gamma <- distribution__fit_gamma(
+        positive,
+        tolerance = tolerance,
+        max_iterations = max_iterations
+    )
+    dry_probability <- mean(!wet)
+    wet_probability <- 1 - dry_probability
+    dry_log_likelihood <- if (any(!wet)) {
+        sum(!wet) * log(dry_probability)
+    } else {
+        0
+    }
+    wet_log_likelihood <- length(positive) * log(wet_probability) +
+        sum(stats::dgamma(
+            positive,
+            shape = gamma$parameters$shape,
+            scale = gamma$parameters$scale,
+            log = TRUE
+        ))
+    fit <- list(
+        family = "mixed_gamma",
+        parameters = list(
+            dry_probability = dry_probability,
+            wet_probability = wet_probability,
+            dry_threshold = dry_threshold,
+            shape = gamma$parameters$shape,
+            scale = gamma$parameters$scale
+        ),
+        sample_size = length(values),
+        positive_sample_size = length(positive),
+        method = "point_mass_and_maximum_likelihood_zero_location",
+        log_likelihood = dry_log_likelihood + wet_log_likelihood
+    )
+    edcdf__validate_fit(fit)
+    fit
+}
+
+# Dispatch the two publication-backed distribution families while retaining
+# their method-specific fitting conventions.
+edcdf__fit_distribution <- function(values, resolved) {
+    if (identical(
+        resolved$distribution_model,
+        "beta_four_parameter"
+    )) {
+        return(edcdf__fit_beta4(
+            values,
+            resolved$range_extension_sd,
+            resolved$fit_tolerance,
+            resolved$fit_max_iterations
+        ))
+    }
+    edcdf__fit_mixed_gamma(
+        values,
+        resolved$dry_threshold,
+        resolved$min_positive_samples,
+        resolved$fit_tolerance,
+        resolved$fit_max_iterations
+    )
+}
+
+# Evaluate the fitted future distribution at projected values using either the
+# bounded Beta CDF or the dry-point-mass plus Gamma CDF.
+edcdf__cdf <- function(fit, values) {
+    edcdf__validate_fit(fit)
+    checkmate::assert_numeric(
+        values,
+        finite = TRUE,
+        any.missing = FALSE
+    )
+    parameters <- fit$parameters
+    if (identical(fit$family, "beta_four_parameter")) {
+        scaled <- (values - parameters$lower) /
+            (parameters$upper - parameters$lower)
+        return(stats::pbeta(
+            pmin(pmax(scaled, 0), 1),
+            shape1 = parameters$shape1,
+            shape2 = parameters$shape2
+        ))
+    }
+    probability <- rep.int(
+        parameters$dry_probability,
+        length(values)
+    )
+    wet <- values > parameters$dry_threshold
+    probability[wet] <- parameters$dry_probability +
+        parameters$wet_probability * stats::pgamma(
+            values[wet],
+            shape = parameters$shape,
+            scale = parameters$scale
+        )
+    probability
+}
+
+# Evaluate the generalized inverse for a four-parameter Beta or mixed-Gamma
+# fit. Probabilities inside the dry point mass map deterministically to zero.
+edcdf__quantile <- function(fit, probability) {
+    edcdf__validate_fit(fit)
+    checkmate::assert_numeric(
+        probability,
+        lower = 0,
+        upper = 1,
+        finite = TRUE,
+        any.missing = FALSE
+    )
+    parameters <- fit$parameters
+    if (identical(fit$family, "beta_four_parameter")) {
+        return(
+            parameters$lower +
+                (parameters$upper - parameters$lower) *
+                    stats::qbeta(
+                        probability,
+                        shape1 = parameters$shape1,
+                        shape2 = parameters$shape2
+                    )
+        )
+    }
+    value <- numeric(length(probability))
+    wet <- probability > parameters$dry_probability
+    conditional_probability <- (
+        probability[wet] - parameters$dry_probability
+    ) / parameters$wet_probability
+    value[wet] <- stats::qgamma(
+        pmin(pmax(conditional_probability, 0), 1),
+        shape = parameters$shape,
+        scale = parameters$scale
+    )
+    value
+}
+
+# Replace values at or below the declared dry threshold with the point-mass
+# value before fitting, recording role-specific occurrence counts.
+edcdf__prepared_values <- function(series, resolved) {
+    values <- lapply(series, function(data) data[["value"]])
+    if (!identical(resolved$distribution_model, "mixed_gamma")) {
+        return(list(values = values, precipitation = NULL))
+    }
+    dry_counts <- vapply(
+        values,
+        function(value) sum(value <= resolved$dry_threshold),
+        integer(1L)
+    )
+    values <- lapply(values, function(value) {
+        value[value <= resolved$dry_threshold] <- 0
+        value
+    })
+    list(
+        values = values,
+        precipitation = list(
+            dry_threshold = resolved$dry_threshold,
+            input_dry_values = dry_counts
+        )
+    )
+}
+
+# Apply the Li additive equation
+# x_adjusted = x_future + Q_observed(p) - Q_historical(p),
+# where p is the fitted future-model probability.
+edcdf__map_values <- function(
+  observed,
+  historical,
+  future,
+  resolved
+) {
+    fit_observed <- edcdf__fit_distribution(observed, resolved)
+    fit_historical <- edcdf__fit_distribution(
+        historical,
+        resolved
+    )
+    fit_future <- edcdf__fit_distribution(future, resolved)
+    raw_probability <- edcdf__cdf(fit_future, future)
+    probability <- distribution__clamp_probability(
+        raw_probability,
+        resolved$cdf_epsilon
+    )
+    observed_quantile <- edcdf__quantile(
+        fit_observed,
+        probability
+    )
+    historical_quantile <- edcdf__quantile(
+        fit_historical,
+        probability
+    )
+    correction <- observed_quantile - historical_quantile
+    list(
+        value = future + correction,
+        fits = list(
+            observed_reference = fit_observed,
+            model_historical = fit_historical,
+            model_future = fit_future
+        ),
+        diagnostics = list(
+            probability_range = range(probability),
+            probability_clamped_values = sum(
+                probability != raw_probability
+            ),
+            observed_quantile_range = range(observed_quantile),
+            historical_quantile_range = range(historical_quantile),
+            correction_range = range(correction)
+        )
+    )
+}
+
+# Convert one native calendar-month adjustment into inspectable provenance
+# without retaining the full intermediate daily arrays.
+edcdf__month_record <- function(
+  month,
+  observed,
+  historical,
+  future,
+  mapped
+) {
+    c(
+        list(
+            month = as.integer(month),
+            observed_samples = nrow(observed),
+            historical_samples = nrow(historical),
+            future_samples = nrow(future),
+            observed_years = range(observed[["cf_year"]]),
+            historical_years = range(historical[["cf_year"]]),
+            future_years = range(future[["cf_year"]]),
+            fits = mapped$fits
+        ),
+        mapped$diagnostics
+    )
+}
+
+# Fit and apply one distribution triplet per native calendar month. This is an
+# explicit daily adaptation of the publication's separate monthly fields.
+edcdf__adjust_values <- function(series, resolved) {
+    prepared <- edcdf__prepared_values(series, resolved)
+    observed <- series$observed_reference
+    historical <- series$model_historical
+    future <- series$model_future
+    adjusted <- rep.int(NA_real_, nrow(future))
+    records <- list()
+    months <- sort(unique(future[["cf_month"]]))
+
+    for (record_index in seq_along(months)) {
+        month <- months[[record_index]]
+        observed_rows <- observed[["cf_month"]] == month
+        historical_rows <- historical[["cf_month"]] == month
+        future_rows <- future[["cf_month"]] == month
+        sample_counts <- c(
+            observed = sum(observed_rows),
+            historical = sum(historical_rows),
+            future = sum(future_rows)
+        )
+        if (any(sample_counts < resolved$min_samples)) {
+            cli::cli_abort(
+                "Equidistant CDF Matching month {month} has fewer than {resolved$min_samples} observed, historical, or future daily values."
+            )
+        }
+        mapped <- edcdf__map_values(
+            prepared$values$observed_reference[observed_rows],
+            prepared$values$model_historical[historical_rows],
+            prepared$values$model_future[future_rows],
+            resolved
+        )
+        adjusted[future_rows] <- mapped$value
+        records[[record_index]] <- edcdf__month_record(
+            month,
+            observed[observed_rows, , drop = FALSE],
+            historical[historical_rows, , drop = FALSE],
+            future[future_rows, , drop = FALSE],
+            mapped
+        )
+    }
+    if (anyNA(adjusted)) {
+        cli::cli_abort(
+            "Equidistant CDF Matching did not assign every future-model daily row exactly once."
+        )
+    }
+
+    precipitation <- prepared$precipitation
+    if (!is.null(precipitation)) {
+        precipitation$negative_before_clipping <- sum(adjusted < 0)
+        recensored <- adjusted <= resolved$dry_threshold
+        adjusted[recensored] <- 0
+        precipitation$output_dry_values <- sum(recensored)
+    }
+    bounded <- pmin(
+        pmax(adjusted, resolved$bounds[[1L]]),
+        resolved$bounds[[2L]]
+    )
+    diagnostics <- list(
+        month_count = length(records),
+        observed_month_samples = c(
+            minimum = min(vapply(
+                records,
+                function(record) record$observed_samples,
+                integer(1L)
+            )),
+            maximum = max(vapply(
+                records,
+                function(record) record$observed_samples,
+                integer(1L)
+            ))
+        ),
+        historical_month_samples = c(
+            minimum = min(vapply(
+                records,
+                function(record) record$historical_samples,
+                integer(1L)
+            )),
+            maximum = max(vapply(
+                records,
+                function(record) record$historical_samples,
+                integer(1L)
+            ))
+        ),
+        future_month_samples = c(
+            minimum = min(vapply(
+                records,
+                function(record) record$future_samples,
+                integer(1L)
+            )),
+            maximum = max(vapply(
+                records,
+                function(record) record$future_samples,
+                integer(1L)
+            ))
+        ),
+        clipped_values = sum(bounded != adjusted),
+        months = records
+    )
+    if (!is.null(precipitation)) {
+        diagnostics$precipitation <- precipitation
+    }
+    list(value = bounded, diagnostics = diagnostics)
+}
+
+# Execute one univariate Equidistant CDF Matching group and return the common
+# future-backbone DailyAdjustedSeries contract.
+edcdf__apply_group <- function(inputs, settings, key) {
+    resolved <- edcdf__settings(settings)
+    variable <- names(settings)[[1L]]
+    series <- edcdf__inputs(
+        inputs,
+        variable,
+        resolved$distribution_model
+    )
+    mapped <- edcdf__adjust_values(series, resolved)
+    future <- series$model_future
+    future[["value"]] <- mapped$value
+
+    bias__daily_adjusted_series(
+        future,
+        output_role = "model_future",
+        transformation = "equidistant_cdf_matching",
+        settings = resolved,
+        provenance = list(
+            method = "equidistant_cdf_matching",
+            references = EDCDF_REFERENCES,
+            group_key = key,
+            output_backbone = "model_future",
+            published_frequency = "mon",
+            adapted_frequency = "day",
+            frequency_source = "epwshiftr_daily_adaptation",
+            seasonal_grouping = "native_calendar_month",
+            equation_equivalence =
+                "absolute_quantile_delta_mapping",
+            diagnostics = mapped$diagnostics
+        )
+    )
+}
+
+# Return an explicit diagnostic if the method violates the common
+# future-model output contract.
+edcdf__validate_result <- function(value, inputs, key) {
+    if (!S7::S7_inherits(value, DailyAdjustedSeries)) {
+        return(
+            "Equidistant CDF Matching must return a DailyAdjustedSeries object."
+        )
+    }
+    if (!identical(value@output_role, "model_future")) {
+        return(
+            "Equidistant CDF Matching output must retain the `model_future` role."
+        )
+    }
+    TRUE
+}
+
+# Construct the package-native daily signal with only the Li temperature and
+# precipitation variable alternatives.
+edcdf__component <- function() {
+    alternatives <- as.list(EDCDF_LI_VARIABLES)
+    roles <- c(
+        "observed_reference",
+        "model_historical",
+        "model_future"
+    )
+    requirements <- lapply(roles, function(role) {
+        component__input_requirement(
+            role,
+            representations = "series",
+            frequencies = "day",
+            variable_sets = alternatives
+        )
+    })
+    names(requirements) <- roles
+    signal__component(
+        name = "equidistant_cdf_matching_daily",
+        label = "Daily Equidistant CDF Matching",
+        required_inputs = requirements,
+        input_kinds = "calendar_indexed_daily_series",
+        output_kinds = "daily_adjusted_series",
+        scopes = "univariate",
+        stochastic = FALSE,
+        profiles = edcdf__profiles(),
+        apply_group = edcdf__apply_group,
+        operations = list(validate_result = edcdf__validate_result),
+        metadata = list(
+            method_family = "parametric_quantile_mapping",
+            published_frequency = "mon",
+            adapted_frequency = "day",
+            daily_adaptation = "native_calendar_month_pooling",
+            equation_equivalence =
+                "absolute_quantile_delta_mapping",
+            distributions = list(
+                tas = "beta_four_parameter",
+                pr = "mixed_gamma"
+            )
+        )
+    )
+}
+
+# Register the daily Equidistant CDF Matching signal during package load.
+edcdf__register_component <- function() {
+    component__register(edcdf__component(), overwrite = TRUE)
+}

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -19,6 +19,7 @@
     qdm__register_component()
     sdm__register_component()
     cdft__register_component()
+    edcdf__register_component()
 
     # set package options
     .opts <- list(

--- a/tests/testthat/test-equidistant-cdf-matching.R
+++ b/tests/testthat/test-equidistant-cdf-matching.R
@@ -1,0 +1,518 @@
+# Build native-calendar daily rows for Equidistant CDF Matching fixtures
+# without coercing 360-, 365-, or 366-day coordinates through base Date.
+edcdf_test__series <- function(
+  variable_id,
+  year,
+  values,
+  calendar = "noleap",
+  units = if (identical(variable_id, "pr")) {
+      "kg m-2 s-1"
+  } else {
+      "K"
+  }
+) {
+    origin <- data.frame(
+        year = as.integer(year),
+        month = 1L,
+        day = 1L
+    )
+    fields <- cf_time_offset2date(
+        seq.int(0L, length(values) - 1L),
+        origin,
+        calendar
+    )
+    fields$hour <- 12L
+    fields$minute <- 0L
+    fields$second <- 0
+    data.frame(
+        variable_id = rep.int(variable_id, length(values)),
+        value = as.numeric(values),
+        units = rep.int(units, length(values)),
+        frequency = rep.int("day", length(values)),
+        cf_time__coordinates(fields, calendar),
+        stringsAsFactors = FALSE
+    )
+}
+
+# Construct the package role metadata and one aligned signal group used by
+# component lifecycle tests.
+edcdf_test__execution_inputs <- function(
+  observed,
+  historical,
+  future,
+  key = list(site = "A")
+) {
+    list(
+        inputs = weather__new_inputs(
+            observed_reference = weather__new_input(
+                "observed_reference",
+                observed
+            ),
+            model_historical = weather__new_input(
+                "model_historical",
+                historical
+            ),
+            model_future = weather__new_input(
+                "model_future",
+                future
+            )
+        ),
+        group = signal__group(
+            key = key,
+            inputs = list(
+                observed_reference = observed,
+                model_historical = historical,
+                model_future = future
+            ),
+            variables = unique(future$variable_id)
+        )
+    )
+}
+
+# Execute compact fixtures with reduced sample thresholds while retaining all
+# published distribution and package-adaptation settings.
+edcdf_test__execute <- function(
+  variable,
+  observed,
+  historical,
+  future,
+  overrides = list(),
+  key = list(site = "A"),
+  warn_experimental = FALSE
+) {
+    boundary <- edcdf_test__execution_inputs(
+        observed,
+        historical,
+        future,
+        key
+    )
+    settings <- utils::modifyList(
+        list(
+            min_samples = 2L,
+            min_positive_samples = 2L
+        ),
+        overrides
+    )
+    component__execute(
+        edcdf__component(),
+        "apply",
+        inputs = boundary$inputs,
+        groups = list(boundary$group),
+        overrides = stats::setNames(list(settings), variable),
+        warn_experimental = warn_experimental
+    )
+}
+
+# Retrieve one complete default profile for direct settings validation.
+edcdf_test__settings <- function(variable) {
+    profiles <- edcdf__profiles()
+    index <- which(vapply(
+        profiles,
+        function(profile) identical(profile@variable_id, variable),
+        logical(1L)
+    ))
+    profiles[[index]]@settings
+}
+
+test_that("four-parameter Beta fit uses the Li range convention", {
+    values <- c(1, 2, 3, 4, 6, 9)
+    fit <- edcdf__fit_beta4(
+        values,
+        range_extension_sd = 0.5,
+        tolerance = 1e-10,
+        max_iterations = 1000L
+    )
+
+    expect_identical(fit$family, "beta_four_parameter")
+    expect_equal(
+        fit$parameters$lower,
+        min(values) - 0.5 * stats::sd(values)
+    )
+    expect_equal(
+        fit$parameters$upper,
+        max(values) + 0.5 * stats::sd(values)
+    )
+    expect_gt(fit$parameters$shape1, 0)
+    expect_gt(fit$parameters$shape2, 0)
+    probabilities <- c(0.1, 0.5, 0.9)
+    expect_equal(
+        edcdf__cdf(
+            fit,
+            edcdf__quantile(fit, probabilities)
+        ),
+        probabilities,
+        tolerance = 1e-8
+    )
+    expect_error(
+        edcdf__fit_beta4(
+            rep(2, 5),
+            0.5,
+            1e-10,
+            1000L
+        ),
+        "constant"
+    )
+})
+
+test_that("mixed Gamma fit retains dry mass and positive amounts", {
+    values <- c(0, 0, 1, 2, 4, 8)
+    fit <- edcdf__fit_mixed_gamma(
+        values,
+        dry_threshold = 0,
+        min_positive_samples = 2L,
+        tolerance = 1e-10,
+        max_iterations = 1000L
+    )
+
+    expect_identical(fit$family, "mixed_gamma")
+    expect_equal(fit$parameters$dry_probability, 2 / 6)
+    expect_equal(fit$parameters$wet_probability, 4 / 6)
+    expect_identical(fit$positive_sample_size, 4L)
+    expect_equal(edcdf__quantile(fit, 0.2), 0)
+    expect_gt(edcdf__quantile(fit, 0.8), 0)
+    positive_probabilities <- c(0.5, 0.7, 0.9)
+    expect_equal(
+        edcdf__cdf(
+            fit,
+            edcdf__quantile(fit, positive_probabilities)
+        ),
+        positive_probabilities,
+        tolerance = 1e-8
+    )
+    expect_error(
+        edcdf__fit_mixed_gamma(
+            c(0, 0, 1),
+            0,
+            2L,
+            1e-10,
+            1000L
+        ),
+        "at least 2 positive"
+    )
+})
+
+test_that("Equidistant CDF Matching applies the published additive equation", {
+    observed <- c(1, 2, 4, 7, 11, 16)
+    historical <- observed + 5
+    future <- observed + 12
+    resolved <- edcdf_test__settings("tas")
+    resolved$min_samples <- 2L
+    mapped <- edcdf__map_values(
+        observed,
+        historical,
+        future,
+        resolved
+    )
+    probability <- distribution__clamp_probability(
+        edcdf__cdf(mapped$fits$model_future, future),
+        resolved$cdf_epsilon
+    )
+    expected <- future +
+        edcdf__quantile(
+            mapped$fits$observed_reference,
+            probability
+        ) -
+        edcdf__quantile(
+            mapped$fits$model_historical,
+            probability
+        )
+
+    expect_equal(mapped$value, expected)
+    expect_equal(mapped$value, future - 5, tolerance = 1e-6)
+    expect_equal(mapped$diagnostics$correction_range, c(-5, -5))
+})
+
+test_that("daily adaptation pools native calendar months separately", {
+    base <- seq_len(59) + sin(seq_len(59))
+    historical_offset <- c(rep(5, 31), rep(10, 28))
+    future_offset <- c(rep(15, 31), rep(30, 28))
+    observed <- edcdf_test__series("tas", 2001L, base)
+    historical <- edcdf_test__series(
+        "tas",
+        1991L,
+        base + historical_offset
+    )
+    future <- edcdf_test__series(
+        "tas",
+        2061L,
+        base + future_offset
+    )
+    execution <- edcdf_test__execute(
+        "tas",
+        observed,
+        historical,
+        future
+    )
+    adjusted <- execution@values[[1L]]
+
+    expect_equal(
+        adjusted@data$value,
+        future$value - historical_offset,
+        tolerance = 1e-5
+    )
+    expect_identical(
+        adjusted@provenance$diagnostics$month_count,
+        2L
+    )
+    expect_identical(
+        adjusted@provenance$frequency_source,
+        "epwshiftr_daily_adaptation"
+    )
+    expect_identical(
+        adjusted@provenance$equation_equivalence,
+        "absolute_quantile_delta_mapping"
+    )
+})
+
+test_that("temperature identity is preserved on native CF calendars", {
+    calendars <- c("360_day", "noleap", "all_leap")
+    observed_values <- c(1, 3, 2, 5, 4, 8, 7, 6, 10, 9, 12, 11)
+    future_values <- c(11, 13, 12, 15, 14, 18, 17, 16, 20, 19, 22, 21)
+
+    for (calendar in calendars) {
+        observed <- edcdf_test__series(
+            "tas",
+            2001L,
+            observed_values,
+            calendar
+        )
+        historical <- edcdf_test__series(
+            "tas",
+            1991L,
+            observed_values,
+            calendar
+        )
+        future <- edcdf_test__series(
+            "tas",
+            2061L,
+            future_values,
+            calendar
+        )
+        execution <- edcdf_test__execute(
+            "tas",
+            observed,
+            historical,
+            future
+        )
+        adjusted <- execution@values[[1L]]
+
+        expect_equal(adjusted@data$value, future_values)
+        expect_identical(
+            adjusted@data[BIAS_DAILY_SERIES_COLUMNS[-2L]],
+            future[BIAS_DAILY_SERIES_COLUMNS[-2L]]
+        )
+        expect_identical(
+            unique(adjusted@data$cf_calendar),
+            calendar
+        )
+    }
+})
+
+test_that("mixed Gamma precipitation preserves identity and dry values", {
+    observed_values <- c(0, 0, 1, 2, 3, 5, 8, 13)
+    future_values <- c(0, 0, 0, 2, 4, 6, 9, 15)
+    observed <- edcdf_test__series(
+        "pr",
+        2001L,
+        observed_values
+    )
+    historical <- edcdf_test__series(
+        "pr",
+        1991L,
+        observed_values
+    )
+    future <- edcdf_test__series(
+        "pr",
+        2061L,
+        future_values
+    )
+    execution <- edcdf_test__execute(
+        "pr",
+        observed,
+        historical,
+        future
+    )
+    adjusted <- execution@values[[1L]]
+    diagnostics <- adjusted@provenance$diagnostics$precipitation
+
+    expect_equal(adjusted@data$value, future_values)
+    expect_identical(diagnostics$input_dry_values, c(
+        observed_reference = 2L,
+        model_historical = 2L,
+        model_future = 3L
+    ))
+    expect_identical(diagnostics$output_dry_values, 3L)
+    expect_identical(
+        adjusted@settings$negative_precipitation_policy,
+        "clip_zero"
+    )
+})
+
+test_that("negative additive precipitation corrections are explicit", {
+    observed <- edcdf_test__series(
+        "pr",
+        2001L,
+        c(0, 0, 1, 2, 3, 5, 8, 13)
+    )
+    historical <- edcdf_test__series(
+        "pr",
+        1991L,
+        c(0, 0, 10, 20, 30, 50, 80, 130)
+    )
+    future <- edcdf_test__series(
+        "pr",
+        2061L,
+        c(0, 0, 1, 2, 3, 5, 8, 13)
+    )
+    execution <- edcdf_test__execute(
+        "pr",
+        observed,
+        historical,
+        future
+    )
+    adjusted <- execution@values[[1L]]
+    diagnostics <- adjusted@provenance$diagnostics$precipitation
+
+    expect_true(all(adjusted@data$value >= 0))
+    expect_gt(diagnostics$negative_before_clipping, 0L)
+    expect_gt(diagnostics$output_dry_values, 2L)
+})
+
+test_that("settings and incompatible inputs fail explicitly", {
+    settings <- edcdf_test__settings("tas")
+    invalid <- settings
+    invalid$range_extension_sd <- 0
+    expect_error(
+        edcdf__settings(list(tas = invalid)),
+        "must be positive"
+    )
+
+    invalid <- settings
+    invalid$seasonal_grouping <- "annual_phase"
+    expect_error(
+        edcdf__settings(list(tas = invalid)),
+        "currently requires"
+    )
+
+    invalid <- settings
+    invalid$unexpected <- TRUE
+    expect_error(
+        edcdf__settings(list(tas = invalid)),
+        "Unexpected"
+    )
+
+    negative <- edcdf_test__series(
+        "pr",
+        2001L,
+        c(0, -1, 1, 2)
+    )
+    positive <- edcdf_test__series(
+        "pr",
+        1991L,
+        c(0, 1, 2, 3)
+    )
+    boundary <- edcdf_test__execution_inputs(
+        negative,
+        positive,
+        positive
+    )
+    expect_error(
+        component__execute(
+            edcdf__component(),
+            "apply",
+            inputs = boundary$inputs,
+            groups = list(boundary$group),
+            overrides = list(pr = list(
+                min_samples = 2L,
+                min_positive_samples = 2L
+            )),
+            warn_experimental = FALSE
+        ),
+        "non-negative"
+    )
+})
+
+test_that("profiles expose monthly evidence and daily adaptation", {
+    edcdf__register_component()
+    component <- component__get(
+        "signal",
+        "equidistant_cdf_matching_daily"
+    )
+    profiles <- component@metadata$signal_profiles
+
+    expect_true(S7::S7_inherits(component, WeatherComponentSpec))
+    expect_identical(component@stage, "signal")
+    expect_identical(
+        component@input_kinds,
+        "calendar_indexed_daily_series"
+    )
+    expect_identical(component@output_kinds, "daily_adjusted_series")
+    expect_identical(component@scopes, "univariate")
+    expect_false(component@stochastic)
+    expect_identical(
+        sort(names(profiles)),
+        sort(EDCDF_LI_VARIABLES)
+    )
+    expect_true(all(vapply(
+        profiles,
+        function(profile) identical(
+            profile$evidence,
+            "experimental"
+        ),
+        logical(1L)
+    )))
+    expect_true(all(vapply(
+        profiles,
+        function(profile) identical(
+            profile$metadata$method_variable_source,
+            "li_2010_monthly"
+        ),
+        logical(1L)
+    )))
+    expect_identical(
+        profiles$tas$settings$distribution_model,
+        "beta_four_parameter"
+    )
+    expect_identical(
+        profiles$pr$settings$distribution_model,
+        "mixed_gamma"
+    )
+    expect_identical(component@metadata$published_frequency, "mon")
+    expect_identical(component@metadata$adapted_frequency, "day")
+})
+
+test_that("experimental daily profile warning and contracts are retained", {
+    values <- c(1, 3, 2, 5, 4, 8, 7, 6, 10, 9, 12, 11)
+    observed <- edcdf_test__series("tas", 2001L, values)
+    historical <- edcdf_test__series("tas", 1991L, values)
+    future <- edcdf_test__series("tas", 2061L, values + 5)
+
+    expect_warning(
+        edcdf_test__execute(
+            "tas",
+            observed,
+            historical,
+            future,
+            warn_experimental = TRUE
+        ),
+        "experimental"
+    )
+
+    calendar <- component__spec(
+        name = "edcdf_calendar_test",
+        stage = "calendar",
+        input_kinds = "preprocessed_daily_series",
+        output_kinds = "calendar_indexed_daily_series",
+        operations = list(apply = identity)
+    )
+    sequence <- component__spec(
+        name = "edcdf_sequence_test",
+        stage = "sequence",
+        input_kinds = "daily_adjusted_series",
+        output_kinds = "weather_sequence",
+        operations = list(generate = identity)
+    )
+    component <- edcdf__component()
+    expect_true(component__compatible(calendar, component))
+    expect_true(component__compatible(component, sequence))
+})

--- a/vignettes-raw/articles/epw-morpher.Rmd
+++ b/vignettes-raw/articles/epw-morpher.Rmd
@@ -500,7 +500,7 @@ interpretation. Group failures either abort or return an explicit diagnostic
 with a `NULL` result; they are never silently converted to missing numeric
 values.
 
-Six package-native standalone signals currently use this contract:
+Seven package-native standalone signals currently use this contract:
 
 | Registry name | Correction | Output backbone | Variable-profile evidence |
 |:--------------|:-----------|:----------------|:--------------------------|
@@ -508,6 +508,7 @@ Six package-native standalone signals currently use this contract:
 | `delta_change_daily` | Monthly historical-to-future mean change, additive for temperature and multiplicative for precipitation | `observed_reference` | Published defaults for `tas`, `tasmin`, `tasmax`, and `pr` |
 | `quantile_mapping_daily` | \(F^{-1}_{obs}(F_{hist}(x_{future}))\) in calendar-neutral circular daily windows | `model_future` | Published method-variable profiles for `tas` and `pr`; implementation-selected defaults for `hurs`, `psl`, `rlds`, `sfcWind`, `tasmin`, and `tasmax` remain experimental |
 | `quantile_delta_mapping_daily` | Transfer \(x_{future} - F^{-1}_{hist}(p)\) or \(x_{future} / F^{-1}_{hist}(p)\) onto \(F^{-1}_{obs}(p)\), where \(p = F_{future,t}(x_{future})\) | `model_future` | Published absolute-change temperature and relative-change precipitation profiles; implementation-selected defaults for other supported variables remain experimental |
+| `equidistant_cdf_matching_daily` | Apply \(x_{future} + F^{-1}_{obs}(p) - F^{-1}_{hist}(p)\), where \(p = F_{future}(x_{future})\), using the Li et al. parametric distributions | `model_future` | Li et al. published monthly profiles for `tas` and `pr`; native calendar-month daily pooling is an experimental epwshiftr adaptation |
 | `scaled_distribution_mapping_daily` | Parametric distribution and recurrence-interval scaling, absolute for temperature and relative for precipitation | `model_future` | Published profiles for `tas` and `pr`; applying the Normal branch to `tasmin` and `tasmax` remains experimental |
 | `cdf_transform_daily` | Construct \(F_{obs,future}(x) = F_{obs,hist}(F^{-1}_{model,hist}(F_{model,future}(x)))\), then quantile match the future-model sequence to that target CDF | `model_future` | Published daily profiles for `pr`, `tas`, `tasmin`, `tasmax`, `rsds`, and `sfcWind` |
 
@@ -532,6 +533,23 @@ transfers relative changes. Precipitation values at or below the published
 before adjustment and censored back to zero afterward. Window sample counts,
 transferred changes, clipping, censoring, and effective seeds are retained in
 provenance.
+
+`equidistant_cdf_matching_daily` implements the additive equation published by
+Li et al. (2010):
+\(x'_{future} = x_{future} + F^{-1}_{obs}(p) -
+F^{-1}_{hist}(p)\), where \(p = F_{future}(x_{future})\). Cannon et al.
+(2015) showed that this equation is mathematically equivalent to the absolute
+form of Quantile Delta Mapping. The component remains separate because it
+preserves the Li distribution model: temperature uses four-parameter Beta
+distributions whose observed range is extended by half a sample standard
+deviation, while precipitation uses a point mass at zero plus a zero-location
+Gamma distribution for wet values. The original method was applied to monthly
+fields, not daily series. epwshiftr therefore marks its native CF-calendar
+month pooling of daily values as an experimental frequency adaptation rather
+than a published daily default. Negative adjusted precipitation values are
+clipped to zero. Fitted parameters, monthly sample coverage, probability
+clamping, dry counts, clipping, and this frequency provenance remain
+inspectable in the result.
 
 `scaled_distribution_mapping_daily` instead fits the parametric distributions
 and recurrence-interval changes from Switanek et al. (2017) within each

--- a/vignettes-raw/precompiled-checksums.csv
+++ b/vignettes-raw/precompiled-checksums.csv
@@ -1,7 +1,7 @@
 "source","output","source_md5","output_md5"
 "vignettes-raw/articles/cli-esgf-store.Rmd","vignettes/articles/cli-esgf-store.Rmd","cac788f79010ad56496939cdde3580bb","e58e5cafa0d3b2218081c25a1098273f"
 "vignettes-raw/articles/downloader.Rmd","vignettes/articles/downloader.Rmd","9668ccb5b39f0ca2f49e146a1a100a7c","4b67e4a9ddaecfe7ce3ac268936e2a2d"
-"vignettes-raw/articles/epw-morpher.Rmd","vignettes/articles/epw-morpher.Rmd","c263be217d7ee057ae16213bd8f07307","f5f784538f6ea25e3f8b7e53c629c7fd"
+"vignettes-raw/articles/epw-morpher.Rmd","vignettes/articles/epw-morpher.Rmd","4dac1faba29a03a8eea0c144bd44de17","93aa35d52eb2d7bf7719bcbf0308f27b"
 "vignettes-raw/articles/esg-dictionaries.Rmd","vignettes/articles/esg-dictionaries.Rmd","94eb2513975549a6765afa221a2e10c1","290348d35a29e925f1b3732586e54cfb"
 "vignettes-raw/articles/esg-store.Rmd","vignettes/articles/esg-store.Rmd","c2d810261308c837b84c803a0d2632c5","bb73ddac53598a36b049797782ce3c02"
 "vignettes-raw/articles/esgf-query-results.Rmd","vignettes/articles/esgf-query-results.Rmd","9cb7e909ecc499eba79e4295857101d1","20854ab68644b18addeefcef1baafcfa"

--- a/vignettes/articles/epw-morpher.Rmd
+++ b/vignettes/articles/epw-morpher.Rmd
@@ -508,7 +508,7 @@ interpretation. Group failures either abort or return an explicit diagnostic
 with a `NULL` result; they are never silently converted to missing numeric
 values.
 
-Six package-native standalone signals currently use this contract:
+Seven package-native standalone signals currently use this contract:
 
 | Registry name | Correction | Output backbone | Variable-profile evidence |
 |:--------------|:-----------|:----------------|:--------------------------|
@@ -516,6 +516,7 @@ Six package-native standalone signals currently use this contract:
 | `delta_change_daily` | Monthly historical-to-future mean change, additive for temperature and multiplicative for precipitation | `observed_reference` | Published defaults for `tas`, `tasmin`, `tasmax`, and `pr` |
 | `quantile_mapping_daily` | \(F^{-1}_{obs}(F_{hist}(x_{future}))\) in calendar-neutral circular daily windows | `model_future` | Published method-variable profiles for `tas` and `pr`; implementation-selected defaults for `hurs`, `psl`, `rlds`, `sfcWind`, `tasmin`, and `tasmax` remain experimental |
 | `quantile_delta_mapping_daily` | Transfer \(x_{future} - F^{-1}_{hist}(p)\) or \(x_{future} / F^{-1}_{hist}(p)\) onto \(F^{-1}_{obs}(p)\), where \(p = F_{future,t}(x_{future})\) | `model_future` | Published absolute-change temperature and relative-change precipitation profiles; implementation-selected defaults for other supported variables remain experimental |
+| `equidistant_cdf_matching_daily` | Apply \(x_{future} + F^{-1}_{obs}(p) - F^{-1}_{hist}(p)\), where \(p = F_{future}(x_{future})\), using the Li et al. parametric distributions | `model_future` | Li et al. published monthly profiles for `tas` and `pr`; native calendar-month daily pooling is an experimental epwshiftr adaptation |
 | `scaled_distribution_mapping_daily` | Parametric distribution and recurrence-interval scaling, absolute for temperature and relative for precipitation | `model_future` | Published profiles for `tas` and `pr`; applying the Normal branch to `tasmin` and `tasmax` remains experimental |
 | `cdf_transform_daily` | Construct \(F_{obs,future}(x) = F_{obs,hist}(F^{-1}_{model,hist}(F_{model,future}(x)))\), then quantile match the future-model sequence to that target CDF | `model_future` | Published daily profiles for `pr`, `tas`, `tasmin`, `tasmax`, `rsds`, and `sfcWind` |
 
@@ -540,6 +541,23 @@ transfers relative changes. Precipitation values at or below the published
 before adjustment and censored back to zero afterward. Window sample counts,
 transferred changes, clipping, censoring, and effective seeds are retained in
 provenance.
+
+`equidistant_cdf_matching_daily` implements the additive equation published by
+Li et al. (2010):
+\(x'_{future} = x_{future} + F^{-1}_{obs}(p) -
+F^{-1}_{hist}(p)\), where \(p = F_{future}(x_{future})\). Cannon et al.
+(2015) showed that this equation is mathematically equivalent to the absolute
+form of Quantile Delta Mapping. The component remains separate because it
+preserves the Li distribution model: temperature uses four-parameter Beta
+distributions whose observed range is extended by half a sample standard
+deviation, while precipitation uses a point mass at zero plus a zero-location
+Gamma distribution for wet values. The original method was applied to monthly
+fields, not daily series. epwshiftr therefore marks its native CF-calendar
+month pooling of daily values as an experimental frequency adaptation rather
+than a published daily default. Negative adjusted precipitation values are
+clipped to zero. Fitted parameters, monthly sample coverage, probability
+clamping, dry counts, clipping, and this frequency provenance remain
+inspectable in the result.
 
 `scaled_distribution_mapping_daily` instead fits the parametric distributions
 and recurrence-interval changes from Switanek et al. (2017) within each


### PR DESCRIPTION
## Summary

Add package-native daily Equidistant CDF Matching using the Li et al. parametric distributions while recording that native calendar-month daily pooling adapts an originally monthly method.

## Changes

- Register `equidistant_cdf_matching_daily` for `tas` and `pr`.
- Implement the additive Li equation and record its equivalence to absolute Quantile Delta Mapping.
- Fit four-parameter Beta temperature distributions with the published range convention and mixed-Gamma precipitation distributions with deterministic dry mass.
- Apply fits by native CF-calendar month across the requested projection period.
- Record fitted parameters, sample coverage, probability clamping, dry counts, clipping, settings, and daily-adaptation provenance.
- Add equation, fit, calendar, precipitation, settings, profile, warning, and component-contract tests.
- Document the new signal, its monthly-to-daily provenance, and its relationship to absolute Quantile Delta Mapping in NEWS and the precompiled raw vignette.
- Closes #174
