### PR TITLE
feat: add frequency-aware adjusted series

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -46,6 +46,13 @@
 
 ## New features
 
+* Added the frequency-aware `AdjustedWeatherSeries` signal-result contract.
+  Existing daily methods retain their strict `DailyAdjustedSeries` output,
+  while regular sub-daily outputs carry explicit frequency, timestep, and
+  calendar-native time-of-day metadata. `direct_model_realization` now
+  preserves complete daily or sub-daily source-model years without resampling
+  (#185).
+
 * Added the deterministic `direct_model_realization` sequence component. It
   preserves corrected daily `model_future` chronology, partitions complete
   native CF-calendar years without selecting or resampling days, and retains

--- a/R/bias-adjustment.R
+++ b/R/bias-adjustment.R
@@ -1,9 +1,9 @@
 #' @include weather-signal.R
 NULL
 
-# A daily adjusted series is the package-native signal output shared by bias
-# adjustment methods, independently of any external method class hierarchy.
-BIAS_DAILY_SERIES_COLUMNS <- c(
+# Adjusted weather series share calendar-native coordinates independently of
+# the signal method and retain their native temporal frequency explicitly.
+BIAS_ADJUSTED_SERIES_COLUMNS <- c(
     "variable_id",
     "value",
     "units",
@@ -15,6 +15,17 @@ BIAS_DAILY_SERIES_COLUMNS <- c(
     "cf_day_of_year",
     "cf_year_days",
     "annual_phase"
+)
+
+# Daily methods retain their original canonical table without inventing a
+# time-of-day coordinate that is irrelevant to daily statistics.
+BIAS_DAILY_SERIES_COLUMNS <- BIAS_ADJUSTED_SERIES_COLUMNS
+
+# Sub-daily values add their exact position within the native-calendar day so
+# multiple samples never collapse onto the same date key.
+BIAS_SUBDAILY_SERIES_COLUMNS <- c(
+    BIAS_ADJUSTED_SERIES_COLUMNS,
+    "cf_second_of_day"
 )
 
 # Linear Scaling defaults cite the review in which the monthly additive
@@ -45,21 +56,28 @@ bias__named_list_error <- function(value, name) {
     NULL
 }
 
-# Validate the calendar-native daily table at the boundary shared by all
-# methods producing a DailyAdjustedSeries.
-bias__daily_data_error <- function(data) {
+# Validate the calendar-native fields shared by daily and sub-daily signal
+# results before applying frequency-specific sampling rules.
+bias__calendar_data_error <- function(
+    data,
+    required_columns,
+    label,
+    key_columns,
+    key_message
+) {
     if (!is.data.frame(data)) {
         return("`data` must be a data frame.")
     }
-    missing <- setdiff(BIAS_DAILY_SERIES_COLUMNS, names(data))
+    missing <- setdiff(required_columns, names(data))
     if (length(missing)) {
         return(sprintf(
-            "`data` is missing canonical daily column(s): %s.",
+            "`data` is missing canonical %s column(s): %s.",
+            label,
             paste(sprintf("`%s`", missing), collapse = ", ")
         ))
     }
     if (!nrow(data)) {
-        return("`data` must contain at least one daily value.")
+        return(sprintf("`data` must contain at least one %s value.", label))
     }
     if (!is.character(data[["variable_id"]]) ||
         anyNA(data[["variable_id"]]) ||
@@ -80,8 +98,8 @@ bias__daily_data_error <- function(data) {
     }
     if (!is.character(data[["frequency"]]) ||
         anyNA(data[["frequency"]]) ||
-        any(data[["frequency"]] != "day")) {
-        return("`frequency` must be `day` for every row.")
+        any(!nzchar(data[["frequency"]]))) {
+        return("`frequency` must contain non-missing, non-empty strings.")
     }
     if (!is.character(data[["cf_calendar"]]) ||
         anyNA(data[["cf_calendar"]]) ||
@@ -162,77 +180,220 @@ bias__daily_data_error <- function(data) {
         index <- data[["variable_id"]] == variable
         if (length(unique(data[["units"]][index])) != 1L) {
             return(sprintf(
-                "Variable `%s` must use one unit within a daily series.",
+                "Variable `%s` must use one unit within an adjusted series.",
                 variable
             ))
         }
     }
-    key <- data[
+    key <- data[key_columns]
+    if (anyDuplicated(key)) {
+        return(key_message)
+    }
+    NULL
+}
+
+# Validate the calendar-native daily table at the boundary shared by all
+# existing daily bias-adjustment methods.
+bias__daily_data_error <- function(data) {
+    error <- bias__calendar_data_error(
+        data,
+        BIAS_DAILY_SERIES_COLUMNS,
+        "daily",
         c(
             "variable_id",
             "cf_calendar",
             "cf_year",
             "cf_month",
             "cf_day"
-        )
-    ]
-    if (anyDuplicated(key)) {
-        return(
-            "`data` must have unique variable-calendar-year-month-day keys."
-        )
+        ),
+        "`data` must have unique variable-calendar-year-month-day keys."
+    )
+    if (!is.null(error)) {
+        return(error)
+    }
+    if (any(data[["frequency"]] != "day")) {
+        return("`frequency` must be `day` for every row.")
     }
     NULL
 }
 
-# DailyAdjustedSeries carries a canonical daily table and the semantic metadata
-# required by later sequence, hourly, physics, and output components.
-DailyAdjustedSeries <- S7::new_class(
-    "DailyAdjustedSeries",
+# Validate exact sub-day positions and their regular timestep without reducing
+# native CF dates to Gregorian timestamps.
+bias__subdaily_data_error <- function(data, frequency, time_step_seconds) {
+    error <- bias__calendar_data_error(
+        data,
+        BIAS_SUBDAILY_SERIES_COLUMNS,
+        "sub-daily",
+        c(
+            "variable_id",
+            "cf_calendar",
+            "cf_year",
+            "cf_month",
+            "cf_day",
+            "cf_second_of_day"
+        ),
+        paste(
+            "`data` must have unique",
+            "variable-calendar-year-month-day-second keys."
+        )
+    )
+    if (!is.null(error)) {
+        return(error)
+    }
+    if (any(data[["frequency"]] != frequency)) {
+        return("`data` frequency must match the declared `frequency`.")
+    }
+    seconds <- data[["cf_second_of_day"]]
+    if (!is.numeric(seconds) ||
+        any(!is.finite(seconds)) ||
+        any(seconds < 0 | seconds >= 86400)) {
+        return("`cf_second_of_day` must contain finite values in [0, 86400).")
+    }
+
+    # The annual phase and explicit time-of-day must describe the same native
+    # CF instant; this prevents ambiguous ordering around day boundaries.
+    expected_phase <- (
+        data[["cf_day_of_year"]] - 1 + seconds / 86400
+    ) / data[["cf_year_days"]]
+    tolerance <- sqrt(.Machine$double.eps)
+    if (any(abs(data[["annual_phase"]] - expected_phase) > tolerance)) {
+        return(
+            "`annual_phase` is inconsistent with `cf_second_of_day`."
+        )
+    }
+
+    # All samples must lie on one regular lattice even when incomplete periods
+    # are retained for a later completeness diagnostic.
+    remainders <- seconds %% time_step_seconds
+    distance <- abs(remainders - remainders[[1L]])
+    circular_distance <- pmin(
+        distance,
+        time_step_seconds - distance
+    )
+    if (any(circular_distance > 1e-6)) {
+        return("Sub-daily samples must share one regular timestep lattice.")
+    }
+    NULL
+}
+
+# Validate semantic metadata once for every adjusted-series specialization.
+bias__adjusted_series_error <- function(self) {
+    if (length(self@frequency) != 1L ||
+        is.na(self@frequency) ||
+        !grepl("^[A-Za-z0-9][A-Za-z0-9._-]*$", self@frequency)) {
+        return("`frequency` must be one non-empty frequency identifier.")
+    }
+    if (length(self@time_step_seconds) != 1L ||
+        is.na(self@time_step_seconds) ||
+        !is.finite(self@time_step_seconds) ||
+        self@time_step_seconds <= 0) {
+        return("`time_step_seconds` must be one positive finite number.")
+    }
+    if (!is.data.frame(self@data) ||
+        !"frequency" %in% names(self@data) ||
+        !identical(unique(self@data[["frequency"]]), self@frequency)) {
+        return("`data` must contain exactly the declared `frequency`.")
+    }
+    if (length(self@output_role) != 1L ||
+        is.na(self@output_role) ||
+        !self@output_role %in% WEATHER_INPUT_ROLES) {
+        return("`output_role` must identify one future-weather input role.")
+    }
+    if (length(self@transformation) != 1L ||
+        is.na(self@transformation) ||
+        !grepl("^[a-z][a-z0-9_]*$", self@transformation)) {
+        return("`transformation` must use lower snake_case.")
+    }
+    variables <- unique(self@data[["variable_id"]])
+    metadata_error <- bias__named_list_error(
+        self@variable_metadata,
+        "variable_metadata"
+    )
+    if (!is.null(metadata_error) ||
+        !setequal(names(self@variable_metadata), variables) ||
+        length(self@variable_metadata) != length(variables) ||
+        !all(vapply(
+            self@variable_metadata,
+            is.list,
+            logical(1L)
+        ))) {
+        return(
+            "`variable_metadata` must contain one named list per variable."
+        )
+    }
+    for (name in c("settings", "provenance")) {
+        error <- bias__named_list_error(S7::prop(self, name), name)
+        if (!is.null(error)) {
+            return(error)
+        }
+    }
+    NULL
+}
+
+# AdjustedWeatherSeries is the package-native, frequency-aware signal result
+# shared by daily and sub-daily methods.
+AdjustedWeatherSeries <- S7::new_class(
+    "AdjustedWeatherSeries",
+    abstract = TRUE,
     properties = list(
         data = S7::new_property(S7::class_any),
+        frequency = S7::new_property(S7::class_character),
+        time_step_seconds = S7::new_property(S7::class_numeric),
         output_role = S7::new_property(S7::class_character),
         transformation = S7::new_property(S7::class_character),
         variable_metadata = S7::new_property(S7::class_list),
         settings = S7::new_property(S7::class_list, default = list()),
         provenance = S7::new_property(S7::class_list, default = list())
     ),
+    validator = bias__adjusted_series_error
+)
+
+# DailyAdjustedSeries preserves the original strict daily contract while also
+# satisfying the common frequency-aware adjusted-series boundary.
+DailyAdjustedSeries <- S7::new_class(
+    "DailyAdjustedSeries",
+    parent = AdjustedWeatherSeries,
     validator = function(self) {
+        if (!identical(self@frequency, "day") ||
+            !identical(as.numeric(self@time_step_seconds), 86400)) {
+            return(
+                "DailyAdjustedSeries requires `day` frequency and an 86400-second timestep."
+            )
+        }
         error <- bias__daily_data_error(self@data)
         if (!is.null(error)) {
             return(error)
         }
-        if (length(self@output_role) != 1L ||
-            is.na(self@output_role) ||
-            !self@output_role %in% WEATHER_INPUT_ROLES) {
-            return("`output_role` must identify one future-weather input role.")
-        }
-        if (length(self@transformation) != 1L ||
-            is.na(self@transformation) ||
-            !grepl("^[a-z][a-z0-9_]*$", self@transformation)) {
-            return("`transformation` must use lower snake_case.")
-        }
-        variables <- unique(self@data[["variable_id"]])
-        metadata_error <- bias__named_list_error(
-            self@variable_metadata,
-            "variable_metadata"
-        )
-        if (!is.null(metadata_error) ||
-            !setequal(names(self@variable_metadata), variables) ||
-            length(self@variable_metadata) != length(variables) ||
-            !all(vapply(
-                self@variable_metadata,
-                is.list,
-                logical(1L)
-            ))) {
+        NULL
+    }
+)
+
+# SubdailyAdjustedSeries retains a regular native-calendar time lattice for
+# hourly and multi-hourly signal outputs.
+SubdailyAdjustedSeries <- S7::new_class(
+    "SubdailyAdjustedSeries",
+    parent = AdjustedWeatherSeries,
+    validator = function(self) {
+        if (identical(self@frequency, "day") ||
+            self@time_step_seconds >= 86400) {
             return(
-                "`variable_metadata` must contain one named list per variable."
+                "SubdailyAdjustedSeries requires a sub-daily frequency and timestep."
             )
         }
-        for (name in c("settings", "provenance")) {
-            error <- bias__named_list_error(S7::prop(self, name), name)
-            if (!is.null(error)) {
-                return(error)
-            }
+        samples_per_day <- 86400 / self@time_step_seconds
+        if (abs(samples_per_day - round(samples_per_day)) >
+            sqrt(.Machine$double.eps)) {
+            return(
+                "`time_step_seconds` must divide one 86400-second day exactly."
+            )
+        }
+        error <- bias__subdaily_data_error(
+            self@data,
+            self@frequency,
+            self@time_step_seconds
+        )
+        if (!is.null(error)) {
+            return(error)
         }
         NULL
     }
@@ -254,21 +415,114 @@ bias__daily_table <- function(data, name = "data") {
 
 # Derive stable per-variable descriptors directly from the validated output
 # table unless a method supplies richer metadata explicitly.
-bias__variable_metadata <- function(data) {
+bias__variable_metadata <- function(data, frequency) {
     variables <- unique(data[["variable_id"]])
     metadata <- lapply(variables, function(variable) {
         index <- data[["variable_id"]] == variable
         list(
             units = unique(data[["units"]][index]),
-            frequency = "day",
+            frequency = frequency,
             calendars = sort(unique(data[["cf_calendar"]][index]))
         )
     })
     stats::setNames(metadata, variables)
 }
 
-# Construct the common result type so method kernels cannot omit its semantic
-# role, settings, or provenance.
+# Construct the frequency-aware result type so signal kernels cannot omit its
+# temporal semantics, role, settings, or provenance.
+bias__adjusted_series <- function(
+    data,
+    frequency,
+    time_step_seconds,
+    output_role,
+    transformation,
+    variable_metadata = NULL,
+    settings = list(),
+    provenance = list()
+) {
+    checkmate::assert_string(
+        frequency,
+        pattern = "^[A-Za-z0-9][A-Za-z0-9._-]*$"
+    )
+    checkmate::assert_number(time_step_seconds, lower = 0, finite = TRUE)
+    if (time_step_seconds <= 0) {
+        cli::cli_abort(
+            "{.arg time_step_seconds} must be one positive number."
+        )
+    }
+    if (identical(frequency, "day")) {
+        data <- bias__daily_table(data)
+    } else {
+        samples_per_day <- 86400 / time_step_seconds
+        if (time_step_seconds >= 86400 ||
+            abs(samples_per_day - round(samples_per_day)) >
+                sqrt(.Machine$double.eps)) {
+            cli::cli_abort(
+                "{.arg time_step_seconds} must divide one 86400-second day exactly."
+            )
+        }
+        data <- bias__subdaily_table(
+            data,
+            frequency,
+            time_step_seconds
+        )
+    }
+    checkmate::assert_choice(output_role, WEATHER_INPUT_ROLES)
+    checkmate::assert_string(
+        transformation,
+        pattern = "^[a-z][a-z0-9_]*$"
+    )
+    if (is.null(variable_metadata)) {
+        variable_metadata <- bias__variable_metadata(data, frequency)
+    }
+    checkmate::assert_list(variable_metadata, names = "unique")
+    checkmate::assert_list(settings, names = "unique")
+    checkmate::assert_list(provenance, names = "unique")
+
+    constructor <- if (identical(frequency, "day")) {
+        DailyAdjustedSeries
+    } else {
+        SubdailyAdjustedSeries
+    }
+    constructor(
+        data = data,
+        frequency = frequency,
+        time_step_seconds = time_step_seconds,
+        output_role = output_role,
+        transformation = transformation,
+        variable_metadata = variable_metadata,
+        settings = settings,
+        provenance = provenance
+    )
+}
+
+# Copy and validate a canonical sub-daily table without inferring its timestep
+# from incomplete or gapped observations.
+bias__subdaily_table <- function(
+    data,
+    frequency,
+    time_step_seconds,
+    name = "data"
+) {
+    if (!is.data.frame(data)) {
+        cli::cli_abort(
+            "{.arg {name}} must be a canonical sub-daily data frame."
+        )
+    }
+    out <- as.data.frame(data, stringsAsFactors = FALSE)
+    error <- bias__subdaily_data_error(
+        out,
+        frequency,
+        time_step_seconds
+    )
+    if (!is.null(error)) {
+        cli::cli_abort("{.arg {name}} is invalid: {error}")
+    }
+    out
+}
+
+# Preserve the daily constructor used by all existing signal kernels while
+# routing its metadata through the common adjusted-series class hierarchy.
 bias__daily_adjusted_series <- function(
     data,
     output_role,
@@ -277,21 +531,34 @@ bias__daily_adjusted_series <- function(
     settings = list(),
     provenance = list()
 ) {
-    data <- bias__daily_table(data)
-    checkmate::assert_choice(output_role, WEATHER_INPUT_ROLES)
-    checkmate::assert_string(
-        transformation,
-        pattern = "^[a-z][a-z0-9_]*$"
-    )
-    if (is.null(variable_metadata)) {
-        variable_metadata <- bias__variable_metadata(data)
-    }
-    checkmate::assert_list(variable_metadata, names = "unique")
-    checkmate::assert_list(settings, names = "unique")
-    checkmate::assert_list(provenance, names = "unique")
-
-    DailyAdjustedSeries(
+    bias__adjusted_series(
         data = data,
+        frequency = "day",
+        time_step_seconds = 86400,
+        output_role = output_role,
+        transformation = transformation,
+        variable_metadata = variable_metadata,
+        settings = settings,
+        provenance = provenance
+    )
+}
+
+# Construct a sub-daily adjusted series only when the caller declares its
+# exact frequency and regular timestep explicitly.
+bias__subdaily_adjusted_series <- function(
+    data,
+    frequency,
+    time_step_seconds,
+    output_role,
+    transformation,
+    variable_metadata = NULL,
+    settings = list(),
+    provenance = list()
+) {
+    bias__adjusted_series(
+        data = data,
+        frequency = frequency,
+        time_step_seconds = time_step_seconds,
         output_role = output_role,
         transformation = transformation,
         variable_metadata = variable_metadata,

--- a/R/weather-sequence.R
+++ b/R/weather-sequence.R
@@ -25,8 +25,9 @@ sequence__direct_group_id <- function(group) {
 }
 
 # Check whether one adjusted variable group contains exactly one complete,
-# ordered native-calendar year before it enters an hourly reconstructor.
-sequence__direct_year_error <- function(data, weather_year, calendar) {
+# ordered native-calendar year at its declared regular frequency.
+sequence__direct_year_error <- function(adjusted, weather_year, calendar) {
+    data <- adjusted@data
     if (!identical(unique(as.integer(data[["cf_year"]])), weather_year)) {
         return("Every direct-model row must match `weather_year`.")
     }
@@ -45,16 +46,67 @@ sequence__direct_year_error <- function(data, weather_year, calendar) {
     for (variable in unique(data[["variable_id"]])) {
         rows <- data[data[["variable_id"]] == variable, , drop = FALSE]
         year_days <- unique(as.integer(rows[["cf_year_days"]]))
-        if (length(year_days) != 1L ||
-            nrow(rows) != year_days ||
-            !identical(
-                as.integer(rows[["cf_day_of_year"]]),
-                seq_len(year_days)
-            )) {
+        if (length(year_days) != 1L) {
+            return(sprintf(
+                "Variable `%s` must use one native-calendar year length.",
+                variable
+            ))
+        }
+        if (identical(adjusted@frequency, "day")) {
+            if (nrow(rows) == year_days &&
+                identical(
+                    as.integer(rows[["cf_day_of_year"]]),
+                    seq_len(year_days)
+                )) {
+                next
+            }
             return(sprintf(
                 "Variable `%s` must cover every native-calendar day in weather year %d.",
                 variable,
                 weather_year
+            ))
+        }
+
+        # A complete sub-daily year repeats the same regular time-of-day
+        # lattice on every native-calendar day, including non-Gregorian years.
+        samples_per_day <- as.integer(round(
+            86400 / adjusted@time_step_seconds
+        ))
+        expected_days <- rep(seq_len(year_days), each = samples_per_day)
+        if (nrow(rows) != length(expected_days) ||
+            !identical(
+                as.integer(rows[["cf_day_of_year"]]),
+                expected_days
+            )) {
+            return(sprintf(
+                "Variable `%s` must cover every declared sub-daily timestep in weather year %d.",
+                variable,
+                weather_year
+            ))
+        }
+        offsets <- rows[["cf_second_of_day"]][seq_len(samples_per_day)]
+        wrapped_steps <- diff(c(offsets, offsets[[1L]] + 86400))
+        tolerance <- sqrt(.Machine$double.eps)
+        if (any(abs(wrapped_steps - adjusted@time_step_seconds) > tolerance)) {
+            return(sprintf(
+                "Variable `%s` has an irregular within-day timestep lattice.",
+                variable
+            ))
+        }
+        observed_offsets <- matrix(
+            rows[["cf_second_of_day"]],
+            ncol = samples_per_day,
+            byrow = TRUE
+        )
+        expected_offsets <- matrix(
+            rep.int(offsets, year_days),
+            ncol = samples_per_day,
+            byrow = TRUE
+        )
+        if (any(abs(observed_offsets - expected_offsets) > tolerance)) {
+            return(sprintf(
+                "Variable `%s` must use the same sub-daily offsets on every day.",
+                variable
             ))
         }
     }
@@ -62,7 +114,7 @@ sequence__direct_year_error <- function(data, weather_year, calendar) {
 }
 
 # DirectModelSeries retains one signal group's key, variables, correction
-# metadata, and calendar-native daily values after partitioning by source year.
+# metadata, and calendar-native values after partitioning by source year.
 DirectModelSeries <- S7::new_class(
     "DirectModelSeries",
     properties = list(
@@ -91,8 +143,8 @@ DirectModelSeries <- S7::new_class(
             anyDuplicated(self@variables)) {
             return("`variables` must contain unique CMIP-style identifiers.")
         }
-        if (!S7::S7_inherits(self@adjusted, DailyAdjustedSeries)) {
-            return("`adjusted` must be a DailyAdjustedSeries object.")
+        if (!S7::S7_inherits(self@adjusted, AdjustedWeatherSeries)) {
+            return("`adjusted` must be an AdjustedWeatherSeries object.")
         }
         if (!identical(self@adjusted@output_role, "model_future")) {
             return("Direct model realization requires a `model_future` signal output.")
@@ -108,7 +160,7 @@ DirectModelSeries <- S7::new_class(
 )
 
 # DirectModelSequenceMember groups all corrected signal series belonging to
-# one complete source-model year without selecting, resampling, or reordering days.
+# one complete source-model year without selecting, resampling, or reordering values.
 DirectModelSequenceMember <- S7::new_class(
     "DirectModelSequenceMember",
     properties = list(
@@ -153,7 +205,7 @@ DirectModelSequenceMember <- S7::new_class(
         }
         for (item in self@series) {
             error <- sequence__direct_year_error(
-                item@adjusted@data,
+                item@adjusted,
                 self@weather_year,
                 self@calendar
             )
@@ -171,13 +223,14 @@ DirectModelSequenceMember <- S7::new_class(
     }
 )
 
-# DirectModelSequence is the typed intermediate exchanged between a future-
-# backbone signal and a later daily-to-hourly reconstruction component.
+# DirectModelSequence is the frequency-aware intermediate exchanged between a
+# future-backbone signal and later reconstruction and physical components.
 DirectModelSequence <- S7::new_class(
     "DirectModelSequence",
     properties = list(
         members = S7::new_property(S7::class_list),
         frequency = S7::new_property(S7::class_character),
+        time_step_seconds = S7::new_property(S7::class_numeric),
         provenance = S7::new_property(S7::class_list, default = list())
     ),
     validator = function(self) {
@@ -190,8 +243,16 @@ DirectModelSequence <- S7::new_class(
             ))) {
             return("`members` must contain DirectModelSequenceMember objects.")
         }
-        if (!identical(self@frequency, "day")) {
-            return("DirectModelSequence currently requires daily values.")
+        if (length(self@frequency) != 1L ||
+            is.na(self@frequency) ||
+            !nzchar(self@frequency)) {
+            return("`frequency` must identify one adjusted-series frequency.")
+        }
+        if (length(self@time_step_seconds) != 1L ||
+            is.na(self@time_step_seconds) ||
+            !is.finite(self@time_step_seconds) ||
+            self@time_step_seconds <= 0) {
+            return("`time_step_seconds` must be one positive finite number.")
         }
         years <- vapply(
             self@members,
@@ -232,6 +293,19 @@ DirectModelSequence <- S7::new_class(
         ))) {
             return("Every direct-model year must contain the same signal groups.")
         }
+        for (member in self@members) {
+            for (item in member@series) {
+                if (!identical(item@adjusted@frequency, self@frequency) ||
+                    !isTRUE(all.equal(
+                        item@adjusted@time_step_seconds,
+                        self@time_step_seconds
+                    ))) {
+                    return(
+                        "Every direct-model series must share the sequence frequency and timestep."
+                    )
+                }
+            }
+        }
         if (length(self@provenance) &&
             (is.null(names(self@provenance)) ||
                 any(!nzchar(names(self@provenance))) ||
@@ -254,8 +328,10 @@ sequence__slice_adjusted <- function(adjusted, year) {
         c("cf_day_of_year", "annual_phase", "variable_id")
     )
     variables <- unique(data[["variable_id"]])
-    bias__daily_adjusted_series(
-        data,
+    bias__adjusted_series(
+        data = data,
+        frequency = adjusted@frequency,
+        time_step_seconds = adjusted@time_step_seconds,
         output_role = adjusted@output_role,
         transformation = adjusted@transformation,
         variable_metadata = adjusted@variable_metadata[variables],
@@ -290,7 +366,7 @@ sequence__direct_member <- function(series, weather_year, calendar) {
 }
 
 # Preserve the corrected future-model chronology, partition it by complete CF
-# year, and retain group-level signal metadata for later hourly reconstruction.
+# year, and retain group-level signal metadata for later reconstruction.
 sequence__direct_model_generate <- function(
     data,
     inputs,
@@ -314,10 +390,10 @@ sequence__direct_model_generate <- function(
         data@values,
         S7::S7_inherits,
         logical(1L),
-        class = DailyAdjustedSeries
+        class = AdjustedWeatherSeries
     ))) {
         cli::cli_abort(
-            "Direct model realization currently requires DailyAdjustedSeries values."
+            "Direct model realization requires AdjustedWeatherSeries values."
         )
     }
 
@@ -365,6 +441,22 @@ sequence__direct_model_generate <- function(
             "Every direct-model signal group must use the same CF calendar."
         )
     }
+    frequencies <- vapply(
+        data@values,
+        function(adjusted) adjusted@frequency,
+        character(1L)
+    )
+    time_steps <- vapply(
+        data@values,
+        function(adjusted) adjusted@time_step_seconds,
+        numeric(1L)
+    )
+    if (length(unique(frequencies)) != 1L ||
+        length(unique(time_steps)) != 1L) {
+        cli::cli_abort(
+            "Every direct-model signal group must use the same frequency and timestep."
+        )
+    }
 
     years <- year_sets[[1L]]
     members <- lapply(years, function(year) {
@@ -383,7 +475,8 @@ sequence__direct_model_generate <- function(
     })
     DirectModelSequence(
         members = members,
-        frequency = "day",
+        frequency = frequencies[[1L]],
+        time_step_seconds = time_steps[[1L]],
         provenance = list(
             method = "direct_model_realization",
             source_role = "model_future",
@@ -392,6 +485,8 @@ sequence__direct_model_generate <- function(
             resampling = "none",
             years = years,
             calendar = calendars[[1L]],
+            frequency = frequencies[[1L]],
+            time_step_seconds = time_steps[[1L]],
             group_ids = group_ids
         )
     )
@@ -408,11 +503,13 @@ sequence__direct_model_component <- function() {
             model_future = component__input_requirement(
                 "model_future",
                 representations = "series",
-                frequencies = "day",
                 calendars = CF_TIME_CALENDARS
             )
         ),
-        input_kinds = "daily_adjusted_series",
+        input_kinds = c(
+            "daily_adjusted_series",
+            "adjusted_weather_series"
+        ),
         output_kinds = "direct_model_sequence",
         scopes = "multivariate",
         stochastic = FALSE,
@@ -423,7 +520,7 @@ sequence__direct_model_component <- function() {
             ordering = "native_cf_chronology",
             selection = "none",
             resampling = "none",
-            supported_frequencies = "day",
+            frequency_policy = "single_regular_frequency",
             output_contract = "direct_model_sequence"
         )
     )

--- a/tests/testthat/test-adjusted-series.R
+++ b/tests/testthat/test-adjusted-series.R
@@ -1,0 +1,205 @@
+# Build a regular calendar-native sub-daily table while exposing the exact
+# time-of-day coordinate and one untouched source timestamp column.
+adjusted_series_test__subdaily <- function(
+    variable = "tas",
+    year = 2061L,
+    days = 2L,
+    calendar = "noleap",
+    frequency = "3hr",
+    time_step_seconds = 10800,
+    time_offset_seconds = 0
+) {
+    offsets <- seq.int(
+        from = time_offset_seconds,
+        to = days * 86400 - time_step_seconds + time_offset_seconds,
+        by = time_step_seconds
+    )
+    day_offsets <- offsets %/% 86400
+    seconds <- offsets %% 86400
+    fields <- cf_time_offset2date(
+        day_offsets,
+        data.frame(year = year, month = 1L, day = 1L),
+        calendar
+    )
+    fields$hour <- seconds %/% 3600
+    fields$minute <- (seconds %% 3600) %/% 60
+    fields$second <- seconds %% 60
+    coordinates <- cf_time__coordinates(fields, calendar)
+    data.frame(
+        variable_id = rep.int(variable, length(offsets)),
+        value = seq_along(offsets),
+        units = rep.int("K", length(offsets)),
+        frequency = rep.int(frequency, length(offsets)),
+        coordinates,
+        cf_second_of_day = as.numeric(seconds),
+        source_time = sprintf(
+            "%s:%05d",
+            calendar,
+            as.integer(offsets)
+        ),
+        stringsAsFactors = FALSE
+    )
+}
+
+# Build a compact daily table without depending on helpers from another test
+# file or assigning Gregorian dates to non-Gregorian calendars.
+adjusted_series_test__daily <- function() {
+    fields <- cf_time_offset2date(
+        0:3,
+        data.frame(year = 2061L, month = 1L, day = 1L),
+        "noleap"
+    )
+    fields$hour <- 12L
+    fields$minute <- 0L
+    fields$second <- 0
+    data.frame(
+        variable_id = rep.int("tas", 4L),
+        value = c(280, 282, 284, 286),
+        units = rep.int("K", 4L),
+        frequency = rep.int("day", 4L),
+        cf_time__coordinates(fields, "noleap"),
+        stringsAsFactors = FALSE
+    )
+}
+
+test_that("daily adjusted series remains a strict specialization", {
+    data <- adjusted_series_test__daily()
+    adjusted <- bias__daily_adjusted_series(
+        data,
+        output_role = "model_future",
+        transformation = "test_adjustment"
+    )
+
+    expect_s7_class(adjusted, DailyAdjustedSeries)
+    expect_true(S7::S7_inherits(adjusted, AdjustedWeatherSeries))
+    expect_identical(adjusted@frequency, "day")
+    expect_identical(as.numeric(adjusted@time_step_seconds), 86400)
+    expect_identical(adjusted@data, data)
+})
+
+test_that("sub-daily adjusted series retains its regular CF time lattice", {
+    for (calendar in CF_TIME_CALENDARS) {
+        data <- adjusted_series_test__subdaily(calendar = calendar)
+        adjusted <- bias__subdaily_adjusted_series(
+            data,
+            frequency = "3hr",
+            time_step_seconds = 10800,
+            output_role = "model_future",
+            transformation = "test_adjustment",
+            settings = list(window_months = 3L),
+            provenance = list(method = "test_adjustment")
+        )
+
+        expect_s7_class(adjusted, SubdailyAdjustedSeries)
+        expect_true(
+            S7::S7_inherits(adjusted, AdjustedWeatherSeries),
+            info = calendar
+        )
+        expect_identical(adjusted@frequency, "3hr", info = calendar)
+        expect_identical(
+            as.numeric(adjusted@time_step_seconds),
+            10800,
+            info = calendar
+        )
+        expect_identical(
+            adjusted@data$source_time,
+            data$source_time,
+            info = calendar
+        )
+        expect_identical(
+            adjusted@variable_metadata$tas$frequency,
+            "3hr",
+            info = calendar
+        )
+    }
+
+    offset_data <- adjusted_series_test__subdaily(
+        time_offset_seconds = 5400
+    )
+    expect_no_error(
+        bias__subdaily_adjusted_series(
+            offset_data,
+            "3hr",
+            10800,
+            "model_future",
+            "test_adjustment"
+        )
+    )
+})
+
+test_that("sub-daily adjusted series rejects ambiguous temporal metadata", {
+    data <- adjusted_series_test__subdaily()
+
+    duplicate <- rbind(data, data[1L, ])
+    expect_error(
+        bias__subdaily_adjusted_series(
+            duplicate,
+            "3hr",
+            10800,
+            "model_future",
+            "test_adjustment"
+        ),
+        "unique variable-calendar-year-month-day-second"
+    )
+
+    inconsistent_phase <- data
+    inconsistent_phase$annual_phase[[2L]] <-
+        inconsistent_phase$annual_phase[[2L]] + 0.00001
+    expect_error(
+        bias__subdaily_adjusted_series(
+            inconsistent_phase,
+            "3hr",
+            10800,
+            "model_future",
+            "test_adjustment"
+        ),
+        "annual_phase.*cf_second_of_day"
+    )
+
+    irregular <- data
+    irregular$cf_second_of_day[[2L]] <- 7200
+    irregular$annual_phase[[2L]] <-
+        irregular$cf_second_of_day[[2L]] /
+        86400 / irregular$cf_year_days[[2L]]
+    expect_error(
+        bias__subdaily_adjusted_series(
+            irregular,
+            "3hr",
+            10800,
+            "model_future",
+            "test_adjustment"
+        ),
+        "regular timestep lattice"
+    )
+
+    expect_error(
+        bias__subdaily_adjusted_series(
+            data,
+            "3hr",
+            0,
+            "model_future",
+            "test_adjustment"
+        ),
+        "positive number"
+    )
+    expect_error(
+        bias__subdaily_adjusted_series(
+            data,
+            "3hr",
+            10000,
+            "model_future",
+            "test_adjustment"
+        ),
+        "divide one 86400-second day"
+    )
+    expect_error(
+        bias__subdaily_adjusted_series(
+            data,
+            "1hr",
+            3600,
+            "model_future",
+            "test_adjustment"
+        ),
+        "declared `frequency`"
+    )
+})

--- a/tests/testthat/test-direct-model-sequence.R
+++ b/tests/testthat/test-direct-model-sequence.R
@@ -59,6 +59,79 @@ direct_sequence_test__adjusted <- function(
     )
 }
 
+# Build one complete regular sub-daily year whose exact native-calendar times
+# make missing, duplicated, or reordered samples observable.
+direct_sequence_test__subdaily_year <- function(
+    variable,
+    year,
+    calendar = "noleap",
+    frequency = "3hr",
+    time_step_seconds = 10800,
+    reverse = FALSE
+) {
+    year_days <- cf_time__year_days(year, calendar)[[1L]]
+    offsets <- seq.int(
+        from = 0,
+        to = year_days * 86400 - time_step_seconds,
+        by = time_step_seconds
+    )
+    day_offsets <- offsets %/% 86400
+    seconds <- offsets %% 86400
+    fields <- cf_time_offset2date(
+        day_offsets,
+        data.frame(year = year, month = 1L, day = 1L),
+        calendar
+    )
+    fields$hour <- seconds %/% 3600
+    fields$minute <- (seconds %% 3600) %/% 60
+    fields$second <- seconds %% 60
+    data <- data.frame(
+        variable_id = rep.int(variable, length(offsets)),
+        value = seq_along(offsets),
+        units = rep.int("K", length(offsets)),
+        frequency = rep.int(frequency, length(offsets)),
+        cf_time__coordinates(fields, calendar),
+        cf_second_of_day = as.numeric(seconds),
+        source_time_offset = as.numeric(offsets),
+        stringsAsFactors = FALSE
+    )
+    if (isTRUE(reverse)) {
+        data <- data[rev(seq_len(nrow(data))), , drop = FALSE]
+    }
+    data
+}
+
+# Construct a typed future-backbone sub-daily series spanning complete source
+# years while preserving an upstream provenance record.
+direct_sequence_test__subdaily_adjusted <- function(
+    variable,
+    years,
+    calendar = "noleap",
+    frequency = "3hr",
+    time_step_seconds = 10800,
+    reverse = FALSE
+) {
+    rows <- lapply(years, function(year) {
+        direct_sequence_test__subdaily_year(
+            variable,
+            year,
+            calendar,
+            frequency,
+            time_step_seconds,
+            reverse
+        )
+    })
+    bias__subdaily_adjusted_series(
+        do.call(rbind, rows),
+        frequency = frequency,
+        time_step_seconds = time_step_seconds,
+        output_role = "model_future",
+        transformation = "test_adjustment",
+        settings = list(window_months = 3L),
+        provenance = list(method = "test_adjustment")
+    )
+}
+
 # Assemble the canonical signal envelope consumed by every sequence component
 # without invoking a particular bias-adjustment kernel in these focused tests.
 direct_sequence_test__execution <- function(
@@ -199,6 +272,49 @@ test_that("direct model sequence accepts every supported native CF calendar", {
     }
 })
 
+test_that("direct model sequence preserves complete sub-daily model years", {
+    adjusted <- direct_sequence_test__subdaily_adjusted(
+        "tas",
+        2061:2062,
+        reverse = TRUE
+    )
+    sequence <- sequence__direct_model_generate(
+        direct_sequence_test__execution(list(adjusted)),
+        NULL,
+        NULL,
+        list()
+    )
+
+    expect_s7_class(sequence, DirectModelSequence)
+    expect_identical(sequence@frequency, "3hr")
+    expect_identical(as.numeric(sequence@time_step_seconds), 10800)
+    expect_identical(sequence@provenance$frequency, "3hr")
+    expect_identical(sequence@provenance$time_step_seconds, 10800)
+    expect_identical(
+        vapply(
+            sequence@members,
+            function(member) member@weather_year,
+            integer(1L)
+        ),
+        2061:2062
+    )
+    for (member in sequence@members) {
+        data <- member@series[[1L]]@adjusted@data
+        expect_s7_class(
+            member@series[[1L]]@adjusted,
+            SubdailyAdjustedSeries
+        )
+        expect_identical(
+            data$cf_second_of_day[1:8],
+            seq.int(0, 75600, by = 10800)
+        )
+        expect_identical(
+            data$source_time_offset[1:8],
+            seq.int(0, 75600, by = 10800)
+        )
+    }
+})
+
 test_that("direct model component is registered and contract-compatible", {
     sequence__register_direct_model_component()
     component <- component__get("sequence", "direct_model_realization")
@@ -218,11 +334,25 @@ test_that("direct model component is registered and contract-compatible", {
 
     expect_s7_class(component, WeatherComponentSpec)
     expect_identical(component@stage, "sequence")
-    expect_identical(component@input_kinds, "daily_adjusted_series")
+    expect_identical(
+        component@input_kinds,
+        c("daily_adjusted_series", "adjusted_weather_series")
+    )
     expect_identical(component@output_kinds, "direct_model_sequence")
     expect_false(component@stochastic)
     expect_identical(component@metadata$selection, "none")
     expect_invisible(component__validate_inputs(component, inputs))
+
+    subdaily_source <- direct_sequence_test__subdaily_year("tas", 2061L)
+    subdaily_inputs <- weather__new_inputs(
+        model_future = weather__new_input(
+            "model_future",
+            subdaily_source
+        )
+    )
+    expect_invisible(
+        component__validate_inputs(component, subdaily_inputs)
+    )
     expect_true(component__compatible(qdm, component))
     expect_true(component__compatible(component, hourly))
 })
@@ -273,6 +403,40 @@ test_that("direct model sequence rejects incomplete or misaligned groups", {
             list()
         ),
         "same CF calendar"
+    )
+
+    incomplete_subdaily_data <- direct_sequence_test__subdaily_year(
+        "tas",
+        2061L
+    )[-1L, ]
+    incomplete_subdaily <- bias__subdaily_adjusted_series(
+        incomplete_subdaily_data,
+        "3hr",
+        10800,
+        "model_future",
+        "test_adjustment"
+    )
+    expect_error(
+        sequence__direct_model_generate(
+            direct_sequence_test__execution(list(incomplete_subdaily)),
+            NULL,
+            NULL,
+            list()
+        ),
+        "cover every declared sub-daily timestep"
+    )
+
+    expect_error(
+        sequence__direct_model_generate(
+            direct_sequence_test__execution(list(
+                direct_sequence_test__adjusted("tas", 2061L),
+                direct_sequence_test__subdaily_adjusted("pr", 2061L)
+            )),
+            NULL,
+            NULL,
+            list()
+        ),
+        "same frequency and timestep"
     )
 })
 

--- a/vignettes-raw/articles/epw-morpher.Rmd
+++ b/vignettes-raw/articles/epw-morpher.Rmd
@@ -492,11 +492,17 @@ recipe. The current standalone sequence contract is:
 
 | Registry name | Accepted signal result | Behavior | Output contract |
 |:--------------|:-----------------------|:---------|:----------------|
-| `direct_model_realization` | Complete daily `DailyAdjustedSeries` groups retaining the `model_future` backbone | Preserve native CF chronology, partition complete source years, and perform no day selection or resampling | One `DirectModelSequence` containing deterministic year members, group keys, corrected values, signal provenance, source years, and calendars |
+| `direct_model_realization` | Complete `DailyAdjustedSeries` or `SubdailyAdjustedSeries` groups satisfying the common `AdjustedWeatherSeries` contract and retaining the `model_future` backbone | Preserve native CF chronology, partition complete source years, and perform no timestep selection or resampling | One `DirectModelSequence` containing deterministic year members, group keys, corrected values, frequency, timestep, signal provenance, source years, and calendars |
 
-`direct_model_realization` currently accepts daily values. Sub-daily signal
-types and their hourly interpolation remain separate later components; the
-sequence stage does not silently interpolate or construct EPW fields.
+`AdjustedWeatherSeries` is the frequency-aware signal-result boundary.
+`DailyAdjustedSeries` remains its strict daily specialization, while
+`SubdailyAdjustedSeries` requires an explicit regular timestep and exact
+`cf_second_of_day` values in addition to the calendar-native date and annual
+phase. `direct_model_realization` requires every group to use the same
+frequency and timestep and to cover each source year completely. It does not
+interpolate, resample, or construct EPW fields. Workflows that interpolate
+climate-model inputs before bias adjustment must perform that transformation
+in an earlier component and retain its provenance.
 
 Bias-adjustment implementations belong to the `signal` stage. Their common
 `apply` operation validates the role-addressable inputs, resolves

--- a/vignettes-raw/precompiled-checksums.csv
+++ b/vignettes-raw/precompiled-checksums.csv
@@ -1,7 +1,7 @@
 "source","output","source_md5","output_md5"
 "vignettes-raw/articles/cli-esgf-store.Rmd","vignettes/articles/cli-esgf-store.Rmd","cac788f79010ad56496939cdde3580bb","e58e5cafa0d3b2218081c25a1098273f"
 "vignettes-raw/articles/downloader.Rmd","vignettes/articles/downloader.Rmd","9668ccb5b39f0ca2f49e146a1a100a7c","4b67e4a9ddaecfe7ce3ac268936e2a2d"
-"vignettes-raw/articles/epw-morpher.Rmd","vignettes/articles/epw-morpher.Rmd","0cc88f8dc14840e7b130bfabca583df1","fc1cef403e74396e3773a5919e220380"
+"vignettes-raw/articles/epw-morpher.Rmd","vignettes/articles/epw-morpher.Rmd","1f98eb732f10f74aae269e78bdc993b3","72ab689ca265fa7564a693522656ff02"
 "vignettes-raw/articles/esg-dictionaries.Rmd","vignettes/articles/esg-dictionaries.Rmd","94eb2513975549a6765afa221a2e10c1","290348d35a29e925f1b3732586e54cfb"
 "vignettes-raw/articles/esg-store.Rmd","vignettes/articles/esg-store.Rmd","c2d810261308c837b84c803a0d2632c5","bb73ddac53598a36b049797782ce3c02"
 "vignettes-raw/articles/esgf-query-results.Rmd","vignettes/articles/esgf-query-results.Rmd","9cb7e909ecc499eba79e4295857101d1","20854ab68644b18addeefcef1baafcfa"

--- a/vignettes/articles/epw-morpher.Rmd
+++ b/vignettes/articles/epw-morpher.Rmd
@@ -500,11 +500,17 @@ recipe. The current standalone sequence contract is:
 
 | Registry name | Accepted signal result | Behavior | Output contract |
 |:--------------|:-----------------------|:---------|:----------------|
-| `direct_model_realization` | Complete daily `DailyAdjustedSeries` groups retaining the `model_future` backbone | Preserve native CF chronology, partition complete source years, and perform no day selection or resampling | One `DirectModelSequence` containing deterministic year members, group keys, corrected values, signal provenance, source years, and calendars |
+| `direct_model_realization` | Complete `DailyAdjustedSeries` or `SubdailyAdjustedSeries` groups satisfying the common `AdjustedWeatherSeries` contract and retaining the `model_future` backbone | Preserve native CF chronology, partition complete source years, and perform no timestep selection or resampling | One `DirectModelSequence` containing deterministic year members, group keys, corrected values, frequency, timestep, signal provenance, source years, and calendars |
 
-`direct_model_realization` currently accepts daily values. Sub-daily signal
-types and their hourly interpolation remain separate later components; the
-sequence stage does not silently interpolate or construct EPW fields.
+`AdjustedWeatherSeries` is the frequency-aware signal-result boundary.
+`DailyAdjustedSeries` remains its strict daily specialization, while
+`SubdailyAdjustedSeries` requires an explicit regular timestep and exact
+`cf_second_of_day` values in addition to the calendar-native date and annual
+phase. `direct_model_realization` requires every group to use the same
+frequency and timestep and to cover each source year completely. It does not
+interpolate, resample, or construct EPW fields. Workflows that interpolate
+climate-model inputs before bias adjustment must perform that transformation
+in an earlier component and retain its provenance.
 
 Bias-adjustment implementations belong to the `signal` stage. Their common
 `apply` operation validates the role-addressable inputs, resolves


### PR DESCRIPTION
## Summary

- Adds a package-native frequency-aware adjusted-series contract while preserving the existing strict daily specialization.
- Extends `direct_model_realization` to retain complete regular daily or sub-daily source-model years.
- Closes #184.

## Changes

- Adds `AdjustedWeatherSeries` with `DailyAdjustedSeries` and `SubdailyAdjustedSeries` specializations, explicit frequency and timestep metadata, and canonical sub-day CF coordinates.
- Preserves signal settings, provenance, extra source-time fields, and native-calendar chronology through year partitioning.
- Rejects duplicate timestamps, inconsistent annual phase, irregular lattices, incomplete years, and cross-group frequency mismatches, with coverage for all supported CF calendars.