### PR TITLE
feat: add `kernel_quantile_delta_mapping_hourly`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -96,6 +96,7 @@ Collate:
     'cdf-transform.R'
     'equidistant-cdf-matching.R'
     'quantile-delta-mapping.R'
+    'kernel-qdm.R'
     'quantile-mapping.R'
     'solr-date.R'
     'query-param.R'

--- a/NEWS.md
+++ b/NEWS.md
@@ -46,6 +46,18 @@
 
 ## New features
 
+* Added the registered `kernel_quantile_delta_mapping_hourly` signal component
+  for pre-aligned hourly observations, historical model output, and future
+  model output. It defaults to Gaussian kernel-density CDFs in centered
+  three-month native-calendar windows, transfers additive quantile changes for
+  temperature and pressure or multiplicative changes for wind, humidity, and
+  radiation, and retains future-model chronology in a
+  `SubdailyAdjustedSeries`. Because the source publication does not report its
+  KDE kernel, bandwidth, numerical grid, tails, or zero-denominator behavior,
+  the corresponding package defaults and supported alternatives are explicitly
+  validated, user-overridable, warned about, and recorded separately from the
+  published method settings (#191).
+
 * Added the registered `solar_radiation_interpolation` preprocessing component
   for interval-mean three-hourly `rsds` and `rsdsdiff`. It preserves explicit
   CF time bounds through regional extraction, allocates each source interval

--- a/R/kernel-qdm.R
+++ b/R/kernel-qdm.R
@@ -1,0 +1,725 @@
+#' @include bias-adjustment.R
+NULL
+
+# Wang et al. document the hourly kernel-density QDM workflow, while Cannon
+# et al. provide the additive and multiplicative trend-preserving equations.
+KQDM_REFERENCES <- c(
+    "https://doi.org/10.1038/s41467-023-41458-5",
+    "https://doi.org/10.1175/JCLI-D-14-00754.1"
+)
+
+# These variables follow the hourly weather fields and transformation families
+# stated by Wang et al.; package extensions remain separate below.
+KQDM_PUBLISHED_VARIABLES <- c(
+    "tas",
+    "ps",
+    "hurs",
+    "sfcWind",
+    "rsds",
+    "rsdsdiff"
+)
+KQDM_EXPERIMENTAL_VARIABLES <- c("psl", "rlds")
+
+# Construct the complete settings schema while keeping the paper's method
+# choices separate from numerical KDE defaults selected by this package.
+kqdm__default_settings <- function(
+    transformation = c("additive", "multiplicative"),
+    bounds
+) {
+    transformation <- match.arg(transformation)
+    list(
+        transformation = transformation,
+        window_months = 3L,
+        window_alignment = "centered",
+        cdf_method = "kernel_density",
+        kernel = "gaussian",
+        bandwidth_method = "nrd0",
+        bandwidth_adjust = 1,
+        grid_points = 2048L,
+        tail_policy = "density_grid_clamp",
+        min_samples = 30L,
+        bounds = bounds,
+        zero_tolerance = sqrt(.Machine$double.eps),
+        zero_denominator_policy = "zero_future_else_error"
+    )
+}
+
+# Build variable-specific profiles. Every profile is labelled experimental
+# because the publication does not report the kernel, bandwidth, grid, tail,
+# or zero-denominator conventions needed for an executable implementation.
+kqdm__profiles <- function() {
+    specifications <- list(
+        tas = list("additive", c(-Inf, Inf)),
+        ps = list("additive", c(0, Inf)),
+        hurs = list("multiplicative", c(0, 100)),
+        sfcWind = list("multiplicative", c(0, Inf)),
+        rsds = list("multiplicative", c(0, Inf)),
+        rsdsdiff = list("multiplicative", c(0, Inf)),
+        psl = list("additive", c(0, Inf)),
+        rlds = list("multiplicative", c(0, Inf))
+    )
+    lapply(names(specifications), function(variable) {
+        specification <- specifications[[variable]]
+        published_variable <- variable %in% KQDM_PUBLISHED_VARIABLES
+        signal__variable_profile(
+            variable,
+            settings = kqdm__default_settings(
+                specification[[1L]],
+                specification[[2L]]
+            ),
+            evidence = "experimental",
+            references = KQDM_REFERENCES,
+            metadata = list(
+                method = "kernel_quantile_delta_mapping",
+                output_role = "model_future",
+                variable_evidence = if (published_variable) {
+                    "method_literature"
+                } else {
+                    "package_extension"
+                },
+                published_settings = c(
+                    "transformation",
+                    "window_months",
+                    "window_alignment",
+                    "cdf_method"
+                ),
+                package_selected_settings = c(
+                    "kernel",
+                    "bandwidth_method",
+                    "bandwidth_adjust",
+                    "grid_points",
+                    "tail_policy",
+                    "min_samples",
+                    "bounds",
+                    "zero_tolerance",
+                    "zero_denominator_policy"
+                )
+            )
+        )
+    })
+}
+
+# Validate every executable convention at the signal boundary so user
+# overrides cannot silently introduce an unsupported numerical method.
+kqdm__settings <- function(settings) {
+    if (length(settings) != 1L ||
+        is.null(names(settings)) ||
+        !nzchar(names(settings)[[1L]]) ||
+        !is.list(settings[[1L]])) {
+        cli::cli_abort(
+            "Kernel-density Quantile Delta Mapping requires settings for exactly one variable."
+        )
+    }
+    resolved <- settings[[1L]]
+    expected <- c(
+        "transformation",
+        "window_months",
+        "window_alignment",
+        "cdf_method",
+        "kernel",
+        "bandwidth_method",
+        "bandwidth_adjust",
+        "grid_points",
+        "tail_policy",
+        "min_samples",
+        "bounds",
+        "zero_tolerance",
+        "zero_denominator_policy"
+    )
+    missing <- setdiff(expected, names(resolved))
+    unexpected <- setdiff(names(resolved), expected)
+    if (length(missing) || length(unexpected)) {
+        cli::cli_abort(c(
+            "Kernel-density Quantile Delta Mapping settings must use the complete supported schema.",
+            "x" = "Missing setting(s): {.val {missing}}.",
+            "x" = "Unexpected setting(s): {.val {unexpected}}."
+        ))
+    }
+    checkmate::assert_choice(
+        resolved$transformation,
+        c("additive", "multiplicative")
+    )
+    checkmate::assert_integerish(
+        resolved$window_months,
+        lower = 1L,
+        upper = 12L,
+        len = 1L,
+        any.missing = FALSE
+    )
+    if (!identical(as.integer(resolved$window_months), 3L) ||
+        !identical(resolved$window_alignment, "centered")) {
+        cli::cli_abort(
+            "Kernel-density Quantile Delta Mapping currently requires the published centered three-month window."
+        )
+    }
+    if (!identical(resolved$cdf_method, "kernel_density")) {
+        cli::cli_abort(
+            "Kernel-density Quantile Delta Mapping requires `cdf_method = \"kernel_density\"`."
+        )
+    }
+    checkmate::assert_choice(
+        resolved$kernel,
+        c(
+            "gaussian",
+            "epanechnikov",
+            "rectangular",
+            "triangular",
+            "biweight",
+            "cosine",
+            "optcosine"
+        )
+    )
+    checkmate::assert_choice(
+        resolved$bandwidth_method,
+        c("nrd0", "nrd", "ucv", "bcv", "SJ-ste", "SJ-dpi")
+    )
+    checkmate::assert_number(
+        resolved$bandwidth_adjust,
+        lower = 0,
+        finite = TRUE
+    )
+    if (resolved$bandwidth_adjust <= 0) {
+        cli::cli_abort("`bandwidth_adjust` must be positive.")
+    }
+    checkmate::assert_integerish(
+        resolved$grid_points,
+        lower = 128L,
+        len = 1L,
+        any.missing = FALSE
+    )
+    grid_points <- as.integer(resolved$grid_points)
+    if (abs(log2(grid_points) - round(log2(grid_points))) >
+        sqrt(.Machine$double.eps)) {
+        cli::cli_abort("`grid_points` must be a power of two.")
+    }
+    checkmate::assert_choice(
+        resolved$tail_policy,
+        c("density_grid_clamp", "error")
+    )
+    checkmate::assert_integerish(
+        resolved$min_samples,
+        lower = 3L,
+        len = 1L,
+        any.missing = FALSE
+    )
+    checkmate::assert_numeric(
+        resolved$bounds,
+        len = 2L,
+        any.missing = FALSE
+    )
+    if (resolved$bounds[[1L]] > resolved$bounds[[2L]]) {
+        cli::cli_abort(
+            "Kernel-density Quantile Delta Mapping bounds must be ordered from lower to upper."
+        )
+    }
+    checkmate::assert_number(
+        resolved$zero_tolerance,
+        lower = 0,
+        finite = TRUE
+    )
+    checkmate::assert_choice(
+        resolved$zero_denominator_policy,
+        c("zero_future_else_error", "error")
+    )
+
+    resolved$window_months <- as.integer(resolved$window_months)
+    resolved$grid_points <- grid_points
+    resolved$min_samples <- as.integer(resolved$min_samples)
+    resolved
+}
+
+# Validate the three role-addressable hourly inputs without coercing any native
+# CF calendar to Gregorian dates or discarding the time-of-day coordinate.
+kqdm__inputs <- function(inputs, variable, transformation) {
+    roles <- c(
+        "observed_reference",
+        "model_historical",
+        "model_future"
+    )
+    if (!identical(sort(names(inputs)), sort(roles))) {
+        cli::cli_abort(
+            "Kernel-density Quantile Delta Mapping requires observed, historical-model, and future-model role payloads."
+        )
+    }
+    series <- lapply(roles, function(role) {
+        bias__subdaily_table(
+            inputs[[role]],
+            frequency = "hour",
+            time_step_seconds = 3600,
+            name = role
+        )
+    })
+    names(series) <- roles
+    for (role in roles) {
+        role_variables <- unique(series[[role]][["variable_id"]])
+        if (!identical(role_variables, variable)) {
+            cli::cli_abort(
+                "Kernel-density Quantile Delta Mapping role {.val {role}} must contain only variable {.val {variable}}."
+            )
+        }
+        if (length(unique(series[[role]][["cf_calendar"]])) != 1L) {
+            cli::cli_abort(
+                "Kernel-density Quantile Delta Mapping role {.val {role}} must contain one native calendar per signal group."
+            )
+        }
+    }
+    units <- vapply(
+        series,
+        function(data) unique(data[["units"]]),
+        character(1L)
+    )
+    if (length(unique(units)) != 1L) {
+        cli::cli_abort(
+            "Kernel-density Quantile Delta Mapping inputs for {.val {variable}} must use identical units."
+        )
+    }
+    if (identical(transformation, "multiplicative") &&
+        any(vapply(
+            series,
+            function(data) any(data[["value"]] < 0),
+            logical(1L)
+        ))) {
+        cli::cli_abort(
+            "Multiplicative kernel-density Quantile Delta Mapping requires non-negative input values."
+        )
+    }
+    series
+}
+
+# Return the previous, current, and following calendar months with December-to-
+# January wrapping independent of the number of days in either source calendar.
+kqdm__window_months <- function(center_month) {
+    checkmate::assert_integerish(
+        center_month,
+        lower = 1L,
+        upper = 12L,
+        len = 1L,
+        any.missing = FALSE
+    )
+    as.integer(((as.integer(center_month) - 1L + -1L:1L) %% 12L) + 1L)
+}
+
+# Estimate one Gaussian kernel-density CDF on an explicit grid and retain only
+# compact fit metadata rather than serializing the full numerical curve.
+kqdm__density_cdf <- function(values, resolved, label) {
+    sample_count <- length(values)
+    if (sample_count < resolved$min_samples) {
+        cli::cli_abort(
+            "Kernel-density Quantile Delta Mapping {.val {label}} has {sample_count} samples; at least {resolved$min_samples} are required."
+        )
+    }
+    if (length(unique(values)) < 2L) {
+        cli::cli_abort(
+            "Kernel-density Quantile Delta Mapping {.val {label}} requires at least two distinct values."
+        )
+    }
+    # The explicit three-bandwidth support and grid size make the otherwise
+    # unreported numerical CDF approximation reproducible across executions.
+    estimate <- tryCatch(
+        stats::density(
+            values,
+            bw = resolved$bandwidth_method,
+            adjust = resolved$bandwidth_adjust,
+            kernel = resolved$kernel,
+            n = resolved$grid_points,
+            cut = 3,
+            na.rm = FALSE
+        ),
+        error = function(error) {
+            cli::cli_abort(
+                "Kernel-density Quantile Delta Mapping could not fit {.val {label}} with bandwidth method {.val {resolved$bandwidth_method}}: {conditionMessage(error)}"
+            )
+        }
+    )
+    bandwidth <- estimate$bw
+    if (!is.finite(bandwidth) || bandwidth <= 0) {
+        cli::cli_abort(
+            "Kernel-density Quantile Delta Mapping could not estimate a positive bandwidth for {.val {label}}."
+        )
+    }
+    increments <- diff(estimate$x) * (
+        head(estimate$y, -1L) + tail(estimate$y, -1L)
+    ) / 2
+    cumulative <- c(0, cumsum(pmax(increments, 0)))
+    total <- cumulative[[length(cumulative)]]
+    if (!is.finite(total) || total <= 0) {
+        cli::cli_abort(
+            "Kernel-density Quantile Delta Mapping produced an invalid CDF for {.val {label}}."
+        )
+    }
+    cumulative <- cumulative / total
+    inverse_index <- !duplicated(cumulative, fromLast = TRUE)
+    if (sum(inverse_index) < 2L) {
+        cli::cli_abort(
+            "Kernel-density Quantile Delta Mapping produced fewer than two distinct CDF probabilities for {.val {label}}."
+        )
+    }
+    list(
+        x = estimate$x,
+        probability = cumulative,
+        inverse_probability = cumulative[inverse_index],
+        inverse_x = estimate$x[inverse_index],
+        summary = list(
+            samples = sample_count,
+            sample_range = range(values),
+            bandwidth = bandwidth,
+            density_support = range(estimate$x)
+        )
+    )
+}
+
+# Evaluate one fitted KDE CDF with the declared endpoint clamp and report use
+# of the finite density-grid tails for diagnostics.
+kqdm__cdf <- function(distribution, values, tail_policy) {
+    lower_tail <- values < distribution$x[[1L]]
+    upper_tail <- values > distribution$x[[length(distribution$x)]]
+    if (identical(tail_policy, "error") &&
+        any(lower_tail | upper_tail)) {
+        cli::cli_abort(
+            "Kernel-density Quantile Delta Mapping encountered {sum(lower_tail | upper_tail)} value(s) outside the fitted density grid."
+        )
+    }
+    list(
+        probability = stats::approx(
+            distribution$x,
+            distribution$probability,
+            xout = values,
+            rule = 2,
+            ties = "ordered"
+        )$y,
+        lower_tail = lower_tail,
+        upper_tail = upper_tail
+    )
+}
+
+# Numerically invert one monotone KDE CDF grid using the same endpoint clamp as
+# forward evaluation so tail behavior stays explicit and deterministic.
+kqdm__inverse_cdf <- function(distribution, probability) {
+    stats::approx(
+        distribution$inverse_probability,
+        distribution$inverse_x,
+        xout = probability,
+        rule = 2,
+        ties = "ordered"
+    )$y
+}
+
+# Apply the additive or multiplicative QDM equation to every future value in
+# one calendar month after fitting all three role distributions.
+kqdm__map_values <- function(
+    observed_distribution,
+    historical_distribution,
+    future_distribution,
+    future_values,
+    resolved,
+    center_month
+) {
+    future_cdf <- kqdm__cdf(
+        future_distribution,
+        future_values,
+        resolved$tail_policy
+    )
+    probability <- future_cdf$probability
+    observed_quantile <- kqdm__inverse_cdf(
+        observed_distribution,
+        probability
+    )
+    historical_quantile <- kqdm__inverse_cdf(
+        historical_distribution,
+        probability
+    )
+
+    if (identical(resolved$transformation, "additive")) {
+        # Additive QDM transfers x_future - Q_historical(p) onto the observed
+        # quantile without replacing the future model's hourly chronology.
+        change <- future_values - historical_quantile
+        adjusted <- observed_quantile + change
+        zero_future_values <- 0L
+    } else {
+        denominator_invalid <- (
+            historical_quantile <= resolved$zero_tolerance
+        )
+        future_zero <- abs(future_values) <= resolved$zero_tolerance
+        undefined <- denominator_invalid & (
+            !future_zero |
+                identical(resolved$zero_denominator_policy, "error")
+        )
+        if (any(undefined)) {
+            cli::cli_abort(
+                "Multiplicative kernel-density Quantile Delta Mapping month {center_month} encountered {sum(undefined)} positive future value(s) with a non-positive or near-zero historical-model quantile."
+            )
+        }
+
+        # Exact future zeros remain zero when their smoothed historical
+        # quantile is undefined; all positive values use the published ratio.
+        change <- numeric(length(future_values))
+        valid <- !denominator_invalid
+        change[valid] <- future_values[valid] / historical_quantile[valid]
+        adjusted <- numeric(length(future_values))
+        adjusted[valid] <- observed_quantile[valid] * change[valid]
+        zero_future_values <- sum(denominator_invalid & future_zero)
+    }
+    list(
+        value = adjusted,
+        probability = probability,
+        change = change,
+        lower_tail = future_cdf$lower_tail,
+        upper_tail = future_cdf$upper_tail,
+        zero_future_values = zero_future_values
+    )
+}
+
+# Fit centered three-month KDEs independently for each output month, then map
+# all rows while retaining the original future-model ordering and coordinates.
+kqdm__adjust_values <- function(series, resolved) {
+    observed <- series$observed_reference
+    historical <- series$model_historical
+    future <- series$model_future
+    adjusted <- rep.int(NA_real_, nrow(future))
+    diagnostics <- vector("list", length(unique(future[["cf_month"]])))
+    center_months <- sort(unique(future[["cf_month"]]))
+
+    for (month_index in seq_along(center_months)) {
+        center_month <- center_months[[month_index]]
+        window_months <- kqdm__window_months(center_month)
+        observed_values <- observed[["value"]][
+            observed[["cf_month"]] %in% window_months
+        ]
+        historical_values <- historical[["value"]][
+            historical[["cf_month"]] %in% window_months
+        ]
+        future_values <- future[["value"]][
+            future[["cf_month"]] %in% window_months
+        ]
+        observed_distribution <- kqdm__density_cdf(
+            observed_values,
+            resolved,
+            sprintf("observed month %d window", center_month)
+        )
+        historical_distribution <- kqdm__density_cdf(
+            historical_values,
+            resolved,
+            sprintf("historical-model month %d window", center_month)
+        )
+        future_distribution <- kqdm__density_cdf(
+            future_values,
+            resolved,
+            sprintf("future-model month %d window", center_month)
+        )
+
+        output_index <- which(future[["cf_month"]] == center_month)
+        mapped <- kqdm__map_values(
+            observed_distribution,
+            historical_distribution,
+            future_distribution,
+            future[["value"]][output_index],
+            resolved,
+            center_month
+        )
+        adjusted[output_index] <- mapped$value
+        diagnostics[[month_index]] <- data.frame(
+            center_month = center_month,
+            window_months = paste(window_months, collapse = ","),
+            observed_samples = observed_distribution$summary$samples,
+            historical_samples = historical_distribution$summary$samples,
+            future_samples = future_distribution$summary$samples,
+            observed_bandwidth = observed_distribution$summary$bandwidth,
+            historical_bandwidth = historical_distribution$summary$bandwidth,
+            future_bandwidth = future_distribution$summary$bandwidth,
+            probability_min = min(mapped$probability),
+            probability_max = max(mapped$probability),
+            change_min = min(mapped$change),
+            change_max = max(mapped$change),
+            future_lower_tail_values = sum(mapped$lower_tail),
+            future_upper_tail_values = sum(mapped$upper_tail),
+            zero_future_values = mapped$zero_future_values,
+            stringsAsFactors = FALSE
+        )
+    }
+    if (anyNA(adjusted)) {
+        cli::cli_abort(
+            "Kernel-density Quantile Delta Mapping did not assign every future-model row."
+        )
+    }
+
+    bounded <- pmin(
+        pmax(adjusted, resolved$bounds[[1L]]),
+        resolved$bounds[[2L]]
+    )
+    month_diagnostics <- do.call(rbind, diagnostics)
+    month_diagnostics$clipped_values <- vapply(
+        month_diagnostics$center_month,
+        function(center_month) {
+            index <- future[["cf_month"]] == center_month
+            sum(bounded[index] != adjusted[index])
+        },
+        integer(1L)
+    )
+    rownames(month_diagnostics) <- NULL
+    list(
+        value = bounded,
+        diagnostics = list(
+            months = month_diagnostics,
+            mapped_probability_range = range(c(
+                month_diagnostics$probability_min,
+                month_diagnostics$probability_max
+            )),
+            transferred_change_range = range(c(
+                month_diagnostics$change_min,
+                month_diagnostics$change_max
+            )),
+            clipped_values = sum(month_diagnostics$clipped_values),
+            implementation = list(
+                kernel = resolved$kernel,
+                bandwidth_method = resolved$bandwidth_method,
+                grid_points = resolved$grid_points,
+                tail_policy = resolved$tail_policy
+            )
+        )
+    )
+}
+
+# Execute one aligned hourly univariate group and return the common
+# frequency-aware adjusted-series contract with full numerical provenance.
+kqdm__apply_group <- function(inputs, settings, key) {
+    resolved <- kqdm__settings(settings)
+    variable <- names(settings)[[1L]]
+    series <- kqdm__inputs(
+        inputs,
+        variable,
+        resolved$transformation
+    )
+    mapped <- kqdm__adjust_values(series, resolved)
+    future <- series$model_future
+    future[["value"]] <- mapped$value
+
+    bias__subdaily_adjusted_series(
+        future,
+        frequency = "hour",
+        time_step_seconds = 3600,
+        output_role = "model_future",
+        transformation = "kernel_quantile_delta_mapping",
+        settings = resolved,
+        provenance = list(
+            method = "kernel_quantile_delta_mapping",
+            references = KQDM_REFERENCES,
+            group_key = key,
+            output_backbone = "model_future",
+            published_method_settings = c(
+                "kernel_density_cdf",
+                "centered_three_month_window",
+                resolved$transformation
+            ),
+            package_selected_numerics = list(
+                kernel = resolved$kernel,
+                bandwidth_method = resolved$bandwidth_method,
+                bandwidth_adjust = resolved$bandwidth_adjust,
+                grid_points = resolved$grid_points,
+                tail_policy = resolved$tail_policy,
+                zero_denominator_policy = resolved$zero_denominator_policy
+            ),
+            diagnostics = mapped$diagnostics
+        )
+    )
+}
+
+# Return an explicit diagnostic if a kernel violates the future-model hourly
+# output contract expected by downstream sequence components.
+kqdm__validate_result <- function(value, inputs, key) {
+    if (!S7::S7_inherits(value, SubdailyAdjustedSeries)) {
+        return(
+            "Kernel-density Quantile Delta Mapping must return a SubdailyAdjustedSeries object."
+        )
+    }
+    if (!identical(value@frequency, "hour") ||
+        !identical(as.numeric(value@time_step_seconds), 3600)) {
+        return(
+            "Kernel-density Quantile Delta Mapping output must retain the hourly frequency and 3600-second timestep."
+        )
+    }
+    if (!identical(value@output_role, "model_future")) {
+        return(
+            "Kernel-density Quantile Delta Mapping output must retain the `model_future` role."
+        )
+    }
+    TRUE
+}
+
+# Construct the reusable hourly signal with explicit role, variable, frequency,
+# intermediate-kind, and output-contract declarations.
+kqdm__component <- function() {
+    alternatives <- as.list(c(
+        KQDM_PUBLISHED_VARIABLES,
+        KQDM_EXPERIMENTAL_VARIABLES
+    ))
+    roles <- c(
+        "observed_reference",
+        "model_historical",
+        "model_future"
+    )
+    requirements <- lapply(roles, function(role) {
+        component__input_requirement(
+            role,
+            representations = "series",
+            frequencies = "hour",
+            variable_sets = alternatives
+        )
+    })
+    names(requirements) <- roles
+    signal__component(
+        name = "kernel_quantile_delta_mapping_hourly",
+        label = "Hourly kernel-density Quantile Delta Mapping",
+        required_inputs = requirements,
+        input_kinds = "calendar_indexed_hourly_series",
+        output_kinds = "subdaily_adjusted_series",
+        scopes = "univariate",
+        stochastic = FALSE,
+        profiles = kqdm__profiles(),
+        apply_group = kqdm__apply_group,
+        operations = list(validate_result = kqdm__validate_result),
+        metadata = list(
+            method_family = "bias_adjustment",
+            output_contract = "subdaily_adjusted_series",
+            output_frequency = "hour",
+            output_step_seconds = 3600,
+            references = KQDM_REFERENCES,
+            published_method = list(
+                cdf = "kernel_density",
+                window = "centered_three_months",
+                additive_variables = c("tas", "ps"),
+                multiplicative_variables = c(
+                    "hurs",
+                    "sfcWind",
+                    "rsds",
+                    "rsdsdiff"
+                )
+            ),
+            unreported_numerical_defaults = c(
+                "kernel",
+                "bandwidth_method",
+                "bandwidth_adjust",
+                "grid_points",
+                "tail_policy",
+                "min_samples",
+                "bounds",
+                "zero_tolerance",
+                "zero_denominator_policy"
+            )
+        )
+    )
+}
+
+# Register the standalone signal once so recipes and component inspection can
+# resolve it without constructing an author-specific complete workflow.
+kqdm__register_component <- function() {
+    component <- kqdm__component()
+    key <- component__registry_key(component@stage, component@name)
+    if (!exists(
+        key,
+        envir = WEATHER_COMPONENT_REGISTRY,
+        inherits = FALSE
+    )) {
+        component__register(component)
+    }
+    invisible(NULL)
+}

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -17,6 +17,7 @@
     bias__register_delta_change_component()
     qm__register_component()
     qdm__register_component()
+    kqdm__register_component()
     sdm__register_component()
     cdft__register_component()
     edcdf__register_component()

--- a/tests/testthat/test-kernel-qdm.R
+++ b/tests/testthat/test-kernel-qdm.R
@@ -1,0 +1,391 @@
+# Build one regular-lattice hourly series sampled at noon on every native CF
+# day, keeping tests compact while exercising sub-daily calendar metadata.
+kqdm_test__series <- function(
+    variable,
+    year,
+    values,
+    calendar = "noleap",
+    units = switch(
+        variable,
+        tas = "K",
+        ps = "Pa",
+        psl = "Pa",
+        hurs = "%",
+        sfcWind = "m s-1",
+        rsds = "W m-2",
+        rsdsdiff = "W m-2",
+        rlds = "W m-2",
+        "1"
+    )
+) {
+    fields <- cf_time_offset2date(
+        seq.int(0L, length(values) - 1L),
+        data.frame(year = as.integer(year), month = 1L, day = 1L),
+        calendar
+    )
+    fields$hour <- 12L
+    fields$minute <- 0L
+    fields$second <- 0
+    data.frame(
+        variable_id = rep.int(variable, length(values)),
+        value = as.numeric(values),
+        units = rep.int(units, length(values)),
+        frequency = rep.int("hour", length(values)),
+        cf_time__coordinates(fields, calendar),
+        cf_second_of_day = rep.int(43200, length(values)),
+        source_row = seq_along(values),
+        stringsAsFactors = FALSE
+    )
+}
+
+# Return a smooth, non-constant annual signal with the exact number of days in
+# the requested native calendar.
+kqdm_test__annual_values <- function(year, calendar, offset = 0) {
+    day_count <- cf_time__year_days(as.integer(year), calendar)
+    phase <- (seq_len(day_count) - 0.5) / day_count
+    10 + 2 * sin(2 * pi * phase) + 0.01 * seq_len(day_count) + offset
+}
+
+# Construct role descriptors and one aligned signal group for common component
+# execution tests.
+kqdm_test__boundary <- function(observed, historical, future) {
+    list(
+        inputs = weather__new_inputs(
+            observed_reference = weather__new_input(
+                "observed_reference",
+                observed
+            ),
+            model_historical = weather__new_input(
+                "model_historical",
+                historical
+            ),
+            model_future = weather__new_input(
+                "model_future",
+                future
+            )
+        ),
+        group = signal__group(
+            key = list(site = "A"),
+            inputs = list(
+                observed_reference = observed,
+                model_historical = historical,
+                model_future = future
+            ),
+            variables = unique(future$variable_id)
+        )
+    )
+}
+
+# Execute the registered signal contract with a smaller deterministic KDE grid
+# so unit tests retain the production algorithm without unnecessary runtime.
+kqdm_test__execute <- function(
+    variable,
+    observed,
+    historical,
+    future,
+    overrides = list(),
+    warn_experimental = FALSE
+) {
+    boundary <- kqdm_test__boundary(observed, historical, future)
+    settings <- utils::modifyList(
+        list(grid_points = 512L, min_samples = 10L),
+        overrides
+    )
+    component__execute(
+        kqdm__component(),
+        "apply",
+        inputs = boundary$inputs,
+        groups = list(boundary$group),
+        overrides = stats::setNames(list(settings), variable),
+        warn_experimental = warn_experimental
+    )
+}
+
+# Retrieve one default profile by variable for direct kernel validation.
+kqdm_test__settings <- function(variable) {
+    profiles <- kqdm__profiles()
+    index <- which(vapply(
+        profiles,
+        function(profile) identical(profile@variable_id, variable),
+        logical(1L)
+    ))
+    profiles[[index]]@settings
+}
+
+test_that("hourly kernel QDM transfers additive quantile changes", {
+    base <- kqdm_test__annual_values(1991L, "noleap")
+    observed <- kqdm_test__series("tas", 2001L, base - 2)
+    historical <- kqdm_test__series("tas", 1991L, base)
+    future <- kqdm_test__series("tas", 2061L, base + 4)
+
+    execution <- kqdm_test__execute(
+        "tas",
+        observed,
+        historical,
+        future
+    )
+    adjusted <- execution@values[[1L]]
+
+    expect_s7_class(execution, SignalExecutionResult)
+    expect_s7_class(adjusted, SubdailyAdjustedSeries)
+    expect_equal(adjusted@data$value, future$value - 2, tolerance = 0.02)
+    expect_identical(adjusted@data$source_row, future$source_row)
+    expect_identical(adjusted@frequency, "hour")
+    expect_identical(as.numeric(adjusted@time_step_seconds), 3600)
+    expect_identical(adjusted@output_role, "model_future")
+    expect_identical(
+        adjusted@transformation,
+        "kernel_quantile_delta_mapping"
+    )
+    expect_identical(execution@diagnostics$status, "ok")
+})
+
+test_that("hourly kernel QDM transfers multiplicative quantile changes", {
+    base <- kqdm_test__annual_values(1991L, "noleap")
+    observed <- kqdm_test__series("sfcWind", 2001L, base * 1.5)
+    historical <- kqdm_test__series("sfcWind", 1991L, base)
+    future <- kqdm_test__series("sfcWind", 2061L, base * 2)
+
+    adjusted <- kqdm_test__execute(
+        "sfcWind",
+        observed,
+        historical,
+        future
+    )@values[[1L]]
+
+    expect_equal(adjusted@data$value, future$value * 1.5, tolerance = 0.04)
+    expect_identical(adjusted@settings$transformation, "multiplicative")
+    expect_true(all(adjusted@data$value >= 0))
+})
+
+test_that("hourly kernel QDM wraps month windows on native CF calendars", {
+    expect_identical(kqdm__window_months(1L), c(12L, 1L, 2L))
+    expect_identical(kqdm__window_months(12L), c(11L, 12L, 1L))
+
+    for (calendar in c("360_day", "all_leap")) {
+        year <- if (identical(calendar, "all_leap")) 2000L else 2001L
+        values <- kqdm_test__annual_values(year, calendar)
+        observed <- kqdm_test__series(
+            "tas",
+            year,
+            values,
+            calendar
+        )
+        historical <- kqdm_test__series(
+            "tas",
+            year - 10L,
+            values,
+            calendar
+        )
+        future <- kqdm_test__series(
+            "tas",
+            year + 60L,
+            values,
+            calendar
+        )
+        adjusted <- kqdm_test__execute(
+            "tas",
+            observed,
+            historical,
+            future
+        )@values[[1L]]
+
+        expect_equal(
+            adjusted@data$value,
+            values,
+            tolerance = 0.02,
+            info = calendar
+        )
+        january <- adjusted@provenance$diagnostics$months
+        january <- january[january$center_month == 1L, ]
+        expect_identical(january$window_months, "12,1,2", info = calendar)
+        expect_identical(
+            unique(adjusted@data$cf_calendar),
+            calendar,
+            info = calendar
+        )
+    }
+})
+
+test_that("hourly kernel QDM records package-selected numerical settings", {
+    base <- kqdm_test__annual_values(1991L, "noleap")
+    observed <- kqdm_test__series("tas", 2001L, base)
+    historical <- kqdm_test__series("tas", 1991L, base)
+    future <- kqdm_test__series("tas", 2061L, base + 1)
+
+    execution <- NULL
+    expect_warning(
+        execution <- kqdm_test__execute(
+            "tas",
+            observed,
+            historical,
+            future,
+            overrides = list(
+                kernel = "epanechnikov",
+                bandwidth_method = "nrd",
+                bandwidth_adjust = 0.75
+            ),
+            warn_experimental = TRUE
+        ),
+        "experimental"
+    )
+    adjusted <- execution@values[[1L]]
+    numerics <- adjusted@provenance$package_selected_numerics
+
+    expect_identical(adjusted@settings$bandwidth_adjust, 0.75)
+    expect_identical(adjusted@settings$grid_points, 512L)
+    expect_identical(adjusted@settings$kernel, "epanechnikov")
+    expect_identical(adjusted@settings$bandwidth_method, "nrd")
+    expect_identical(numerics$kernel, "epanechnikov")
+    expect_identical(numerics$bandwidth_method, "nrd")
+    expect_identical(numerics$bandwidth_adjust, 0.75)
+    expect_identical(numerics$grid_points, 512L)
+    expect_identical(
+        adjusted@provenance$published_method_settings,
+        c(
+            "kernel_density_cdf",
+            "centered_three_month_window",
+            "additive"
+        )
+    )
+    expect_equal(nrow(adjusted@provenance$diagnostics$months), 12L)
+})
+
+test_that("hourly kernel QDM is deterministic and records clipping", {
+    base <- kqdm_test__annual_values(1991L, "noleap") + 30
+    observed <- kqdm_test__series("hurs", 2001L, base * 3)
+    historical <- kqdm_test__series("hurs", 1991L, base)
+    future <- kqdm_test__series("hurs", 2061L, base)
+
+    first <- kqdm_test__execute(
+        "hurs",
+        observed,
+        historical,
+        future
+    )@values[[1L]]
+    second <- kqdm_test__execute(
+        "hurs",
+        observed,
+        historical,
+        future
+    )@values[[1L]]
+
+    expect_identical(first@data$value, second@data$value)
+    expect_true(all(first@data$value <= 100))
+    expect_true(first@provenance$diagnostics$clipped_values > 0L)
+    expect_equal(
+        sum(first@provenance$diagnostics$months$clipped_values),
+        first@provenance$diagnostics$clipped_values
+    )
+})
+
+test_that("hourly kernel QDM rejects invalid inputs and numerical settings", {
+    base <- kqdm_test__annual_values(1991L, "noleap")
+    observed <- kqdm_test__series("sfcWind", 2001L, base)
+    historical <- kqdm_test__series("sfcWind", 1991L, base)
+    future <- kqdm_test__series("sfcWind", 2061L, base)
+    boundary <- kqdm_test__boundary(observed, historical, future)
+    settings <- kqdm_test__settings("sfcWind")
+    settings$grid_points <- 512L
+    settings$min_samples <- 10L
+
+    negative <- boundary$group@inputs
+    negative$model_future$value[[1L]] <- -1
+    expect_error(
+        kqdm__apply_group(
+            negative,
+            list(sfcWind = settings),
+            list(site = "A")
+        ),
+        "non-negative"
+    )
+
+    wrong_frequency <- boundary$group@inputs
+    wrong_frequency$model_future$frequency <- "3hr"
+    expect_error(
+        kqdm__apply_group(
+            wrong_frequency,
+            list(sfcWind = settings),
+            list(site = "A")
+        ),
+        "declared `frequency`"
+    )
+
+    invalid_grid <- settings
+    invalid_grid$grid_points <- 500L
+    expect_error(
+        kqdm__apply_group(
+            boundary$group@inputs,
+            list(sfcWind = invalid_grid),
+            list(site = "A")
+        ),
+        "power of two"
+    )
+
+    constant <- rep.int(5, length(base))
+    expect_error(
+        kqdm_test__execute(
+            "sfcWind",
+            kqdm_test__series("sfcWind", 2001L, constant),
+            kqdm_test__series("sfcWind", 1991L, constant),
+            kqdm_test__series("sfcWind", 2061L, constant)
+        ),
+        "at least two distinct values"
+    )
+})
+
+test_that("hourly kernel QDM is registered with frequency-aware contracts", {
+    kqdm__register_component()
+    component <- component__get(
+        "signal",
+        "kernel_quantile_delta_mapping_hourly"
+    )
+    profiles <- component@metadata$signal_profiles
+
+    expect_s7_class(component, WeatherComponentSpec)
+    expect_identical(component@stage, "signal")
+    expect_identical(
+        component@input_kinds,
+        "calendar_indexed_hourly_series"
+    )
+    expect_identical(component@output_kinds, "subdaily_adjusted_series")
+    expect_identical(component@scopes, "univariate")
+    expect_false(component@stochastic)
+    expect_identical(
+        sort(names(profiles)),
+        sort(c(
+            KQDM_PUBLISHED_VARIABLES,
+            KQDM_EXPERIMENTAL_VARIABLES
+        ))
+    )
+    expect_true(all(vapply(
+        profiles,
+        function(profile) identical(profile$evidence, "experimental"),
+        logical(1L)
+    )))
+    expect_identical(
+        profiles$tas$metadata$variable_evidence,
+        "method_literature"
+    )
+    expect_identical(
+        profiles$psl$metadata$variable_evidence,
+        "package_extension"
+    )
+
+    calendar <- component__spec(
+        name = "kqdm_calendar_test",
+        stage = "calendar",
+        input_kinds = "hourly_role_inputs",
+        output_kinds = "calendar_indexed_hourly_series",
+        operations = list(apply = identity)
+    )
+    sequence <- component__spec(
+        name = "kqdm_sequence_test",
+        stage = "sequence",
+        input_kinds = "subdaily_adjusted_series",
+        output_kinds = "weather_sequence",
+        operations = list(generate = identity)
+    )
+    expect_true(component__compatible(calendar, component))
+    expect_true(component__compatible(component, sequence))
+})

--- a/vignettes-raw/articles/epw-morpher.Rmd
+++ b/vignettes-raw/articles/epw-morpher.Rmd
@@ -549,7 +549,7 @@ interpretation. Group failures either abort or return an explicit diagnostic
 with a `NULL` result; they are never silently converted to missing numeric
 values.
 
-Eight package-native standalone signals currently use this contract:
+Nine package-native standalone signals currently use this contract:
 
 | Registry name | Correction | Output backbone | Variable-profile evidence |
 |:--------------|:-----------|:----------------|:--------------------------|
@@ -557,6 +557,7 @@ Eight package-native standalone signals currently use this contract:
 | `delta_change_daily` | Monthly historical-to-future mean change, additive for temperature and multiplicative for precipitation | `observed_reference` | Published defaults for `tas`, `tasmin`, `tasmax`, and `pr` |
 | `quantile_mapping_daily` | \(F^{-1}_{obs}(F_{hist}(x_{future}))\) in calendar-neutral circular daily windows | `model_future` | Published method-variable profiles for `tas` and `pr`; implementation-selected defaults for `hurs`, `psl`, `rlds`, `sfcWind`, `tasmin`, and `tasmax` remain experimental |
 | `quantile_delta_mapping_daily` | Transfer \(x_{future} - F^{-1}_{hist}(p)\) or \(x_{future} / F^{-1}_{hist}(p)\) onto \(F^{-1}_{obs}(p)\), where \(p = F_{future,t}(x_{future})\) | `model_future` | Published absolute-change temperature and relative-change precipitation profiles; implementation-selected defaults for other supported variables remain experimental |
+| `kernel_quantile_delta_mapping_hourly` | Fit KDE CDFs in centered three-month calendar windows, then transfer additive or multiplicative modeled quantile changes | `model_future` | Published hourly KDE-QDM window and transformation families; unreported kernel, bandwidth, grid, tail, and zero-denominator defaults remain experimental and explicit |
 | `equidistant_cdf_matching_daily` | Apply \(x_{future} + F^{-1}_{obs}(p) - F^{-1}_{hist}(p)\), where \(p = F_{future}(x_{future})\), using the Li et al. parametric distributions | `model_future` | Li et al. published monthly profiles for `tas` and `pr`; native calendar-month daily pooling is an experimental epwshiftr adaptation |
 | `scaled_distribution_mapping_daily` | Parametric distribution and recurrence-interval scaling, absolute for temperature and relative for precipitation | `model_future` | Published profiles for `tas` and `pr`; applying the Normal branch to `tasmin` and `tasmax` remains experimental |
 | `cdf_transform_daily` | Construct \(F_{obs,future}(x) = F_{obs,hist}(F^{-1}_{model,hist}(F_{model,future}(x)))\), then quantile match the future-model sequence to that target CDF | `model_future` | Published daily profiles for `pr`, `tas`, `tasmin`, `tasmax`, `rsds`, and `sfcWind` |
@@ -583,6 +584,30 @@ transfers relative changes. Precipitation values at or below the published
 before adjustment and censored back to zero afterward. Window sample counts,
 transferred changes, clipping, censoring, and effective seeds are retained in
 provenance.
+
+`kernel_quantile_delta_mapping_hourly` implements the hourly variant described
+by [Wang et al. (2023)](https://doi.org/10.1038/s41467-023-41458-5) after
+temporal downscaling. For every future calendar month, the preceding, current,
+and following months are pooled independently from `observed_reference`,
+`model_historical`, and `model_future`; December and January wrap without
+coercing 360-, 365-, or 366-day inputs to Gregorian dates. The future KDE gives
+\(p\), and observed and historical KDE quantiles at \(p\) receive the additive
+or multiplicative QDM equation. The future rows, exact time-of-day positions,
+and native CF chronology remain the output backbone.
+
+The publication specifies KDE CDFs, a three-month moving window, additive
+temperature and pressure changes, and multiplicative wind, humidity, and
+radiation changes. It and its supplementary information do not specify the KDE
+kernel, bandwidth, numerical CDF grid, finite-grid tail behavior, minimum sample
+count, bounds, or treatment of a zero multiplicative denominator. The component
+therefore labels every current profile experimental. Its default Gaussian
+kernel, `nrd0` bandwidth, grid, endpoint clamp, bounds, and zero handling are
+ordinary package settings rather than claims about the authors' unpublished
+code. Supported `stats::density()` kernels and bandwidth selectors, an erroring
+tail policy, and strict zero-denominator handling can be selected through the
+same validated overrides. The resolved values, per-month sample counts and
+bandwidths, mapped probability and change ranges, tail use, zero handling, and
+clipping remain in result provenance.
 
 `equidistant_cdf_matching_daily` implements the additive equation published by
 Li et al. (2010):

--- a/vignettes-raw/precompiled-checksums.csv
+++ b/vignettes-raw/precompiled-checksums.csv
@@ -1,7 +1,7 @@
 "source","output","source_md5","output_md5"
 "vignettes-raw/articles/cli-esgf-store.Rmd","vignettes/articles/cli-esgf-store.Rmd","cac788f79010ad56496939cdde3580bb","e58e5cafa0d3b2218081c25a1098273f"
 "vignettes-raw/articles/downloader.Rmd","vignettes/articles/downloader.Rmd","9668ccb5b39f0ca2f49e146a1a100a7c","4b67e4a9ddaecfe7ce3ac268936e2a2d"
-"vignettes-raw/articles/epw-morpher.Rmd","vignettes/articles/epw-morpher.Rmd","86a3fa988f4465ce477be37bc83d5faf","1ee51b0f0a26267d5d633698a1e8ec42"
+"vignettes-raw/articles/epw-morpher.Rmd","vignettes/articles/epw-morpher.Rmd","3de57eda19bb39a804348162a72dba39","cbbd276a8419b0062ee2c13143149839"
 "vignettes-raw/articles/esg-dictionaries.Rmd","vignettes/articles/esg-dictionaries.Rmd","94eb2513975549a6765afa221a2e10c1","290348d35a29e925f1b3732586e54cfb"
 "vignettes-raw/articles/esg-store.Rmd","vignettes/articles/esg-store.Rmd","c2d810261308c837b84c803a0d2632c5","bb73ddac53598a36b049797782ce3c02"
 "vignettes-raw/articles/esgf-query-results.Rmd","vignettes/articles/esgf-query-results.Rmd","9cb7e909ecc499eba79e4295857101d1","20854ab68644b18addeefcef1baafcfa"

--- a/vignettes/articles/epw-morpher.Rmd
+++ b/vignettes/articles/epw-morpher.Rmd
@@ -557,7 +557,7 @@ interpretation. Group failures either abort or return an explicit diagnostic
 with a `NULL` result; they are never silently converted to missing numeric
 values.
 
-Eight package-native standalone signals currently use this contract:
+Nine package-native standalone signals currently use this contract:
 
 | Registry name | Correction | Output backbone | Variable-profile evidence |
 |:--------------|:-----------|:----------------|:--------------------------|
@@ -565,6 +565,7 @@ Eight package-native standalone signals currently use this contract:
 | `delta_change_daily` | Monthly historical-to-future mean change, additive for temperature and multiplicative for precipitation | `observed_reference` | Published defaults for `tas`, `tasmin`, `tasmax`, and `pr` |
 | `quantile_mapping_daily` | \(F^{-1}_{obs}(F_{hist}(x_{future}))\) in calendar-neutral circular daily windows | `model_future` | Published method-variable profiles for `tas` and `pr`; implementation-selected defaults for `hurs`, `psl`, `rlds`, `sfcWind`, `tasmin`, and `tasmax` remain experimental |
 | `quantile_delta_mapping_daily` | Transfer \(x_{future} - F^{-1}_{hist}(p)\) or \(x_{future} / F^{-1}_{hist}(p)\) onto \(F^{-1}_{obs}(p)\), where \(p = F_{future,t}(x_{future})\) | `model_future` | Published absolute-change temperature and relative-change precipitation profiles; implementation-selected defaults for other supported variables remain experimental |
+| `kernel_quantile_delta_mapping_hourly` | Fit KDE CDFs in centered three-month calendar windows, then transfer additive or multiplicative modeled quantile changes | `model_future` | Published hourly KDE-QDM window and transformation families; unreported kernel, bandwidth, grid, tail, and zero-denominator defaults remain experimental and explicit |
 | `equidistant_cdf_matching_daily` | Apply \(x_{future} + F^{-1}_{obs}(p) - F^{-1}_{hist}(p)\), where \(p = F_{future}(x_{future})\), using the Li et al. parametric distributions | `model_future` | Li et al. published monthly profiles for `tas` and `pr`; native calendar-month daily pooling is an experimental epwshiftr adaptation |
 | `scaled_distribution_mapping_daily` | Parametric distribution and recurrence-interval scaling, absolute for temperature and relative for precipitation | `model_future` | Published profiles for `tas` and `pr`; applying the Normal branch to `tasmin` and `tasmax` remains experimental |
 | `cdf_transform_daily` | Construct \(F_{obs,future}(x) = F_{obs,hist}(F^{-1}_{model,hist}(F_{model,future}(x)))\), then quantile match the future-model sequence to that target CDF | `model_future` | Published daily profiles for `pr`, `tas`, `tasmin`, `tasmax`, `rsds`, and `sfcWind` |
@@ -591,6 +592,30 @@ transfers relative changes. Precipitation values at or below the published
 before adjustment and censored back to zero afterward. Window sample counts,
 transferred changes, clipping, censoring, and effective seeds are retained in
 provenance.
+
+`kernel_quantile_delta_mapping_hourly` implements the hourly variant described
+by [Wang et al. (2023)](https://doi.org/10.1038/s41467-023-41458-5) after
+temporal downscaling. For every future calendar month, the preceding, current,
+and following months are pooled independently from `observed_reference`,
+`model_historical`, and `model_future`; December and January wrap without
+coercing 360-, 365-, or 366-day inputs to Gregorian dates. The future KDE gives
+\(p\), and observed and historical KDE quantiles at \(p\) receive the additive
+or multiplicative QDM equation. The future rows, exact time-of-day positions,
+and native CF chronology remain the output backbone.
+
+The publication specifies KDE CDFs, a three-month moving window, additive
+temperature and pressure changes, and multiplicative wind, humidity, and
+radiation changes. It and its supplementary information do not specify the KDE
+kernel, bandwidth, numerical CDF grid, finite-grid tail behavior, minimum sample
+count, bounds, or treatment of a zero multiplicative denominator. The component
+therefore labels every current profile experimental. Its default Gaussian
+kernel, `nrd0` bandwidth, grid, endpoint clamp, bounds, and zero handling are
+ordinary package settings rather than claims about the authors' unpublished
+code. Supported `stats::density()` kernels and bandwidth selectors, an erroring
+tail policy, and strict zero-denominator handling can be selected through the
+same validated overrides. The resolved values, per-month sample counts and
+bandwidths, mapped probability and change ranges, tail use, zero handling, and
+clipping remain in result provenance.
 
 `equidistant_cdf_matching_daily` implements the additive equation published by
 Li et al. (2010):


### PR DESCRIPTION
## Summary

- Adds a package-native hourly kernel-density Quantile Delta Mapping signal for pre-aligned observed, historical-model, and future-model weather series.
- Keeps the publication's stated method settings separate from unreported, user-overridable KDE numerical defaults.
- Closes #190.

## Changes

- Registers `kernel_quantile_delta_mapping_hourly` with centered three-month native-calendar windows, additive and multiplicative variable profiles, and `SubdailyAdjustedSeries` output.
- Records resolved kernel, bandwidth, grid, tail, zero-denominator, bounds, monthly fit diagnostics, and future-backbone provenance.
- Adds calendar, transformation, validation, determinism, clipping, component-contract, NEWS, and raw-vignette coverage.