### PR TITLE
feat: support future weather sequences

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -111,6 +111,7 @@ Collate:
     'standalone-cache.R'
     'weather-pipeline.R'
     'weather-recipe.R'
+    'weather-sequence.R'
     'zzz.R'
 Config/testthat/edition: 3
 Config/Needs/website: r-lib/asciicast, r-lib/pkgload

--- a/NEWS.md
+++ b/NEWS.md
@@ -46,6 +46,11 @@
 
 ## New features
 
+* Future-weather recipes with `future_year` or `multi_year` output types now
+  persist a year-addressable sequence manifest and write one independently
+  resumable Parquet and EPW member per weather year. Existing
+  `representative_year` outputs and identifiers remain unchanged (#181).
+
 * Weather component pipelines now pass optional variable-specific
   `signal_overrides` to the selected signal component. Reusable downstream
   temperature reconstruction components ignore signal-owned settings while

--- a/R/epw-morpher.R
+++ b/R/epw-morpher.R
@@ -2098,10 +2098,107 @@ morpher__run_context <- function(context) {
     }
     backend <- epw_morph_backend(context$recipe$backend)
     result <- backend$run(context)
-    if (!inherits(result, "epw_morph_result")) {
-        cli::cli_abort("EPW morphing backend {.val {backend$name}} did not return an {.cls epw_morph_result}.")
+    if (!inherits(result, "epw_morph_result") &&
+        !S7::S7_inherits(result, WeatherSequenceResult)) {
+        cli::cli_abort(
+            "EPW morphing backend {.val {backend$name}} did not return an {.cls epw_morph_result} or {.cls WeatherSequenceResult}."
+        )
+    }
+    if (!is.null(recipe_spec)) {
+        actual_output_type <- if (S7::S7_inherits(
+            result,
+            WeatherSequenceResult
+        )) {
+            result@output_type
+        } else {
+            "representative_year"
+        }
+        if (!identical(recipe_spec@output_type, actual_output_type)) {
+            cli::cli_abort(c(
+                "Future-weather backend output does not match its registered recipe contract.",
+                "x" = "Recipe {.val {recipe_spec@name}} declares {.val {recipe_spec@output_type}} but returned {.val {actual_output_type}}."
+            ))
+        }
     }
     result
+}
+
+# Fill nullable sequence columns when reading manifests created before the
+# year-addressable result schema so existing stores keep one-member semantics.
+morpher__normalize_result_manifest <- function(rows) {
+    rows <- data.table::as.data.table(data.table::copy(rows))
+    defaults <- list(
+        output_type = "representative_year",
+        sequence_id = NA_character_,
+        weather_year = NA_integer_,
+        calendar = NA_character_,
+        stochastic_seed = NA_integer_,
+        member_count = 1L,
+        provenance_json = "[]"
+    )
+    for (name in names(defaults)) {
+        if (!name %in% names(rows)) {
+            rows[, (name) := defaults[[name]]]
+            next
+        }
+        missing <- is.na(rows[[name]])
+        if (is.character(rows[[name]])) {
+            missing <- missing | !nzchar(rows[[name]])
+        }
+        if (name %in% c(
+            "sequence_id",
+            "weather_year",
+            "calendar",
+            "stochastic_seed"
+        )) {
+            next
+        }
+        data.table::set(
+            rows,
+            i = which(missing),
+            j = name,
+            value = defaults[[name]]
+        )
+    }
+    rows[]
+}
+
+# A resumed case is complete only when every member promised by its manifest
+# still exists; one surviving year must not hide a missing sibling year.
+morpher__result_case_complete <- function(rows) {
+    if (!nrow(rows)) {
+        return(FALSE)
+    }
+    expected <- unique(as.integer(rows$member_count))
+    member_keys <- paste(
+        rows$output_type,
+        rows$sequence_id,
+        rows$weather_year,
+        sep = "\r"
+    )
+    length(expected) == 1L &&
+        !is.na(expected) &&
+        expected > 0L &&
+        nrow(rows) == expected &&
+        !anyDuplicated(member_keys) &&
+        !anyDuplicated(rows$output_path)
+}
+
+# Restore deterministic case and member order after reading rows from DuckDB,
+# whose physical row order is not a persistence contract.
+morpher__order_result_rows <- function(rows, cases) {
+    rows <- data.table::as.data.table(data.table::copy(rows))
+    if (!nrow(rows)) {
+        return(rows[])
+    }
+    rows[, (".case_order") := match(rows[["case_id"]], cases)]
+    data.table::setorderv(
+        rows,
+        c(".case_order", "sequence_id", "weather_year", "output_path"),
+        na.last = TRUE
+    )
+    rows[, (".case_order") := NULL]
+    rows[]
 }
 
 morpher__belcher_monthly_variable <- function(context, variable_id) {
@@ -5342,7 +5439,8 @@ EpwMorpher <- R6::R6Class(
         },
 
         #' @description
-        #' Execute a morphing plan and write hourly result Parquet files.
+        #' Execute a morphing plan and write one hourly Parquet file per result
+        #' member and weather year.
         #'
         #' @param morph_id Morphing plan ID.
         #' @param overwrite Whether to overwrite existing result files.
@@ -5364,7 +5462,9 @@ EpwMorpher <- R6::R6Class(
                 cli::cli_abort("No morphing cases were found for morph ID {.val {morph_id}}.")
             }
 
-            existing <- morpher__read_table(private$store, "epw_morph_result")
+            existing <- morpher__normalize_result_manifest(
+                morpher__read_table(private$store, "epw_morph_result")
+            )
             target_morph_id <- morph_id
             existing <- existing[existing[["morph_id"]] == target_morph_id]
             existing_paths <- if (nrow(existing)) {
@@ -5376,7 +5476,14 @@ EpwMorpher <- R6::R6Class(
                 existing[["case_id"]] %in% cases &
                     vapply(existing_paths, file.exists, logical(1L))
             ]
-            if (!isTRUE(overwrite) && isTRUE(resume) && length(unique(complete_existing$case_id)) == length(cases)) {
+            complete_cases <- cases[vapply(cases, function(case_id) {
+                rows <- complete_existing[
+                    complete_existing[["case_id"]] == case_id
+                ]
+                morpher__result_case_complete(rows)
+            }, logical(1L))]
+            if (!isTRUE(overwrite) && isTRUE(resume) &&
+                length(complete_cases) == length(cases)) {
                 private$set_plan_status(morph_id, "result_done")
                 if (!is.null(reporter)) {
                     for (case_index in seq_along(cases)) {
@@ -5388,7 +5495,7 @@ EpwMorpher <- R6::R6Class(
                             current = case_index, total = length(cases))
                     }
                 }
-                return(complete_existing[match(cases, complete_existing$case_id)])
+                return(morpher__order_result_rows(complete_existing, cases))
             }
 
             private$set_plan_status(morph_id, "running")
@@ -5457,19 +5564,16 @@ EpwMorpher <- R6::R6Class(
                             reporter$unit_started(label, current = case_index, total = length(cases),
                                 details = private$report_case_details(case, "morph_case"))
                         }
-                        path <- private$morph_result_path(morph_id, case_id)
                         target_case_id <- case_id
                         existing_case <- complete_existing[complete_existing[["case_id"]] == target_case_id]
-                        if (!isTRUE(overwrite) && isTRUE(resume) && nrow(existing_case)) {
-                            result_rows[[length(result_rows) + 1L]] <- existing_case[1L]
+                        if (!isTRUE(overwrite) && isTRUE(resume) &&
+                            morpher__result_case_complete(existing_case)) {
+                            result_rows[[length(result_rows) + 1L]] <- existing_case
                             if (!is.null(reporter)) {
                                 reporter$unit_skipped(sprintf("Reused %s", label),
                                     current = case_index, total = length(cases))
                             }
                             next
-                        }
-                        if (file.exists(path) && !isTRUE(overwrite)) {
-                            cli::cli_abort("Morph result already exists without a complete manifest row: {.path {path}}.")
                         }
                         case_climate <- private$filter_case_climate(climate, case, by)
                         if (!nrow(case_climate)) {
@@ -5512,32 +5616,110 @@ EpwMorpher <- R6::R6Class(
                             warning = FALSE
                         )
                         case_result <- morpher__run_context(context)
-                        case_data <- case_result$data
-                        if (!nrow(case_data)) {
-                            cli::cli_abort("No morphed data were produced for morphing case {.val {target_case_id}}.")
+                        member_records <- sequence__records(case_result)
+                        member_count <- length(member_records)
+                        for (member in member_records) {
+                            case_data <- member$data
+                            if (!nrow(case_data)) {
+                                cli::cli_abort(
+                                    "No morphed data were produced for morphing case {.val {target_case_id}}."
+                                )
+                            }
+                            path <- private$morph_result_path(
+                                morph_id,
+                                case_id,
+                                output_type = member$output_type,
+                                sequence_id = member$sequence_id,
+                                weather_year = member$weather_year
+                            )
+                            path_rel <- store_rel_path(
+                                path,
+                                root = private$store$path
+                            )
+                            existing_member <- existing[
+                                existing[["case_id"]] == case_id &
+                                    existing[["output_path"]] == path_rel
+                            ]
+                            if (!isTRUE(overwrite) && isTRUE(resume) &&
+                                nrow(existing_member) == 1L &&
+                                file.exists(path)) {
+                                # Partial sequence recovery reuses intact
+                                # siblings and regenerates only missing years.
+                                result_rows[[length(result_rows) + 1L]] <-
+                                    existing_member
+                                next
+                            }
+                            if (file.exists(path) && !isTRUE(overwrite)) {
+                                cli::cli_abort(
+                                    "Morph result already exists without a complete manifest row: {.path {path}}."
+                                )
+                            }
+                            case_meta <- private$case_metadata_from_case(
+                                case,
+                                case_data
+                            )
+                            for (name in names(case_meta)) {
+                                case_data[, (name) := case_meta[[name]]]
+                            }
+                            write_parquet_file(case_data, path)
+                            provenance_json <- as.character(morpher__json(
+                                member$provenance
+                            ))
+                            identity <- list(
+                                output_type = member$output_type,
+                                sequence_id = member$sequence_id,
+                                weather_year = member$weather_year,
+                                calendar = member$calendar,
+                                stochastic_seed = member$stochastic_seed,
+                                member_count = member_count,
+                                provenance_json = provenance_json
+                            )
+                            artifact_id <- private$store$register_artifact(
+                                kind = "output",
+                                path = path,
+                                role = "derived",
+                                project = "CMIP6",
+                                metadata = c(
+                                    list(
+                                        morph_id = morph_id,
+                                        case_id = case_id
+                                    ),
+                                    identity
+                                )
+                            )
+                            result_id <- if (identical(
+                                member$output_type,
+                                "representative_year"
+                            )) {
+                                morpher__hash(morph_id, case_id, path)
+                            } else {
+                                morpher__hash(
+                                    morph_id,
+                                    case_id,
+                                    member$output_type,
+                                    member$sequence_id,
+                                    member$weather_year,
+                                    path
+                                )
+                            }
+                            result_rows[[length(result_rows) + 1L]] <- data.frame(
+                                result_id = result_id,
+                                morph_id = morph_id,
+                                case_id = case_id,
+                                artifact_id = artifact_id,
+                                output_path = path_rel,
+                                row_count = nrow(case_data),
+                                output_type = member$output_type,
+                                sequence_id = member$sequence_id,
+                                weather_year = member$weather_year,
+                                calendar = member$calendar,
+                                stochastic_seed = member$stochastic_seed,
+                                member_count = member_count,
+                                provenance_json = provenance_json,
+                                created_at = morpher__now(),
+                                stringsAsFactors = FALSE
+                            )
                         }
-                        case_meta <- private$case_metadata_from_case(case, case_data)
-                        for (name in names(case_meta)) {
-                            case_data[, (name) := case_meta[[name]]]
-                        }
-                        write_parquet_file(case_data, path)
-                        artifact_id <- private$store$register_artifact(
-                            kind = "output",
-                            path = path,
-                            role = "derived",
-                            project = "CMIP6",
-                            metadata = list(morph_id = morph_id, case_id = case_id)
-                        )
-                        result_rows[[length(result_rows) + 1L]] <- data.frame(
-                            result_id = morpher__hash(morph_id, case_id, path),
-                            morph_id = morph_id,
-                            case_id = case_id,
-                            artifact_id = artifact_id,
-                            output_path = store_rel_path(path, root = private$store$path),
-                            row_count = nrow(case_data),
-                            created_at = morpher__now(),
-                            stringsAsFactors = FALSE
-                        )
                         if (!is.null(reporter)) {
                             reporter$unit_completed(sprintf("Morphed %s", label),
                                 current = case_index, total = length(cases), outcome = "completed")
@@ -5547,7 +5729,7 @@ EpwMorpher <- R6::R6Class(
                     morpher__delete_by_key(private$store, "epw_morph_result", "morph_id", morph_id)
                     morpher__replace_rows(private$store, "epw_morph_result", results, "result_id")
                     private$set_plan_status(morph_id, "result_done")
-                    results[]
+                    morpher__order_result_rows(results, cases)
                 },
                 error = function(e) {
                     private$set_plan_status(morph_id, "failed", conditionMessage(e))
@@ -5557,7 +5739,7 @@ EpwMorpher <- R6::R6Class(
         },
 
         #' @description
-        #' Write future EPW files from morphing results.
+        #' Write one future EPW file for every persisted result member.
         #'
         #' @param morph_id Morphing plan ID.
         #' @param dir Output directory inside the store root. Relative paths are
@@ -5575,13 +5757,19 @@ EpwMorpher <- R6::R6Class(
             checkmate::assert_flag(separate)
             checkmate::assert_flag(overwrite)
             checkmate::assert_flag(resume)
-            private$get_plan(morph_id)
-            results <- morpher__read_table(private$store, "epw_morph_result")
+            plan <- private$get_plan(morph_id)
+            results <- morpher__normalize_result_manifest(
+                morpher__read_table(private$store, "epw_morph_result")
+            )
             target_morph_id <- morph_id
             results <- results[results[["morph_id"]] == target_morph_id]
             if (!nrow(results)) {
                 cli::cli_abort("No morphing results were found. Run {.code EpwMorpher$run()} first.")
             }
+            results <- morpher__order_result_rows(
+                results,
+                private$case_rows(plan)$case_id
+            )
 
             tryCatch(
                 {
@@ -5590,7 +5778,9 @@ EpwMorpher <- R6::R6Class(
                     base_epw <- private$epw$clone()
                     suppressMessages(base_epw$drop_unit())
                     base_cols <- names(base_epw$data())
-                    current_outputs <- morpher__read_table(private$store, "epw_output")
+                    current_outputs <- morpher__normalize_result_manifest(
+                        morpher__read_table(private$store, "epw_output")
+                    )
                     target_morph_id <- morph_id
                     current_outputs <- current_outputs[current_outputs[["morph_id"]] == target_morph_id]
                     output_rows <- vector("list", nrow(results))
@@ -5602,7 +5792,29 @@ EpwMorpher <- R6::R6Class(
                         result_path <- store_abs_path(result$output_path[[1L]], root = private$store$path)
                         dt <- morpher__parquet_read(private$store, result_path)
                         meta <- private$case_metadata_from_result(dt)
-                        label <- paste(unlist(meta[c("experiment_id", "variant_label", "period")], use.names = FALSE), collapse = " | ")
+                        sequence_meta <- if (identical(
+                            result$output_type[[1L]],
+                            "representative_year"
+                        )) {
+                            list()
+                        } else {
+                            list(
+                                sequence_id = result$sequence_id[[1L]],
+                                weather_year = result$weather_year[[1L]]
+                            )
+                        }
+                        display_meta <- c(
+                            meta[c(
+                                "experiment_id",
+                                "variant_label",
+                                "period"
+                            )],
+                            sequence_meta
+                        )
+                        label <- paste(
+                            unlist(display_meta, use.names = FALSE),
+                            collapse = " | "
+                        )
                         if (!is.null(reporter)) {
                             reporter$unit_started(label, current = i, total = nrow(results),
                                 details = list(
@@ -5611,16 +5823,40 @@ EpwMorpher <- R6::R6Class(
                                     period = meta$period
                                 ))
                         }
-                        label <- paste(morpher__safe_path(unlist(meta, use.names = FALSE)), collapse = ".")
-                        filename <- paste(tools::file_path_sans_ext(basename(morpher__get_epw_path(private$epw))), label, "epw", sep = ".")
+                        path_meta <- c(meta, sequence_meta)
+                        path_values <- unlist(path_meta, use.names = FALSE)
+                        label <- paste(
+                            morpher__safe_path(path_values),
+                            collapse = "."
+                        )
+                        filename <- paste(
+                            tools::file_path_sans_ext(basename(
+                                morpher__get_epw_path(private$epw)
+                            )),
+                            label,
+                            "epw",
+                            sep = "."
+                        )
                         output_path <- if (isTRUE(separate)) {
-                            file.path(root, do.call(file.path, as.list(morpher__safe_path(unlist(meta, use.names = FALSE)))), filename)
+                            file.path(
+                                root,
+                                do.call(
+                                    file.path,
+                                    as.list(morpher__safe_path(path_values))
+                                ),
+                                filename
+                            )
                         } else {
                             file.path(root, filename)
                         }
                         output_rel <- store_rel_path(output_path, root = private$store$path)
+                        same_result <- current_outputs[["result_id"]] ==
+                            result$result_id[[1L]]
+                        same_result[is.na(same_result)] <-
+                            current_outputs[["case_id"]][is.na(same_result)] ==
+                                result$case_id[[1L]]
                         existing_output <- current_outputs[
-                            current_outputs[["case_id"]] == result$case_id[[1L]] &
+                            same_result &
                                 current_outputs[["path"]] == output_rel
                         ]
                         if (!isTRUE(overwrite) && isTRUE(resume) && nrow(existing_output) && file.exists(output_path)) {
@@ -5636,6 +5872,13 @@ EpwMorpher <- R6::R6Class(
                         }
                         new_epw <- private$epw$clone()
                         set_data <- data.table::copy(dt[, intersect(base_cols, names(dt)), with = FALSE])
+                        if (nrow(set_data) != nrow(base_epw$data())) {
+                            cli::cli_abort(c(
+                                "Future-weather member cannot be written with the selected EPW template.",
+                                "x" = "Member {.val {result$sequence_id[[1L]]}} year {.val {result$weather_year[[1L]]}} has {nrow(set_data)} rows; the template has {nrow(base_epw$data())}.",
+                                "i" = "Map the member to the template calendar before the output stage."
+                            ))
+                        }
                         data.table::setcolorder(set_data, base_cols)
                         suppressMessages(new_epw$drop_unit())
                         suppressMessages(new_epw$set(set_data))
@@ -5645,7 +5888,10 @@ EpwMorpher <- R6::R6Class(
                         epw_file__apply_morph_headers(
                             new_epw, set_data, private$recipe$options
                         )
-                        case_label <- paste(unlist(meta, use.names = FALSE), collapse = "-")
+                        case_label <- paste(
+                            unlist(path_meta, use.names = FALSE),
+                            collapse = "-"
+                        )
                         new_epw$comment1(disclaimer_comment(case_label))
                         new_epw$fill_abnormal(missing = TRUE, out_of_range = TRUE, special = TRUE)
                         dir.create(dirname(output_path), recursive = TRUE, showWarnings = FALSE)
@@ -5655,18 +5901,56 @@ EpwMorpher <- R6::R6Class(
                             path = output_path,
                             role = "output",
                             project = "CMIP6",
-                            metadata = c(list(morph_id = morph_id, case_id = result$case_id[[1L]]), meta)
+                            metadata = c(
+                                list(
+                                    morph_id = morph_id,
+                                    case_id = result$case_id[[1L]],
+                                    result_id = result$result_id[[1L]],
+                                    output_type = result$output_type[[1L]],
+                                    sequence_id = result$sequence_id[[1L]],
+                                    weather_year = result$weather_year[[1L]],
+                                    calendar = result$calendar[[1L]],
+                                    stochastic_seed = result$stochastic_seed[[1L]],
+                                    member_count = result$member_count[[1L]],
+                                    provenance_json = result$provenance_json[[1L]]
+                                ),
+                                meta
+                            )
                         )
+                        output_id <- if (identical(
+                            result$output_type[[1L]],
+                            "representative_year"
+                        )) {
+                            morpher__hash(
+                                morph_id,
+                                result$case_id[[1L]],
+                                output_path
+                            )
+                        } else {
+                            morpher__hash(
+                                morph_id,
+                                result$result_id[[1L]],
+                                output_path
+                            )
+                        }
                         output_rows[[i]] <- data.frame(
-                            output_id = morpher__hash(morph_id, result$case_id[[1L]], output_path),
+                            output_id = output_id,
                             morph_id = morph_id,
                             case_id = result$case_id[[1L]],
+                            result_id = result$result_id[[1L]],
                             artifact_id = artifact_id,
                             path = output_rel,
                             source_id = store__chr1(meta$source_id),
                             experiment_id = store__chr1(meta$experiment_id),
                             variant_label = store__chr1(meta$variant_label),
                             period = store__chr1(meta$period),
+                            output_type = result$output_type[[1L]],
+                            sequence_id = result$sequence_id[[1L]],
+                            weather_year = result$weather_year[[1L]],
+                            calendar = result$calendar[[1L]],
+                            stochastic_seed = result$stochastic_seed[[1L]],
+                            member_count = result$member_count[[1L]],
+                            provenance_json = result$provenance_json[[1L]],
                             created_at = morpher__now(),
                             stringsAsFactors = FALSE
                         )
@@ -6688,8 +6972,36 @@ EpwMorpher <- R6::R6Class(
             )
         },
 
-        morph_result_path = function(morph_id, case_id) {
-            file.path(private$store$path, "outputs", "epw-morph", morph_id, sprintf("case=%s.parquet", morpher__safe_path(case_id)))
+        # Keep legacy representative-year paths stable while sequence results
+        # receive collision-free member and year partitions.
+        morph_result_path = function(
+            morph_id,
+            case_id,
+            output_type = "representative_year",
+            sequence_id = NA_character_,
+            weather_year = NA_integer_
+        ) {
+            root <- file.path(
+                private$store$path,
+                "outputs",
+                "epw-morph",
+                morph_id
+            )
+            if (identical(output_type, "representative_year")) {
+                return(file.path(
+                    root,
+                    sprintf(
+                        "case=%s.parquet",
+                        morpher__safe_path(case_id)
+                    )
+                ))
+            }
+            file.path(
+                root,
+                sprintf("case=%s", morpher__safe_path(case_id)),
+                sprintf("sequence=%s", morpher__safe_path(sequence_id)),
+                sprintf("year=%d.parquet", as.integer(weather_year))
+            )
         }
     )
 )

--- a/R/shift-stage.R
+++ b/R/shift-stage.R
@@ -469,7 +469,12 @@ shift_read_morph_data <- function(store, results, n, columns) {
             result_id = results$result_id[[i]],
             morph_id = results$morph_id[[i]],
             case_id = results$case_id[[i]],
-            output_path = results$output_path[[i]]
+            output_path = results$output_path[[i]],
+            output_type = results$output_type[[i]],
+            sequence_id = results$sequence_id[[i]],
+            weather_year = results$weather_year[[i]],
+            calendar = results$calendar[[i]],
+            stochastic_seed = results$stochastic_seed[[i]]
         ))
         pieces[[i]] <- shift_select_data_columns(dt, columns, "morphed")
         if (!is.infinite(remaining)) {
@@ -510,6 +515,11 @@ shift_read_epw_output_data <- function(store, outputs, n, columns) {
             experiment_id = outputs$experiment_id[[i]],
             variant_label = outputs$variant_label[[i]],
             period = outputs$period[[i]],
+            output_type = outputs$output_type[[i]],
+            sequence_id = outputs$sequence_id[[i]],
+            weather_year = outputs$weather_year[[i]],
+            calendar = outputs$calendar[[i]],
+            stochastic_seed = outputs$stochastic_seed[[i]],
             path = outputs$path[[i]]
         ))
         pieces[[i]] <- shift_select_data_columns(dt, columns, "EPW output")
@@ -8604,7 +8614,7 @@ shift__climate_for_cases <- function(climate, cases, reference = FALSE) {
 }
 
 # Attach output IDs and exported paths to the expected case matrix using the
-# public CMIP identity rather than the internal morph case hash.
+# public CMIP identity while allowing one case to own a complete year sequence.
 shift__complete_output_cases <- function(cases, outputs) {
     cases <- data.table::as.data.table(data.table::copy(cases))
     outputs <- data.table::as.data.table(outputs)
@@ -8618,15 +8628,39 @@ shift__complete_output_cases <- function(cases, outputs) {
                 variant_label == cases$variant_label[[i]] &
                 period == cases$period[[i]]
         ]
-        if (nrow(hit) == 1L) {
+        expected <- if (!nrow(hit) || !"member_count" %in% names(hit)) {
+            1L
+        } else {
+            count <- unique(as.integer(hit$member_count))
+            count <- count[!is.na(count)]
+            if (length(count) == 1L) count else NA_integer_
+        }
+        member_keys <- if (nrow(hit)) {
+            paste(
+                hit$output_type,
+                hit$sequence_id,
+                hit$weather_year,
+                sep = "\r"
+            )
+        } else {
+            character()
+        }
+        if (nrow(hit) && !is.na(expected) && nrow(hit) == expected &&
+            !anyDuplicated(member_keys)) {
             cases$status[[i]] <- "completed"
+            # The case table retains its original scalar compatibility field;
+            # all member IDs remain authoritative in the output manifest.
             cases$output_id[[i]] <- hit$output_id[[1L]]
             if ("export_path" %in% names(hit)) {
                 cases$export_path[[i]] <- hit$export_path[[1L]]
             }
         } else {
             cases$status[[i]] <- "missing"
-            cases$missing_reason[[i]] <- if (!nrow(hit)) "final EPW was not produced" else "multiple final EPWs matched one expected case"
+            cases$missing_reason[[i]] <- if (!nrow(hit)) {
+                "final EPW was not produced"
+            } else {
+                "the expected future-weather sequence is incomplete"
+            }
         }
     }
     cases[]
@@ -9082,7 +9116,7 @@ shift__plan_run <- function(x, run_id, job_id = NULL, reporter = NULL,
         shift__run_cases_write(store, run_id, cases)
         reporter$cases_updated(cases,
             show = shift__ui_at_least(reporter$ui(), "detail"))
-        output_count <- nrow(cases[status == "completed"])
+        output_count <- nrow(shift_outputs(outputs_stage))
         if (!output_count) {
             cli::cli_abort("The workflow produced zero final EPW files.")
         }
@@ -9240,7 +9274,14 @@ shift__export_target_path <- function(row, dir, separate = TRUE) {
     path <- row$path[[1L]]
     filename <- basename(path)
     if (isTRUE(separate)) {
-        parts <- unlist(row[, intersect(c("source_id", "experiment_id", "variant_label", "period"), names(row)), with = FALSE], use.names = FALSE)
+        parts <- unlist(row[, intersect(c(
+            "source_id",
+            "experiment_id",
+            "variant_label",
+            "period",
+            "sequence_id",
+            "weather_year"
+        ), names(row)), with = FALSE], use.names = FALSE)
         parts <- morpher__safe_path(parts[!is.na(parts) & nzchar(parts)])
         return(do.call(file.path, as.list(c(dir, parts, filename))))
     }

--- a/R/store.R
+++ b/R/store.R
@@ -3837,9 +3837,39 @@ EsgStore <- R6::R6Class(
                     artifact_id VARCHAR,
                     output_path VARCHAR,
                     row_count INTEGER,
+                    output_type VARCHAR,
+                    sequence_id VARCHAR,
+                    weather_year INTEGER,
+                    calendar VARCHAR,
+                    stochastic_seed INTEGER,
+                    member_count INTEGER,
+                    provenance_json VARCHAR,
                     created_at TIMESTAMP
                 )
             "
+            )
+            # Existing stores predate year-addressable result rows, so add each
+            # nullable identity column without rewriting their artifacts.
+            private$exec(
+                "ALTER TABLE epw_morph_result ADD COLUMN IF NOT EXISTS output_type VARCHAR"
+            )
+            private$exec(
+                "ALTER TABLE epw_morph_result ADD COLUMN IF NOT EXISTS sequence_id VARCHAR"
+            )
+            private$exec(
+                "ALTER TABLE epw_morph_result ADD COLUMN IF NOT EXISTS weather_year INTEGER"
+            )
+            private$exec(
+                "ALTER TABLE epw_morph_result ADD COLUMN IF NOT EXISTS calendar VARCHAR"
+            )
+            private$exec(
+                "ALTER TABLE epw_morph_result ADD COLUMN IF NOT EXISTS stochastic_seed INTEGER"
+            )
+            private$exec(
+                "ALTER TABLE epw_morph_result ADD COLUMN IF NOT EXISTS member_count INTEGER"
+            )
+            private$exec(
+                "ALTER TABLE epw_morph_result ADD COLUMN IF NOT EXISTS provenance_json VARCHAR"
             )
             private$exec(
                 "
@@ -3847,15 +3877,49 @@ EsgStore <- R6::R6Class(
                     output_id VARCHAR PRIMARY KEY,
                     morph_id VARCHAR,
                     case_id VARCHAR,
+                    result_id VARCHAR,
                     artifact_id VARCHAR,
                     path VARCHAR,
                     source_id VARCHAR,
                     experiment_id VARCHAR,
                     variant_label VARCHAR,
                     period VARCHAR,
+                    output_type VARCHAR,
+                    sequence_id VARCHAR,
+                    weather_year INTEGER,
+                    calendar VARCHAR,
+                    stochastic_seed INTEGER,
+                    member_count INTEGER,
+                    provenance_json VARCHAR,
                     created_at TIMESTAMP
                 )
             "
+            )
+            # Output rows mirror result identity so resume and export can map
+            # every generated year without relying on case-level uniqueness.
+            private$exec(
+                "ALTER TABLE epw_output ADD COLUMN IF NOT EXISTS result_id VARCHAR"
+            )
+            private$exec(
+                "ALTER TABLE epw_output ADD COLUMN IF NOT EXISTS output_type VARCHAR"
+            )
+            private$exec(
+                "ALTER TABLE epw_output ADD COLUMN IF NOT EXISTS sequence_id VARCHAR"
+            )
+            private$exec(
+                "ALTER TABLE epw_output ADD COLUMN IF NOT EXISTS weather_year INTEGER"
+            )
+            private$exec(
+                "ALTER TABLE epw_output ADD COLUMN IF NOT EXISTS calendar VARCHAR"
+            )
+            private$exec(
+                "ALTER TABLE epw_output ADD COLUMN IF NOT EXISTS stochastic_seed INTEGER"
+            )
+            private$exec(
+                "ALTER TABLE epw_output ADD COLUMN IF NOT EXISTS member_count INTEGER"
+            )
+            private$exec(
+                "ALTER TABLE epw_output ADD COLUMN IF NOT EXISTS provenance_json VARCHAR"
             )
             invisible(NULL)
         },

--- a/R/weather-pipeline.R
+++ b/R/weather-pipeline.R
@@ -375,6 +375,10 @@ pipeline__execute <- function(plan, context, options = list()) {
     final <- previous@value
     if (inherits(final, "epw_morph_result")) {
         final$parts$component_pipeline <- pipeline__stage_table(stages)
+    } else if (S7::S7_inherits(final, WeatherSequenceResult)) {
+        # Sequence outputs retain the same inspectable component provenance as
+        # representative-year results without flattening their member data.
+        final@parts$component_pipeline <- pipeline__stage_table(stages)
     }
     WeatherPipelineExecution(
         plan = plan,

--- a/R/weather-sequence.R
+++ b/R/weather-sequence.R
@@ -1,0 +1,233 @@
+# Future-weather sequence results keep year identity outside the hourly table
+# so each member can be persisted, resumed, and written as an independent EPW.
+WeatherSequenceMember <- S7::new_class(
+    "WeatherSequenceMember",
+    properties = list(
+        sequence_id = S7::new_property(S7::class_character),
+        weather_year = S7::new_property(S7::class_integer),
+        calendar = S7::new_property(S7::class_character),
+        stochastic_seed = S7::new_property(
+            S7::class_integer,
+            default = NA_integer_
+        ),
+        data = S7::new_property(S7::class_any),
+        provenance = S7::new_property(S7::class_list, default = list())
+    ),
+    validator = function(self) {
+        if (length(self@sequence_id) != 1L ||
+            is.na(self@sequence_id) ||
+            !grepl("^[A-Za-z0-9][A-Za-z0-9._-]*$", self@sequence_id)) {
+            return(
+                "`sequence_id` must contain only letters, numbers, dots, underscores, or hyphens."
+            )
+        }
+        if (length(self@weather_year) != 1L ||
+            is.na(self@weather_year) ||
+            self@weather_year < 1L) {
+            return("`weather_year` must be one positive integer.")
+        }
+        if (length(self@calendar) != 1L ||
+            is.na(self@calendar) ||
+            !nzchar(self@calendar)) {
+            return("`calendar` must be one non-empty string.")
+        }
+        if (length(self@stochastic_seed) != 1L) {
+            return("`stochastic_seed` must be one integer or `NA_integer_`.")
+        }
+        if (!is.data.frame(self@data) || !nrow(self@data)) {
+            return("`data` must be a non-empty hourly weather table.")
+        }
+        if (!"year" %in% names(self@data)) {
+            return("`data` must contain an EPW `year` column.")
+        }
+        years <- unique(as.integer(self@data[["year"]]))
+        if (anyNA(years) ||
+            length(years) != 1L ||
+            !identical(years, self@weather_year)) {
+            return("Every hourly row must match `weather_year`.")
+        }
+        if (length(self@provenance) &&
+            (is.null(names(self@provenance)) ||
+                any(!nzchar(names(self@provenance))) ||
+                anyDuplicated(names(self@provenance)))) {
+            return("`provenance` must be a uniquely named list.")
+        }
+        NULL
+    }
+)
+
+# WeatherSequenceResult is the final backend contract for one or more explicit
+# future years; existing representative-year backends keep epw_morph_result().
+WeatherSequenceResult <- S7::new_class(
+    "WeatherSequenceResult",
+    properties = list(
+        backend = S7::new_property(S7::class_character),
+        recipe = S7::new_property(S7::class_list),
+        epw = S7::new_property(S7::class_any),
+        output_type = S7::new_property(S7::class_character),
+        members = S7::new_property(S7::class_list),
+        parts = S7::new_property(S7::class_list, default = list()),
+        diagnostics = S7::new_property(S7::class_any, default = NULL),
+        factors = S7::new_property(S7::class_any, default = NULL),
+        provenance = S7::new_property(S7::class_list, default = list())
+    ),
+    validator = function(self) {
+        if (length(self@backend) != 1L ||
+            is.na(self@backend) ||
+            !nzchar(self@backend)) {
+            return("`backend` must be one non-empty string.")
+        }
+        if (!inherits(self@epw, "EpwFile")) {
+            return("`epw` must be an internal EpwFile object.")
+        }
+        if (length(self@output_type) != 1L ||
+            is.na(self@output_type) ||
+            !self@output_type %in% c("future_year", "multi_year")) {
+            return("`output_type` must be `future_year` or `multi_year`.")
+        }
+        if (!length(self@members) ||
+            !all(vapply(
+                self@members,
+                S7::S7_inherits,
+                logical(1L),
+                class = WeatherSequenceMember
+            ))) {
+            return("`members` must contain WeatherSequenceMember objects.")
+        }
+        if (identical(self@output_type, "future_year") &&
+            length(self@members) != 1L) {
+            return("A `future_year` result must contain exactly one member.")
+        }
+        if (identical(self@output_type, "multi_year") &&
+            length(self@members) < 2L) {
+            return("A `multi_year` result must contain at least two members.")
+        }
+        keys <- vapply(self@members, function(member) {
+            paste(member@sequence_id, member@weather_year, sep = "\r")
+        }, character(1L))
+        if (anyDuplicated(keys)) {
+            return("Sequence member `sequence_id` and `weather_year` pairs must be unique.")
+        }
+        template <- self@epw$data()
+        required <- setdiff(names(template), "datetime")
+        valid_data <- vapply(self@members, function(member) {
+            nrow(member@data) == nrow(template) &&
+                all(required %in% names(member@data))
+        }, logical(1L))
+        if (!all(valid_data)) {
+            return(
+                "Every sequence member must contain a complete baseline-shaped EPW year."
+            )
+        }
+        if (length(self@provenance) &&
+            (is.null(names(self@provenance)) ||
+                any(!nzchar(names(self@provenance))) ||
+                anyDuplicated(names(self@provenance)))) {
+            return("`provenance` must be a uniquely named list.")
+        }
+        NULL
+    }
+)
+
+# Construct one validated sequence member after hourly reconstruction and
+# calendar mapping have produced a complete EPW-compatible weather year.
+sequence__member <- function(
+    data,
+    weather_year,
+    sequence_id = "default",
+    calendar = "noleap",
+    stochastic_seed = NA_integer_,
+    provenance = list()
+) {
+    checkmate::assert_data_frame(data, min.rows = 1L)
+    checkmate::assert_int(weather_year, lower = 1L)
+    checkmate::assert_string(
+        sequence_id,
+        pattern = "^[A-Za-z0-9][A-Za-z0-9._-]*$"
+    )
+    checkmate::assert_string(calendar, min.chars = 1L)
+    checkmate::assert_int(stochastic_seed, na.ok = TRUE)
+    checkmate::assert_list(provenance, names = "unique")
+    data <- data.table::as.data.table(data.table::copy(data))
+    if (all(c("year", "month", "day", "hour") %in% names(data))) {
+        # The EPW datetime column is derived convenience data. Recompute it
+        # after year assignment so Parquet timestamps match member identity.
+        data[, datetime := epw_file_datetime(year, month, day, hour)]
+        data.table::setcolorder(
+            data,
+            c("datetime", setdiff(names(data), "datetime"))
+        )
+    }
+    WeatherSequenceMember(
+        sequence_id = sequence_id,
+        weather_year = as.integer(weather_year),
+        calendar = calendar,
+        stochastic_seed = as.integer(stochastic_seed),
+        data = data,
+        provenance = provenance
+    )
+}
+
+# Construct the final typed sequence returned by an internal future-weather
+# backend while retaining the same context metadata as epw_morph_result().
+sequence__result <- function(
+    context,
+    members,
+    output_type = c("multi_year", "future_year"),
+    parts = list(),
+    diagnostics = morpher__empty_diagnostics(),
+    factors = NULL,
+    provenance = list()
+) {
+    checkmate::assert_class(context, "morpher__context")
+    checkmate::assert_list(members, min.len = 1L)
+    output_type <- match.arg(output_type)
+    checkmate::assert_list(parts, names = "named")
+    checkmate::assert_list(provenance, names = "unique")
+    WeatherSequenceResult(
+        backend = context$recipe$backend,
+        recipe = context$recipe,
+        epw = context$epw,
+        output_type = output_type,
+        members = members,
+        parts = parts,
+        diagnostics = diagnostics,
+        factors = factors,
+        provenance = provenance
+    )
+}
+
+# Normalize both legacy single-year and typed sequence backend results into
+# member records consumed uniformly by persistence and EPW output code.
+sequence__records <- function(result) {
+    if (inherits(result, "epw_morph_result")) {
+        return(list(list(
+            output_type = "representative_year",
+            sequence_id = NA_character_,
+            weather_year = NA_integer_,
+            calendar = NA_character_,
+            stochastic_seed = NA_integer_,
+            provenance = list(),
+            data = data.table::as.data.table(data.table::copy(result$data))
+        )))
+    }
+    if (!S7::S7_inherits(result, WeatherSequenceResult)) {
+        cli::cli_abort(
+            "A weather backend result must be an {.cls epw_morph_result} or {.cls WeatherSequenceResult}."
+        )
+    }
+    lapply(result@members, function(member) {
+        list(
+            output_type = result@output_type,
+            sequence_id = member@sequence_id,
+            weather_year = member@weather_year,
+            calendar = member@calendar,
+            stochastic_seed = member@stochastic_seed,
+            provenance = utils::modifyList(
+                result@provenance,
+                member@provenance
+            ),
+            data = data.table::as.data.table(data.table::copy(member@data))
+        )
+    })
+}

--- a/man/EpwMorpher.Rd
+++ b/man/EpwMorpher.Rd
@@ -284,7 +284,8 @@ Abort if a morphing plan has blocking diagnostics.
 \if{html}{\out{<a id="method-EpwMorpher-run"></a>}}
 \if{latex}{\out{\hypertarget{method-EpwMorpher-run}{}}}
 \subsection{Method \code{run()}}{
-Execute a morphing plan and write hourly result Parquet files.
+Execute a morphing plan and write one hourly Parquet file per result
+member and weather year.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{EpwMorpher$run(morph_id, overwrite = FALSE, resume = TRUE, reporter = NULL)}\if{html}{\out{</div>}}
 }
@@ -307,7 +308,7 @@ Execute a morphing plan and write hourly result Parquet files.
 \if{html}{\out{<a id="method-EpwMorpher-write_epw"></a>}}
 \if{latex}{\out{\hypertarget{method-EpwMorpher-write_epw}{}}}
 \subsection{Method \code{write_epw()}}{
-Write future EPW files from morphing results.
+Write one future EPW file for every persisted result member.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{EpwMorpher$write_epw(
   morph_id,

--- a/tests/testthat/helper-epw-morpher.R
+++ b/tests/testthat/helper-epw-morpher.R
@@ -1,0 +1,84 @@
+# Build a stable Solr response envelope for local morphing integration tests.
+epw_morpher_test_response <- function(docs) {
+    list(
+        responseHeader = list(
+            status = 0L,
+            QTime = 0L,
+            params = stats::setNames(list(), character())
+        ),
+        response = list(
+            numFound = nrow(docs),
+            start = 0L,
+            docs = docs,
+            maxScore = 1
+        ),
+        facet_counts = list(
+            facet_queries = stats::setNames(list(), character()),
+            facet_fields = stats::setNames(list(), character()),
+            facet_ranges = stats::setNames(list(), character()),
+            facet_intervals = stats::setNames(list(), character()),
+            facet_heatmaps = stats::setNames(list(), character())
+        ),
+        timestamp = as.POSIXct("2026-01-01 00:00:00", tz = "UTC")
+    )
+}
+
+# Return the file-query parameters shared by local morphing fixtures.
+epw_morpher_test_params <- function() {
+    query_param__as_store(list(
+        project = "CMIP6",
+        latest = TRUE,
+        distrib = TRUE,
+        limit = 10L,
+        type = "File",
+        format = QUERY_PARAM__FORMAT_JSON
+    ))
+}
+
+# Construct a typed ESGF result from local file-document fixtures.
+epw_morpher_test_result <- function(docs) {
+    query_result__new(
+        EsgResultFile,
+        index_node = "https://example.org",
+        params = epw_morpher_test_params(),
+        result = epw_morpher_test_response(docs)
+    )
+}
+
+# Describe one local NetCDF file with the ESGF fields consumed by EsgStore.
+epw_morpher_test_file_docs <- function(
+    path,
+    opendap_url,
+    download_url,
+    variable_id = "tas"
+) {
+    docs <- data.frame(
+        id = sprintf("%s|dataset-1", path),
+        dataset_id = "dataset-1",
+        size = 123,
+        checksum = "abc",
+        checksum_type = "SHA256",
+        instance_id = sprintf("%s.instance", path),
+        master_id = sprintf("%s.master", path),
+        replica = FALSE,
+        tracking_id = "hdl:21.14100/local-test-2060",
+        title = path,
+        version = 20260101L,
+        data_node = "example.org",
+        activity_id = "ScenarioMIP",
+        institution_id = "EC-Earth-Consortium",
+        source_id = "EC-Earth3",
+        experiment_id = "ssp585",
+        variant_label = "r1i1p1f1",
+        frequency = "day",
+        table_id = "day",
+        variable_id = variable_id,
+        grid_label = "gr",
+        check.names = FALSE
+    )
+    docs$url <- I(list(c(
+        sprintf("%s|application/netcdf|OPENDAP", opendap_url),
+        sprintf("%s|application/netcdf|HTTPServer", download_url)
+    )))
+    docs
+}

--- a/tests/testthat/test-epw-morpher.R
+++ b/tests/testthat/test-epw-morpher.R
@@ -1,79 +1,3 @@
-epw_morpher_test_response <- function(docs) {
-    list(
-        responseHeader = list(
-            status = 0L,
-            QTime = 0L,
-            params = stats::setNames(list(), character())
-        ),
-        response = list(
-            numFound = nrow(docs),
-            start = 0L,
-            docs = docs,
-            maxScore = 1
-        ),
-        facet_counts = list(
-            facet_queries = stats::setNames(list(), character()),
-            facet_fields = stats::setNames(list(), character()),
-            facet_ranges = stats::setNames(list(), character()),
-            facet_intervals = stats::setNames(list(), character()),
-            facet_heatmaps = stats::setNames(list(), character())
-        ),
-        timestamp = as.POSIXct("2026-01-01 00:00:00", tz = "UTC")
-    )
-}
-
-epw_morpher_test_params <- function() {
-    query_param__as_store(list(
-        project = "CMIP6",
-        latest = TRUE,
-        distrib = TRUE,
-        limit = 10L,
-        type = "File",
-        format = QUERY_PARAM__FORMAT_JSON
-    ))
-}
-
-epw_morpher_test_result <- function(docs) {
-    query_result__new(
-        EsgResultFile,
-        index_node = "https://example.org",
-        params = epw_morpher_test_params(),
-        result = epw_morpher_test_response(docs)
-    )
-}
-
-epw_morpher_test_file_docs <- function(path, opendap_url, download_url, variable_id = "tas") {
-    docs <- data.frame(
-        id = sprintf("%s|dataset-1", path),
-        dataset_id = "dataset-1",
-        size = 123,
-        checksum = "abc",
-        checksum_type = "SHA256",
-        instance_id = sprintf("%s.instance", path),
-        master_id = sprintf("%s.master", path),
-        replica = FALSE,
-        tracking_id = "hdl:21.14100/local-test-2060",
-        title = path,
-        version = 20260101L,
-        data_node = "example.org",
-        activity_id = "ScenarioMIP",
-        institution_id = "EC-Earth-Consortium",
-        source_id = "EC-Earth3",
-        experiment_id = "ssp585",
-        variant_label = "r1i1p1f1",
-        frequency = "day",
-        table_id = "day",
-        variable_id = variable_id,
-        grid_label = "gr",
-        check.names = FALSE
-    )
-    docs$url <- I(list(c(
-        sprintf("%s|application/netcdf|OPENDAP", opendap_url),
-        sprintf("%s|application/netcdf|HTTPServer", download_url)
-    )))
-    docs
-}
-
 test_that("get_cache_epw() prepares a stable local EPW fixture", {
     dir <- withr::local_tempdir()
     withr::local_envvar(EPWSHIFTR_CHECK_CACHE = dir)
@@ -614,6 +538,10 @@ test_that("epw_morpher() / EpwMorpher$required_variables() / EpwMorpher$summaris
     expect_equal(results$row_count, 8760L)
     result_path <- store_abs_path(results$output_path, root = store$path)
     expect_true(file.exists(result_path))
+    expect_identical(
+        results$result_id,
+        morpher__hash(relaxed$morph_id, results$case_id, result_path)
+    )
 
     result_data <- read_test_parquet(result_path)
     expect_true(all(c("source_id", "experiment_id", "variant_label", "period") %in% names(result_data)))
@@ -637,6 +565,10 @@ test_that("epw_morpher() / EpwMorpher$required_variables() / EpwMorpher$summaris
     expect_equal(nrow(outputs), 1L)
     output_path <- store_abs_path(outputs$path, root = store$path)
     expect_true(file.exists(output_path))
+    expect_identical(
+        outputs$output_id,
+        morpher__hash(relaxed$morph_id, outputs$case_id, output_path)
+    )
     expect_gt(file.size(output_path), 0)
     expect_true(inherits(epw_file_read(output_path), "EpwFile"))
 

--- a/tests/testthat/test-weather-sequence.R
+++ b/tests/testthat/test-weather-sequence.R
@@ -1,0 +1,267 @@
+test_that("future-weather sequence contracts validate year-addressable members", {
+    epw <- epw_file_read(get_cache_epw())
+    weather_2061 <- epw$data()
+    weather_2061[, year := 2061L]
+    weather_2062 <- data.table::copy(weather_2061)
+    weather_2062[, year := 2062L]
+
+    first <- sequence__member(
+        weather_2061,
+        weather_year = 2061L,
+        sequence_id = "realization-1",
+        stochastic_seed = 41L,
+        provenance = list(source = "synthetic")
+    )
+    second <- sequence__member(
+        weather_2062,
+        weather_year = 2062L,
+        sequence_id = "realization-1",
+        stochastic_seed = 42L
+    )
+    context <- morpher__context(
+        epw = epw,
+        climate = data.table::data.table(
+            time = as.POSIXct("2061-01-01", tz = "UTC"),
+            variable_id = "tas",
+            period = "future",
+            year = 2061L,
+            lon = 104,
+            lat = 1,
+            units = "K",
+            value = 300
+        ),
+        recipe = suppressWarnings(epw_morph_recipe("belcher_absolute"))
+    )
+    result <- sequence__result(
+        context,
+        list(first, second),
+        provenance = list(method = "synthetic_sequence")
+    )
+    future_year <- sequence__result(
+        context,
+        list(first),
+        output_type = "future_year"
+    )
+    records <- sequence__records(result)
+
+    expect_s7_class(first, WeatherSequenceMember)
+    expect_s7_class(result, WeatherSequenceResult)
+    expect_identical(future_year@output_type, "future_year")
+    expect_identical(format(first@data$datetime[[1L]], "%Y"), "2061")
+    expect_identical(
+        vapply(records, `[[`, integer(1L), "weather_year"),
+        c(2061L, 2062L)
+    )
+    expect_identical(records[[1L]]$provenance, list(
+        method = "synthetic_sequence",
+        source = "synthetic"
+    ))
+    expect_error(
+        sequence__member(weather_2061, weather_year = 2062L),
+        "Every hourly row"
+    )
+    expect_error(
+        sequence__result(context, list(first), output_type = "multi_year"),
+        "at least two members"
+    )
+    expect_error(
+        sequence__result(
+            context,
+            list(first, first),
+            output_type = "multi_year"
+        ),
+        "must be unique"
+    )
+})
+
+test_that("Shift case completion accepts only complete output sequences", {
+    cases <- data.table::data.table(
+        case_id = "case-1",
+        source_id = "Model-A",
+        experiment_id = "ssp585",
+        variant_label = "r1i1p1f1",
+        period = "2060s",
+        status = "ready",
+        output_id = NA_character_,
+        export_path = NA_character_,
+        missing_reason = NA_character_
+    )
+    outputs <- data.table::data.table(
+        output_id = c("output-2061", "output-2062"),
+        source_id = "Model-A",
+        experiment_id = "ssp585",
+        variant_label = "r1i1p1f1",
+        period = "2060s",
+        weather_year = 2061:2062,
+        member_count = 2L
+    )
+
+    complete <- shift__complete_output_cases(cases, outputs)
+    incomplete <- shift__complete_output_cases(cases, outputs[1L])
+
+    expect_identical(complete$status, "completed")
+    expect_identical(complete$output_id, "output-2061")
+    expect_identical(incomplete$status, "missing")
+    expect_match(incomplete$missing_reason, "sequence is incomplete")
+})
+
+test_that("EpwMorpher persists, resumes, and writes every sequence year", {
+    skip_if_not_installed("duckdb")
+    skip_if_not_installed("RNetCDF")
+
+    nc <- tempfile(fileext = ".nc")
+    write_local_cmip6_netcdf_fixture(nc, 2061L)
+    on.exit(unlink(nc), add = TRUE)
+
+    dir <- tempfile("esg-store-sequence-")
+    store <- EsgStore$new(dir)
+    on.exit(store$close(), add = TRUE)
+
+    docs <- epw_morpher_test_file_docs(
+        path = basename(nc),
+        opendap_url = nc,
+        download_url = nc
+    )
+    query_id <- store$add_files(epw_morpher_test_result(docs))
+    plan <- store$plan_region(
+        query_id = query_id,
+        lon = 103.98,
+        lat = 1.37,
+        time = c("2061-01-02T00:00:00Z", "2061-01-03T23:59:59Z"),
+        site_id = "SIN"
+    )
+    expect_identical(store$extract(plan_id = plan$plan_id)$status, "done")
+
+    backend_name <- paste0("testsequence", Sys.getpid())
+    rules <- data.table::data.table(
+        step = "dry",
+        epw_field = "dry_bulb_temperature",
+        variable_id = "tas",
+        optional_variable_id = NA_character_,
+        method = "offset",
+        required = TRUE,
+        derived = FALSE,
+        method_choices = list("offset")
+    )
+    # The synthetic backend exercises only the sequence/output contract; its
+    # two year members deliberately reuse one EPW template.
+    runner <- function(context, backend) {
+        members <- lapply(seq.int(2061L, 2062L), function(year) {
+            target_year <- year
+            weather <- context$epw$data()
+            weather[, `:=`(
+                year = target_year,
+                dry_bulb_temperature =
+                    dry_bulb_temperature + target_year - 2060L
+            )]
+            sequence__member(
+                weather,
+                weather_year = target_year,
+                sequence_id = "realization-1",
+                calendar = "noleap",
+                stochastic_seed = target_year - 2000L,
+                provenance = list(source_year = target_year)
+            )
+        })
+        sequence__result(
+            context,
+            members,
+            output_type = "multi_year",
+            provenance = list(backend = backend$name)
+        )
+    }
+    backend <- EpwMorphBackend$new(
+        name = backend_name,
+        methods = c(dry = "offset"),
+        method_choices = "offset",
+        rules = rules,
+        runner = runner
+    )
+    epw_morph_register_backend(backend_name, backend, overwrite = TRUE)
+
+    morpher <- epw_morpher(
+        store = store,
+        epw = get_cache_epw(),
+        site_id = "SIN",
+        recipe = epw_morph_recipe(backend_name),
+        label = "sequence-test"
+    )
+    climate <- morpher$summarise_climate(
+        plan$plan_id,
+        epw_morph_periods(future = 2061L),
+        strict = FALSE
+    )
+    baseline <- morpher$summarise_baseline()
+    morph_plan <- morpher$plan(
+        summary_id = unique(climate$summary_id),
+        baseline_id = unique(baseline$baseline_id),
+        strict = FALSE
+    )
+
+    results <- morpher$run(morph_plan$morph_id, overwrite = TRUE)
+    result_paths <- vapply(
+        results$output_path,
+        store_abs_path,
+        character(1L),
+        root = store$path
+    )
+    expect_identical(nrow(results), 2L)
+    expect_identical(results$output_type, rep("multi_year", 2L))
+    expect_identical(results$sequence_id, rep("realization-1", 2L))
+    expect_identical(results$weather_year, c(2061L, 2062L))
+    expect_identical(results$member_count, rep(2L, 2L))
+    expect_true(all(file.exists(result_paths)))
+    expect_match(results$output_path, "sequence=realization-1")
+
+    resumed <- morpher$run(
+        morph_plan$morph_id,
+        overwrite = FALSE,
+        resume = TRUE
+    )
+    expect_identical(resumed$result_id, results$result_id)
+
+    # Losing one member must regenerate that member while preserving its
+    # intact sibling and the complete two-row manifest.
+    sibling_mtime <- file.info(result_paths[[1L]])$mtime
+    unlink(result_paths[[2L]])
+    repaired <- morpher$run(
+        morph_plan$morph_id,
+        overwrite = FALSE,
+        resume = TRUE
+    )
+    expect_identical(repaired$result_id, results$result_id)
+    expect_true(all(file.exists(result_paths)))
+    expect_identical(file.info(result_paths[[1L]])$mtime, sibling_mtime)
+
+    outputs <- morpher$write_epw(
+        morph_id = morph_plan$morph_id,
+        dir = "outputs/future-sequence",
+        separate = FALSE,
+        overwrite = TRUE
+    )
+    output_paths <- vapply(
+        outputs$path,
+        store_abs_path,
+        character(1L),
+        root = store$path
+    )
+    expect_identical(nrow(outputs), 2L)
+    expect_identical(outputs$weather_year, c(2061L, 2062L))
+    expect_match(basename(output_paths), "realization-1\\.206[12]\\.epw$")
+    expect_true(all(file.exists(output_paths)))
+    expect_identical(
+        unname(vapply(output_paths, function(path) {
+            unique(epw_file_read(path)$data()$year)
+        }, integer(1L))),
+        c(2061L, 2062L)
+    )
+
+    resumed_outputs <- morpher$write_epw(
+        morph_id = morph_plan$morph_id,
+        dir = "outputs/future-sequence",
+        separate = FALSE,
+        overwrite = FALSE,
+        resume = TRUE
+    )
+    expect_identical(resumed_outputs$output_id, outputs$output_id)
+})

--- a/vignettes-raw/articles/epw-morpher.Rmd
+++ b/vignettes-raw/articles/epw-morpher.Rmd
@@ -616,7 +616,11 @@ separate stage and is not implied by selecting this signal.
 
 The runner returns `epw_morph_result()` with complete hourly EPW weather data.
 `EpwMorpher$run()` writes that data as Parquet and adds the case metadata
-columns needed by `write_epw()`.
+columns needed by `write_epw()`. Built-in sequence-generating recipes use an
+internal year-addressable result instead. Each member records its output type,
+sequence identifier, weather year, calendar, optional stochastic seed, and
+source provenance; public custom backends that return one
+`epw_morph_result()` retain their existing representative-year behavior.
 
 Rule tables must include `step`, `epw_field`, `method`, and `required`. They can
 use either the compact scalar columns `variable_id` and `optional_variable_id`
@@ -791,8 +795,12 @@ results <- morpher$run(
 )
 ```
 
-`run()` writes hourly morphed weather as Parquet artifacts under the store. It
-does not write EPW text files yet.
+`run()` writes hourly morphed weather as Parquet artifacts under the store. A
+representative-year result produces one artifact per climate case. A future
+sequence produces one independently resumable artifact per sequence member and
+weather year; `output_type`, `sequence_id`, `weather_year`, `calendar`, and
+`stochastic_seed` identify those rows in the result manifest. It does not write
+EPW text files yet.
 
 # Write EPW Files
 
@@ -813,7 +821,9 @@ morpher$outputs(morph_id)
 
 The high-level `shift_epw()` function wraps this step and returns a
 `ShiftOutputs` stage. Use `shift_outputs()` and `shift_data()` when you do not
-need lower-level manifest IDs.
+need lower-level manifest IDs. Sequence results are written as one EPW per
+weather year, with the sequence identifier and year included in the path and
+filename; multiple years are never flattened into a single EPW text file.
 
 For the enhanced profile, final EPW writing uses the persisted hourly Parquet
 artifact to recalculate ground temperatures and six hemisphere-aware

--- a/vignettes-raw/precompiled-checksums.csv
+++ b/vignettes-raw/precompiled-checksums.csv
@@ -1,7 +1,7 @@
 "source","output","source_md5","output_md5"
 "vignettes-raw/articles/cli-esgf-store.Rmd","vignettes/articles/cli-esgf-store.Rmd","cac788f79010ad56496939cdde3580bb","e58e5cafa0d3b2218081c25a1098273f"
 "vignettes-raw/articles/downloader.Rmd","vignettes/articles/downloader.Rmd","9668ccb5b39f0ca2f49e146a1a100a7c","4b67e4a9ddaecfe7ce3ac268936e2a2d"
-"vignettes-raw/articles/epw-morpher.Rmd","vignettes/articles/epw-morpher.Rmd","9ed1c944f1c3afb787ee51ee0aaf0511","b6e427df7d95306d39713dcb5f98766c"
+"vignettes-raw/articles/epw-morpher.Rmd","vignettes/articles/epw-morpher.Rmd","2e5cfb02b73aeb56454c6e1242114dc1","afe7863ca2f8d260b46c9297695672ac"
 "vignettes-raw/articles/esg-dictionaries.Rmd","vignettes/articles/esg-dictionaries.Rmd","94eb2513975549a6765afa221a2e10c1","290348d35a29e925f1b3732586e54cfb"
 "vignettes-raw/articles/esg-store.Rmd","vignettes/articles/esg-store.Rmd","c2d810261308c837b84c803a0d2632c5","bb73ddac53598a36b049797782ce3c02"
 "vignettes-raw/articles/esgf-query-results.Rmd","vignettes/articles/esgf-query-results.Rmd","9cb7e909ecc499eba79e4295857101d1","20854ab68644b18addeefcef1baafcfa"

--- a/vignettes/articles/epw-morpher.Rmd
+++ b/vignettes/articles/epw-morpher.Rmd
@@ -624,7 +624,11 @@ separate stage and is not implied by selecting this signal.
 
 The runner returns `epw_morph_result()` with complete hourly EPW weather data.
 `EpwMorpher$run()` writes that data as Parquet and adds the case metadata
-columns needed by `write_epw()`.
+columns needed by `write_epw()`. Built-in sequence-generating recipes use an
+internal year-addressable result instead. Each member records its output type,
+sequence identifier, weather year, calendar, optional stochastic seed, and
+source provenance; public custom backends that return one
+`epw_morph_result()` retain their existing representative-year behavior.
 
 Rule tables must include `step`, `epw_field`, `method`, and `required`. They can
 use either the compact scalar columns `variable_id` and `optional_variable_id`
@@ -799,8 +803,12 @@ results <- morpher$run(
 )
 ```
 
-`run()` writes hourly morphed weather as Parquet artifacts under the store. It
-does not write EPW text files yet.
+`run()` writes hourly morphed weather as Parquet artifacts under the store. A
+representative-year result produces one artifact per climate case. A future
+sequence produces one independently resumable artifact per sequence member and
+weather year; `output_type`, `sequence_id`, `weather_year`, `calendar`, and
+`stochastic_seed` identify those rows in the result manifest. It does not write
+EPW text files yet.
 
 # Write EPW Files
 
@@ -821,7 +829,9 @@ morpher$outputs(morph_id)
 
 The high-level `shift_epw()` function wraps this step and returns a
 `ShiftOutputs` stage. Use `shift_outputs()` and `shift_data()` when you do not
-need lower-level manifest IDs.
+need lower-level manifest IDs. Sequence results are written as one EPW per
+weather year, with the sequence identifier and year included in the path and
+filename; multiple years are never flattened into a single EPW text file.
 
 For the enhanced profile, final EPW writing uses the persisted hourly Parquet
 artifact to recalculate ground temperatures and six hemisphere-aware


### PR DESCRIPTION
## Summary

- Adds a year-addressable runtime result contract for `future_year` and `multi_year` recipes.
- Preserves existing `representative_year` behavior and custom `epw_morph_result()` backends.
- Closes #180.

## Changes

- Persists one Parquet result per sequence member with year, calendar, seed, provenance, and resume metadata.
- Writes one EPW per weather year with collision-free sequence-aware paths and exposes member identity through `shift_data()` and stored manifests.
- Adds schema migration, partial-resume, compatibility, and two-year end-to-end tests.
