### PR TITLE
feat: pass signal settings through weather pipelines

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -46,6 +46,11 @@
 
 ## New features
 
+* Weather component pipelines now pass optional variable-specific
+  `signal_overrides` to the selected signal component. Reusable downstream
+  temperature reconstruction components ignore signal-owned settings while
+  continuing to validate their own projection options (#179).
+
 * Added the native R `isimip3basd_daily` signal component for the complete
   ISIMIP3BASD 3.0.x marginal bias-adjustment configuration. It transfers
   modeled quantile changes onto historical observations, then maps the

--- a/R/daily-temperature-backend.R
+++ b/R/daily-temperature-backend.R
@@ -458,11 +458,21 @@ daily__temperature_sequence_generate <- function(
     data@values[[1L]]
 }
 
+# Select only projection-owned options before the reusable hourly component
+# validates them, leaving signal-specific settings to their own stage.
+daily__temperature_projection_options <- function(options) {
+    names <- intersect(
+        names(options),
+        names(EPW_MORPH_DAILY_TEMPERATURE_OPTIONS)
+    )
+    daily__temperature_backend_options(options[names])
+}
+
 # Run one selected grouped hourly projector and assemble the common payload for
 # physical closure. The projector remains the only method-specific operation.
 daily__temperature_hourly_result <- function(data, options, projector) {
     checkmate::assert_function(projector)
-    options <- daily__temperature_backend_options(options)
+    options <- daily__temperature_projection_options(options)
     baseline <- data$baseline
     targets <- data$targets
     projected <- projector(

--- a/R/weather-pipeline.R
+++ b/R/weather-pipeline.R
@@ -273,6 +273,17 @@ pipeline__stage_result <- function(component, value) {
     )
 }
 
+# Extract optional signal-setting overrides from backend options while keeping
+# pipelines without configurable signal profiles on the empty-list default.
+pipeline__signal_overrides <- function(options) {
+    overrides <- options$signal_overrides
+    if (is.null(overrides)) {
+        return(list())
+    }
+    checkmate::assert_list(overrides, names = "unique")
+    overrides
+}
+
 # Build the stage-specific operation arguments while retaining one generic
 # executor. Signal components receive their shared group lifecycle contract;
 # every other stage receives the previous typed value.
@@ -296,7 +307,7 @@ pipeline__operation_args <- function(
         signal = list(
             inputs = plan@inputs,
             groups = previous@value,
-            overrides = list(),
+            overrides = pipeline__signal_overrides(options),
             error_policy = "abort",
             warn_experimental = TRUE
         ),

--- a/tests/testthat/test-weather-pipeline.R
+++ b/tests/testthat/test-weather-pipeline.R
@@ -1,0 +1,115 @@
+# Build a minimal valid pipeline plan for testing stage argument dispatch
+# without registering test-only components in the package-wide registry.
+pipeline_test__plan <- function(signal) {
+    stages <- WEATHER_COMPONENT_STAGES
+    components <- lapply(stages, function(stage) {
+        if (identical(stage, "signal")) {
+            return(signal)
+        }
+        operation <- WEATHER_COMPONENT_PRIMARY_OPERATIONS[[stage]]
+        component__spec(
+            name = paste0("pipeline_", stage, "_test"),
+            stage = stage,
+            input_kinds = paste0(stage, "_input"),
+            output_kinds = paste0(stage, "_output"),
+            operations = stats::setNames(
+                list(function(...) NULL),
+                operation
+            )
+        )
+    })
+    names(components) <- stages
+    records <- stats::setNames(
+        lapply(components, function(component) component@name),
+        stages
+    )
+    inputs <- weather__new_inputs(
+        model_future = weather__new_input(
+            "model_future",
+            data.frame(variable_id = "tas", frequency = "day")
+        )
+    )
+    WeatherPipelinePlan(
+        spec = pipeline__spec(records),
+        inputs = inputs,
+        components = components
+    )
+}
+
+test_that("pipeline signal options reach the selected component", {
+    requirement <- component__input_requirement(
+        "model_future",
+        frequencies = "day",
+        variable_sets = "tas"
+    )
+    signal <- signal__component(
+        "pipeline_signal_test",
+        required_inputs = list(model_future = requirement),
+        input_kinds = "calendar_output",
+        output_kinds = "signal_output",
+        profiles = list(signal__variable_profile(
+            "tas",
+            settings = list(offset = 1),
+            evidence = "published",
+            references = "doi:10.1000/pipeline-test"
+        )),
+        apply_group = function(inputs, settings, key) {
+            inputs$model_future + settings$tas$offset
+        }
+    )
+    plan <- pipeline_test__plan(signal)
+    groups <- list(signal__group(
+        inputs = list(model_future = 1:2),
+        variables = "tas"
+    ))
+    previous <- WeatherStageResult(
+        stage = "calendar",
+        component = "pipeline_calendar_test",
+        kind = "calendar_output",
+        value = groups
+    )
+    overrides <- list(tas = list(offset = 5))
+
+    args <- pipeline__operation_args(
+        component = signal,
+        plan = plan,
+        previous = previous,
+        context = NULL,
+        options = list(signal_overrides = overrides),
+        stages = list()
+    )
+    result <- do.call(component__operation(signal, "apply"), args)
+
+    expect_identical(args$overrides, overrides)
+    expect_identical(result@values[[1L]], c(6, 7))
+    expect_identical(result@profiles$tas$settings$offset, 5)
+
+    default_args <- pipeline__operation_args(
+        component = signal,
+        plan = plan,
+        previous = previous,
+        context = NULL,
+        options = list(),
+        stages = list()
+    )
+    expect_identical(default_args$overrides, list())
+    expect_error(
+        pipeline__signal_overrides(list(signal_overrides = "invalid")),
+        "list"
+    )
+})
+
+test_that("daily hourly projection ignores signal-owned options", {
+    options <- c(
+        EPW_MORPH_DAILY_TEMPERATURE_OPTIONS,
+        list(signal_overrides = list(tas = list(offset = 5)))
+    )
+
+    projection <- daily__temperature_projection_options(options)
+
+    expect_named(
+        projection,
+        names(EPW_MORPH_DAILY_TEMPERATURE_OPTIONS)
+    )
+    expect_false("signal_overrides" %in% names(projection))
+})


### PR DESCRIPTION
## Summary

- Passes variable-specific `signal_overrides` through the generic seven-stage weather pipeline.
- Keeps signal-owned settings isolated from reusable downstream temperature reconstruction components.
- Closes #178.

## Changes

- Adds `pipeline__signal_overrides()` and forwards its result to the selected `signal` component.
- Adds `daily__temperature_projection_options()` so the reusable hourly projector validates only its own declared options.
- Adds component-contract tests for override resolution, provenance, empty defaults, invalid values, and downstream option isolation.
