### PR TITLE
feat: add direct model realization sequence

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -46,6 +46,12 @@
 
 ## New features
 
+* Added the deterministic `direct_model_realization` sequence component. It
+  preserves corrected daily `model_future` chronology, partitions complete
+  native CF-calendar years without selecting or resampling days, and retains
+  group identities and signal provenance for later hourly reconstruction
+  (#183).
+
 * Future-weather recipes with `future_year` or `multi_year` output types now
   persist a year-addressable sequence manifest and write one independently
   resumable Parquet and EPW member per weather year. Existing

--- a/R/weather-sequence.R
+++ b/R/weather-sequence.R
@@ -1,3 +1,449 @@
+# Direct model realizations use one stable identifier because ensemble-member
+# identity already belongs to the surrounding morphing case.
+DIRECT_MODEL_SEQUENCE_ID <- "direct-model"
+
+# Return a deterministic identity for one aligned signal group without
+# serializing its input payloads into the downstream sequence.
+sequence__direct_group_id <- function(group) {
+    if (!S7::S7_inherits(group, SignalGroup)) {
+        cli::cli_abort("{.arg group} must be a SignalGroup object.")
+    }
+    key <- group@key[sort(names(group@key))]
+    paste0(
+        "group-",
+        substr(
+            store__hash(
+                list(
+                    key = key,
+                    variables = sort(group@variables)
+                )
+            ),
+            1L,
+            16L
+        )
+    )
+}
+
+# Check whether one adjusted variable group contains exactly one complete,
+# ordered native-calendar year before it enters an hourly reconstructor.
+sequence__direct_year_error <- function(data, weather_year, calendar) {
+    if (!identical(unique(as.integer(data[["cf_year"]])), weather_year)) {
+        return("Every direct-model row must match `weather_year`.")
+    }
+    if (!identical(unique(data[["cf_calendar"]]), calendar)) {
+        return("Every direct-model row must match the member calendar.")
+    }
+    expected_order <- order(
+        data[["cf_day_of_year"]],
+        data[["annual_phase"]],
+        data[["variable_id"]],
+        method = "radix"
+    )
+    if (!identical(expected_order, seq_len(nrow(data)))) {
+        return("Direct-model rows must use native chronological order.")
+    }
+    for (variable in unique(data[["variable_id"]])) {
+        rows <- data[data[["variable_id"]] == variable, , drop = FALSE]
+        year_days <- unique(as.integer(rows[["cf_year_days"]]))
+        if (length(year_days) != 1L ||
+            nrow(rows) != year_days ||
+            !identical(
+                as.integer(rows[["cf_day_of_year"]]),
+                seq_len(year_days)
+            )) {
+            return(sprintf(
+                "Variable `%s` must cover every native-calendar day in weather year %d.",
+                variable,
+                weather_year
+            ))
+        }
+    }
+    NULL
+}
+
+# DirectModelSeries retains one signal group's key, variables, correction
+# metadata, and calendar-native daily values after partitioning by source year.
+DirectModelSeries <- S7::new_class(
+    "DirectModelSeries",
+    properties = list(
+        group_id = S7::new_property(S7::class_character),
+        key = S7::new_property(S7::class_list, default = list()),
+        variables = S7::new_property(S7::class_character),
+        adjusted = S7::new_property(S7::class_any)
+    ),
+    validator = function(self) {
+        if (length(self@group_id) != 1L ||
+            is.na(self@group_id) ||
+            !grepl("^[a-z][a-z0-9-]*$", self@group_id)) {
+            return("`group_id` must use lower-case letters, numbers, and hyphens.")
+        }
+        if (length(self@key) &&
+            (is.null(names(self@key)) ||
+                any(!nzchar(names(self@key))) ||
+                anyDuplicated(names(self@key)) ||
+                any(vapply(self@key, length, integer(1L)) != 1L) ||
+                any(!vapply(self@key, is.atomic, logical(1L))))) {
+            return("`key` must be a uniquely named list of atomic scalar values.")
+        }
+        if (!length(self@variables) ||
+            anyNA(self@variables) ||
+            any(!grepl("^[A-Za-z][A-Za-z0-9_]*$", self@variables)) ||
+            anyDuplicated(self@variables)) {
+            return("`variables` must contain unique CMIP-style identifiers.")
+        }
+        if (!S7::S7_inherits(self@adjusted, DailyAdjustedSeries)) {
+            return("`adjusted` must be a DailyAdjustedSeries object.")
+        }
+        if (!identical(self@adjusted@output_role, "model_future")) {
+            return("Direct model realization requires a `model_future` signal output.")
+        }
+        if (!setequal(
+            self@variables,
+            unique(self@adjusted@data[["variable_id"]])
+        )) {
+            return("`variables` must match the adjusted series variables.")
+        }
+        NULL
+    }
+)
+
+# DirectModelSequenceMember groups all corrected signal series belonging to
+# one complete source-model year without selecting, resampling, or reordering days.
+DirectModelSequenceMember <- S7::new_class(
+    "DirectModelSequenceMember",
+    properties = list(
+        sequence_id = S7::new_property(S7::class_character),
+        weather_year = S7::new_property(S7::class_integer),
+        calendar = S7::new_property(S7::class_character),
+        series = S7::new_property(S7::class_list),
+        provenance = S7::new_property(S7::class_list, default = list())
+    ),
+    validator = function(self) {
+        if (length(self@sequence_id) != 1L ||
+            is.na(self@sequence_id) ||
+            !grepl("^[A-Za-z0-9][A-Za-z0-9._-]*$", self@sequence_id)) {
+            return("`sequence_id` contains unsupported characters.")
+        }
+        if (length(self@weather_year) != 1L ||
+            is.na(self@weather_year) ||
+            self@weather_year < 1L) {
+            return("`weather_year` must be one positive integer.")
+        }
+        if (length(self@calendar) != 1L ||
+            is.na(self@calendar) ||
+            !self@calendar %in% CF_TIME_CALENDARS) {
+            return("`calendar` must identify one supported CF calendar.")
+        }
+        if (!length(self@series) ||
+            !all(vapply(
+                self@series,
+                S7::S7_inherits,
+                logical(1L),
+                class = DirectModelSeries
+            ))) {
+            return("`series` must contain DirectModelSeries objects.")
+        }
+        group_ids <- vapply(
+            self@series,
+            function(item) item@group_id,
+            character(1L)
+        )
+        if (anyDuplicated(group_ids)) {
+            return("Direct-model group identities must be unique within a year.")
+        }
+        for (item in self@series) {
+            error <- sequence__direct_year_error(
+                item@adjusted@data,
+                self@weather_year,
+                self@calendar
+            )
+            if (!is.null(error)) {
+                return(error)
+            }
+        }
+        if (length(self@provenance) &&
+            (is.null(names(self@provenance)) ||
+                any(!nzchar(names(self@provenance))) ||
+                anyDuplicated(names(self@provenance)))) {
+            return("`provenance` must be a uniquely named list.")
+        }
+        NULL
+    }
+)
+
+# DirectModelSequence is the typed intermediate exchanged between a future-
+# backbone signal and a later daily-to-hourly reconstruction component.
+DirectModelSequence <- S7::new_class(
+    "DirectModelSequence",
+    properties = list(
+        members = S7::new_property(S7::class_list),
+        frequency = S7::new_property(S7::class_character),
+        provenance = S7::new_property(S7::class_list, default = list())
+    ),
+    validator = function(self) {
+        if (!length(self@members) ||
+            !all(vapply(
+                self@members,
+                S7::S7_inherits,
+                logical(1L),
+                class = DirectModelSequenceMember
+            ))) {
+            return("`members` must contain DirectModelSequenceMember objects.")
+        }
+        if (!identical(self@frequency, "day")) {
+            return("DirectModelSequence currently requires daily values.")
+        }
+        years <- vapply(
+            self@members,
+            function(member) member@weather_year,
+            integer(1L)
+        )
+        if (anyDuplicated(years) || !identical(years, sort(years))) {
+            return("Direct-model members must use unique ascending weather years.")
+        }
+        sequence_ids <- vapply(
+            self@members,
+            function(member) member@sequence_id,
+            character(1L)
+        )
+        calendars <- vapply(
+            self@members,
+            function(member) member@calendar,
+            character(1L)
+        )
+        if (length(unique(sequence_ids)) != 1L) {
+            return("Direct-model members must share one `sequence_id`.")
+        }
+        if (length(unique(calendars)) != 1L) {
+            return("Direct-model members must share one CF calendar.")
+        }
+        group_ids <- lapply(self@members, function(member) {
+            sort(vapply(
+                member@series,
+                function(item) item@group_id,
+                character(1L)
+            ))
+        })
+        if (!all(vapply(
+            group_ids[-1L],
+            identical,
+            logical(1L),
+            group_ids[[1L]]
+        ))) {
+            return("Every direct-model year must contain the same signal groups.")
+        }
+        if (length(self@provenance) &&
+            (is.null(names(self@provenance)) ||
+                any(!nzchar(names(self@provenance))) ||
+                anyDuplicated(names(self@provenance)))) {
+            return("`provenance` must be a uniquely named list.")
+        }
+        NULL
+    }
+)
+
+# Rebuild one year slice with the original signal transformation, settings,
+# and provenance while retaining only variables present in that source year.
+sequence__slice_adjusted <- function(adjusted, year) {
+    data <- data.table::as.data.table(
+        data.table::copy(adjusted@data)
+    )
+    data <- data[data[["cf_year"]] == year]
+    data.table::setorderv(
+        data,
+        c("cf_day_of_year", "annual_phase", "variable_id")
+    )
+    variables <- unique(data[["variable_id"]])
+    bias__daily_adjusted_series(
+        data,
+        output_role = adjusted@output_role,
+        transformation = adjusted@transformation,
+        variable_metadata = adjusted@variable_metadata[variables],
+        settings = adjusted@settings,
+        provenance = adjusted@provenance
+    )
+}
+
+# Construct one typed year member from all aligned signal groups after the
+# generator has established common year and calendar coverage.
+sequence__direct_member <- function(series, weather_year, calendar) {
+    group_ids <- vapply(
+        series,
+        function(item) item@group_id,
+        character(1L)
+    )
+    DirectModelSequenceMember(
+        sequence_id = DIRECT_MODEL_SEQUENCE_ID,
+        weather_year = as.integer(weather_year),
+        calendar = calendar,
+        series = series,
+        provenance = list(
+            source_role = "model_future",
+            source_year = as.integer(weather_year),
+            calendar = calendar,
+            ordering = "native_cf_chronology",
+            selection = "none",
+            resampling = "none",
+            group_ids = group_ids
+        )
+    )
+}
+
+# Preserve the corrected future-model chronology, partition it by complete CF
+# year, and retain group-level signal metadata for later hourly reconstruction.
+sequence__direct_model_generate <- function(
+    data,
+    inputs,
+    context,
+    options
+) {
+    if (!S7::S7_inherits(data, SignalExecutionResult) ||
+        !length(data@groups) ||
+        length(data@groups) != length(data@values)) {
+        cli::cli_abort(
+            "Direct model realization requires an aligned SignalExecutionResult."
+        )
+    }
+    if (any(data@diagnostics[["status"]] != "ok") ||
+        any(vapply(data@values, is.null, logical(1L)))) {
+        cli::cli_abort(
+            "Direct model realization cannot preserve failed signal groups."
+        )
+    }
+    if (!all(vapply(
+        data@values,
+        S7::S7_inherits,
+        logical(1L),
+        class = DailyAdjustedSeries
+    ))) {
+        cli::cli_abort(
+            "Direct model realization currently requires DailyAdjustedSeries values."
+        )
+    }
+
+    group_ids <- vapply(
+        data@groups,
+        sequence__direct_group_id,
+        character(1L)
+    )
+    if (anyDuplicated(group_ids)) {
+        cli::cli_abort(
+            "Direct model realization received duplicate signal-group identities."
+        )
+    }
+    year_sets <- lapply(data@values, function(adjusted) {
+        if (!identical(adjusted@output_role, "model_future")) {
+            cli::cli_abort(
+                "Direct model realization requires every signal output to retain `model_future`."
+            )
+        }
+        calendars <- unique(adjusted@data[["cf_calendar"]])
+        if (length(calendars) != 1L) {
+            cli::cli_abort(
+                "Each direct-model signal group must use one native CF calendar."
+            )
+        }
+        sort(unique(as.integer(adjusted@data[["cf_year"]])))
+    })
+    if (!all(vapply(
+        year_sets[-1L],
+        identical,
+        logical(1L),
+        year_sets[[1L]]
+    ))) {
+        cli::cli_abort(
+            "Every direct-model signal group must cover the same weather years."
+        )
+    }
+    calendars <- vapply(
+        data@values,
+        function(adjusted) unique(adjusted@data[["cf_calendar"]]),
+        character(1L)
+    )
+    if (length(unique(calendars)) != 1L) {
+        cli::cli_abort(
+            "Every direct-model signal group must use the same CF calendar."
+        )
+    }
+
+    years <- year_sets[[1L]]
+    members <- lapply(years, function(year) {
+        series <- lapply(seq_along(data@values), function(index) {
+            DirectModelSeries(
+                group_id = group_ids[[index]],
+                key = data@groups[[index]]@key,
+                variables = data@groups[[index]]@variables,
+                adjusted = sequence__slice_adjusted(
+                    data@values[[index]],
+                    year
+                )
+            )
+        })
+        sequence__direct_member(series, year, calendars[[1L]])
+    })
+    DirectModelSequence(
+        members = members,
+        frequency = "day",
+        provenance = list(
+            method = "direct_model_realization",
+            source_role = "model_future",
+            ordering = "native_cf_chronology",
+            selection = "none",
+            resampling = "none",
+            years = years,
+            calendar = calendars[[1L]],
+            group_ids = group_ids
+        )
+    )
+}
+
+# Describe the deterministic sequence component independently of any one
+# complete weather recipe or bias-adjustment implementation.
+sequence__direct_model_component <- function() {
+    component__spec(
+        name = "direct_model_realization",
+        stage = "sequence",
+        label = "Direct model realization",
+        required_inputs = list(
+            model_future = component__input_requirement(
+                "model_future",
+                representations = "series",
+                frequencies = "day",
+                calendars = CF_TIME_CALENDARS
+            )
+        ),
+        input_kinds = "daily_adjusted_series",
+        output_kinds = "direct_model_sequence",
+        scopes = "multivariate",
+        stochastic = FALSE,
+        operations = list(generate = sequence__direct_model_generate),
+        metadata = list(
+            sequence_method = "direct_model_realization",
+            source_role = "model_future",
+            ordering = "native_cf_chronology",
+            selection = "none",
+            resampling = "none",
+            supported_frequencies = "day",
+            output_contract = "direct_model_sequence"
+        )
+    )
+}
+
+# Register the reusable sequence implementation once so recipes can refer to
+# its stable algorithmic name without embedding executable functions.
+sequence__register_direct_model_component <- function() {
+    component <- sequence__direct_model_component()
+    key <- component__registry_key(component@stage, component@name)
+    if (!exists(
+        key,
+        envir = WEATHER_COMPONENT_REGISTRY,
+        inherits = FALSE
+    )) {
+        component__register(component)
+    }
+    invisible(NULL)
+}
+
 # Future-weather sequence results keep year identity outside the hourly table
 # so each member can be persisted, resumed, and written as an independent EPW.
 WeatherSequenceMember <- S7::new_class(

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -11,7 +11,7 @@
     registerS3method("print", "epwshiftr_bytes",
         print.epwshiftr_bytes, envir = asNamespace("base"))
     cache__configure(pkgname)
-    # Register standalone signal methods at load time so downstream component
+    # Register standalone scientific components at load time so downstream
     # pipelines can resolve them without constructing a complete EPW recipe.
     bias__register_linear_scaling_component()
     bias__register_delta_change_component()
@@ -21,6 +21,7 @@
     cdft__register_component()
     edcdf__register_component()
     isimip__register_component()
+    sequence__register_direct_model_component()
 
     # set package options
     .opts <- list(

--- a/tests/testthat/test-direct-model-sequence.R
+++ b/tests/testthat/test-direct-model-sequence.R
@@ -1,0 +1,322 @@
+# Build one complete calendar-native year whose values expose any accidental
+# change from source chronology during sequence partitioning.
+direct_sequence_test__year <- function(
+    variable,
+    year,
+    calendar = "noleap",
+    reverse = FALSE
+) {
+    year_days <- cf_time__year_days(year, calendar)[[1L]]
+    fields <- cf_time_offset2date(
+        seq.int(0L, year_days - 1L),
+        data.frame(year = year, month = 1L, day = 1L),
+        calendar
+    )
+    fields$hour <- 12L
+    fields$minute <- 0L
+    fields$second <- 0
+    data <- data.frame(
+        variable_id = rep.int(variable, year_days),
+        value = seq_len(year_days),
+        units = rep.int(if (identical(variable, "pr")) {
+            "kg m-2 s-1"
+        } else {
+            "K"
+        }, year_days),
+        frequency = rep.int("day", year_days),
+        cf_time__coordinates(fields, calendar),
+        stringsAsFactors = FALSE
+    )
+    if (isTRUE(reverse)) {
+        data <- data[rev(seq_len(nrow(data))), , drop = FALSE]
+    }
+    data
+}
+
+# Construct one future-backbone adjusted series spanning the requested model
+# years while retaining a visible upstream transformation record.
+direct_sequence_test__adjusted <- function(
+    variable,
+    years,
+    calendar = "noleap",
+    reverse = FALSE,
+    output_role = "model_future"
+) {
+    rows <- lapply(years, function(year) {
+        direct_sequence_test__year(
+            variable,
+            year,
+            calendar,
+            reverse
+        )
+    })
+    bias__daily_adjusted_series(
+        do.call(rbind, rows),
+        output_role = output_role,
+        transformation = "test_adjustment",
+        settings = list(window_days = 31L),
+        provenance = list(method = "test_adjustment")
+    )
+}
+
+# Assemble the canonical signal envelope consumed by every sequence component
+# without invoking a particular bias-adjustment kernel in these focused tests.
+direct_sequence_test__execution <- function(
+    values,
+    keys = rep(list(list(site = "A")), length(values)),
+    statuses = rep.int("ok", length(values))
+) {
+    groups <- lapply(seq_along(values), function(index) {
+        adjusted <- values[[index]]
+        signal__group(
+            key = keys[[index]],
+            inputs = list(model_future = adjusted@data),
+            variables = unique(adjusted@data[["variable_id"]])
+        )
+    })
+    variables <- unique(unlist(
+        lapply(groups, function(group) group@variables),
+        use.names = FALSE
+    ))
+    SignalExecutionResult(
+        groups = groups,
+        values = values,
+        profiles = stats::setNames(
+            lapply(variables, function(variable) {
+                list(variable_id = variable)
+            }),
+            variables
+        ),
+        diagnostics = data.frame(
+            method = rep.int("test_signal", length(groups)),
+            group = vapply(
+                seq_along(groups),
+                function(index) {
+                    signal__group_label(groups[[index]], index)
+                },
+                character(1L)
+            ),
+            status = statuses,
+            variables = vapply(
+                groups,
+                function(group) paste(group@variables, collapse = ","),
+                character(1L)
+            ),
+            evidence = rep.int("published", length(groups)),
+            message = rep.int(NA_character_, length(groups)),
+            stringsAsFactors = FALSE
+        )
+    )
+}
+
+test_that("direct model sequence preserves and partitions future chronology", {
+    execution <- direct_sequence_test__execution(list(
+        direct_sequence_test__adjusted(
+            "tas",
+            2061:2062,
+            reverse = TRUE
+        ),
+        direct_sequence_test__adjusted("pr", 2061:2062)
+    ))
+
+    first <- sequence__direct_model_generate(
+        execution,
+        inputs = NULL,
+        context = NULL,
+        options = list()
+    )
+    second <- sequence__direct_model_generate(
+        execution,
+        inputs = NULL,
+        context = NULL,
+        options = list()
+    )
+
+    expect_s7_class(first, DirectModelSequence)
+    expect_identical(first@frequency, "day")
+    expect_identical(
+        vapply(
+            first@members,
+            function(member) member@weather_year,
+            integer(1L)
+        ),
+        2061:2062
+    )
+    expect_identical(
+        vapply(
+            first@members,
+            function(member) member@sequence_id,
+            character(1L)
+        ),
+        rep.int(DIRECT_MODEL_SEQUENCE_ID, 2L)
+    )
+    expect_identical(
+        first@provenance$group_ids,
+        second@provenance$group_ids
+    )
+    expect_identical(first@provenance$selection, "none")
+    expect_identical(first@provenance$resampling, "none")
+
+    for (member in first@members) {
+        expect_identical(member@calendar, "noleap")
+        expect_length(member@series, 2L)
+        for (item in member@series) {
+            expect_identical(
+                item@adjusted@data$cf_day_of_year,
+                seq_len(365L)
+            )
+            expect_identical(
+                item@adjusted@provenance$method,
+                "test_adjustment"
+            )
+        }
+    }
+})
+
+test_that("direct model sequence accepts every supported native CF calendar", {
+    for (calendar in CF_TIME_CALENDARS) {
+        execution <- direct_sequence_test__execution(list(
+            direct_sequence_test__adjusted(
+                "tas",
+                2000L,
+                calendar
+            )
+        ))
+        sequence <- sequence__direct_model_generate(
+            execution,
+            NULL,
+            NULL,
+            list()
+        )
+        member <- sequence@members[[1L]]
+
+        expect_identical(member@calendar, calendar, info = calendar)
+        expect_identical(
+            nrow(member@series[[1L]]@adjusted@data),
+            cf_time__year_days(2000L, calendar)[[1L]],
+            info = calendar
+        )
+    }
+})
+
+test_that("direct model component is registered and contract-compatible", {
+    sequence__register_direct_model_component()
+    component <- component__get("sequence", "direct_model_realization")
+    qdm <- qdm__component()
+    hourly <- component__spec(
+        name = "direct_model_hourly_test",
+        stage = "hourly",
+        input_kinds = "direct_model_sequence",
+        output_kinds = "hourly_weather",
+        scopes = "multivariate",
+        operations = list(reconstruct = identity)
+    )
+    source <- direct_sequence_test__year("tas", 2061L)
+    inputs <- weather__new_inputs(
+        model_future = weather__new_input("model_future", source)
+    )
+
+    expect_s7_class(component, WeatherComponentSpec)
+    expect_identical(component@stage, "sequence")
+    expect_identical(component@input_kinds, "daily_adjusted_series")
+    expect_identical(component@output_kinds, "direct_model_sequence")
+    expect_false(component@stochastic)
+    expect_identical(component@metadata$selection, "none")
+    expect_invisible(component__validate_inputs(component, inputs))
+    expect_true(component__compatible(qdm, component))
+    expect_true(component__compatible(component, hourly))
+})
+
+test_that("direct model sequence rejects incomplete or misaligned groups", {
+    complete <- direct_sequence_test__adjusted("tas", 2061:2062)
+    incomplete_data <- direct_sequence_test__year("pr", 2061L)[-365L, ]
+    incomplete <- bias__daily_adjusted_series(
+        incomplete_data,
+        "model_future",
+        "test_adjustment"
+    )
+    expect_error(
+        sequence__direct_model_generate(
+            direct_sequence_test__execution(list(incomplete)),
+            NULL,
+            NULL,
+            list()
+        ),
+        "cover every native-calendar day"
+    )
+
+    expect_error(
+        sequence__direct_model_generate(
+            direct_sequence_test__execution(list(
+                complete,
+                direct_sequence_test__adjusted("pr", 2061L)
+            )),
+            NULL,
+            NULL,
+            list()
+        ),
+        "same weather years"
+    )
+
+    expect_error(
+        sequence__direct_model_generate(
+            direct_sequence_test__execution(list(
+                direct_sequence_test__adjusted("tas", 2061L),
+                direct_sequence_test__adjusted(
+                    "pr",
+                    2061L,
+                    "360_day"
+                )
+            )),
+            NULL,
+            NULL,
+            list()
+        ),
+        "same CF calendar"
+    )
+})
+
+test_that("direct model sequence rejects wrong roles, duplicates, and failures", {
+    observed <- direct_sequence_test__adjusted(
+        "tas",
+        2061L,
+        output_role = "observed_reference"
+    )
+    expect_error(
+        sequence__direct_model_generate(
+            direct_sequence_test__execution(list(observed)),
+            NULL,
+            NULL,
+            list()
+        ),
+        "retain `model_future`"
+    )
+
+    adjusted <- direct_sequence_test__adjusted("tas", 2061L)
+    expect_error(
+        sequence__direct_model_generate(
+            direct_sequence_test__execution(
+                list(adjusted, adjusted),
+                keys = list(list(site = "A"), list(site = "A"))
+            ),
+            NULL,
+            NULL,
+            list()
+        ),
+        "duplicate signal-group identities"
+    )
+
+    failed <- direct_sequence_test__execution(
+        list(adjusted),
+        statuses = "error"
+    )
+    failed@values[1L] <- list(NULL)
+    expect_error(
+        sequence__direct_model_generate(failed, NULL, NULL, list()),
+        "cannot preserve failed signal groups"
+    )
+    expect_error(
+        sequence__direct_model_generate("not-a-signal", NULL, NULL, list()),
+        "aligned SignalExecutionResult"
+    )
+})

--- a/vignettes-raw/articles/epw-morpher.Rmd
+++ b/vignettes-raw/articles/epw-morpher.Rmd
@@ -487,6 +487,17 @@ methods use all seven stages, including explicit
 forms native-calendar monthly distributions and its `signal` component
 requires both historical model output and a separate observed reference.
 
+Sequence implementations can also be registered independently of a complete
+recipe. The current standalone sequence contract is:
+
+| Registry name | Accepted signal result | Behavior | Output contract |
+|:--------------|:-----------------------|:---------|:----------------|
+| `direct_model_realization` | Complete daily `DailyAdjustedSeries` groups retaining the `model_future` backbone | Preserve native CF chronology, partition complete source years, and perform no day selection or resampling | One `DirectModelSequence` containing deterministic year members, group keys, corrected values, signal provenance, source years, and calendars |
+
+`direct_model_realization` currently accepts daily values. Sub-daily signal
+types and their hourly interpolation remain separate later components; the
+sequence stage does not silently interpolate or construct EPW fields.
+
 Bias-adjustment implementations belong to the `signal` stage. Their common
 `apply` operation validates the role-addressable inputs, resolves
 variable-specific settings, and executes aligned groups. Each method supplies

--- a/vignettes-raw/precompiled-checksums.csv
+++ b/vignettes-raw/precompiled-checksums.csv
@@ -1,7 +1,7 @@
 "source","output","source_md5","output_md5"
 "vignettes-raw/articles/cli-esgf-store.Rmd","vignettes/articles/cli-esgf-store.Rmd","cac788f79010ad56496939cdde3580bb","e58e5cafa0d3b2218081c25a1098273f"
 "vignettes-raw/articles/downloader.Rmd","vignettes/articles/downloader.Rmd","9668ccb5b39f0ca2f49e146a1a100a7c","4b67e4a9ddaecfe7ce3ac268936e2a2d"
-"vignettes-raw/articles/epw-morpher.Rmd","vignettes/articles/epw-morpher.Rmd","2e5cfb02b73aeb56454c6e1242114dc1","afe7863ca2f8d260b46c9297695672ac"
+"vignettes-raw/articles/epw-morpher.Rmd","vignettes/articles/epw-morpher.Rmd","0cc88f8dc14840e7b130bfabca583df1","fc1cef403e74396e3773a5919e220380"
 "vignettes-raw/articles/esg-dictionaries.Rmd","vignettes/articles/esg-dictionaries.Rmd","94eb2513975549a6765afa221a2e10c1","290348d35a29e925f1b3732586e54cfb"
 "vignettes-raw/articles/esg-store.Rmd","vignettes/articles/esg-store.Rmd","c2d810261308c837b84c803a0d2632c5","bb73ddac53598a36b049797782ce3c02"
 "vignettes-raw/articles/esgf-query-results.Rmd","vignettes/articles/esgf-query-results.Rmd","9cb7e909ecc499eba79e4295857101d1","20854ab68644b18addeefcef1baafcfa"

--- a/vignettes/articles/epw-morpher.Rmd
+++ b/vignettes/articles/epw-morpher.Rmd
@@ -495,6 +495,17 @@ methods use all seven stages, including explicit
 forms native-calendar monthly distributions and its `signal` component
 requires both historical model output and a separate observed reference.
 
+Sequence implementations can also be registered independently of a complete
+recipe. The current standalone sequence contract is:
+
+| Registry name | Accepted signal result | Behavior | Output contract |
+|:--------------|:-----------------------|:---------|:----------------|
+| `direct_model_realization` | Complete daily `DailyAdjustedSeries` groups retaining the `model_future` backbone | Preserve native CF chronology, partition complete source years, and perform no day selection or resampling | One `DirectModelSequence` containing deterministic year members, group keys, corrected values, signal provenance, source years, and calendars |
+
+`direct_model_realization` currently accepts daily values. Sub-daily signal
+types and their hourly interpolation remain separate later components; the
+sequence stage does not silently interpolate or construct EPW fields.
+
 Bias-adjustment implementations belong to the `signal` stage. Their common
 `apply` operation validates the role-addressable inputs, resolves
 variable-specific settings, and executes aligned groups. Each method supplies


### PR DESCRIPTION
## Summary

- Adds a registered `direct_model_realization` sequence component for corrected daily `model_future` series.
- Keeps bias adjustment, hourly reconstruction, and final EPW construction in their existing component stages.
- Closes #182.

## Changes

- Adds typed contracts for grouped adjusted series, complete source-model years, and deterministic multi-year realizations.
- Preserves native CF chronology and signal provenance while rejecting incomplete years, misaligned calendars, mismatched coverage, failed groups, and duplicate identities.
- Documents the standalone sequence contract and tests every supported CF calendar, year partitioning, component compatibility, and invalid inputs.
