### PR TITLE
refactor: reuse common weather workflow helpers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -545,6 +545,11 @@
 
 ## Internal changes
 
+* Consolidated repeated weather input validation, daily temperature
+  preprocessing, successful signal-value extraction, native-calendar method
+  fixtures, and Solr response fixtures into method-neutral helpers while
+  preserving method equations and observable workflow behavior (#201).
+
 * Added regression tests for batched Dataset child collection, including
   global `limit` handling and progress labels (#119).
 * Updated GitHub Actions workflow dependencies for current Actions behavior

--- a/R/backend-arima-temperature.R
+++ b/R/backend-arima-temperature.R
@@ -383,14 +383,7 @@ arima__signal_apply_group <- function(inputs, settings, key) {
 # Preserve the original TMY day sequence instead of sampling or reordering
 # events after the percentile-dependent climate signal has been estimated.
 arima__sequence_generate <- function(data, inputs, context, options) {
-    if (!S7::S7_inherits(data, SignalExecutionResult) ||
-        length(data@values) != 1L ||
-        is.null(data@values[[1L]])) {
-        cli::cli_abort(
-            "Arima sequence input must contain one successful signal group."
-        )
-    }
-    data@values[[1L]]
+    signal__single_value(data, "Arima")
 }
 
 # Apply each daily additive factor to all 24 TMY hours as specified by Arima

--- a/R/backend-daily-temperature.R
+++ b/R/backend-daily-temperature.R
@@ -83,21 +83,7 @@ daily__temperature_preprocess_apply <- function(
 ) {
     morpher__validate_context(context)
     options <- daily__temperature_backend_options(options)
-    future <- weather__get_input(inputs, "model_future")
-    historical <- weather__get_input(inputs, "model_historical")
-    template <- weather__get_input(inputs, "weather_template")
-    list(
-        baseline = temperature__epw_template(template@source),
-        future = temperature__daily_climate(
-            future@source,
-            "future climate"
-        ),
-        historical = temperature__daily_climate(
-            historical@source,
-            "historical climate"
-        ),
-        options = options
-    )
+    temperature__preprocess_inputs(inputs, options)
 }
 
 # Map future and historical daily sources onto the common 365-day phase grid,

--- a/R/backend-eames-monthly-temperature.R
+++ b/R/backend-eames-monthly-temperature.R
@@ -302,21 +302,7 @@ eames__monthly_temperature_preprocess_apply <- function(
 ) {
     morpher__validate_context(context)
     options <- eames__monthly_temperature_options(options)
-    future <- weather__get_input(inputs, "model_future")
-    historical <- weather__get_input(inputs, "model_historical")
-    template <- weather__get_input(inputs, "weather_template")
-    list(
-        baseline = temperature__epw_template(template@source),
-        future = temperature__daily_climate(
-            future@source,
-            "future climate"
-        ),
-        historical = temperature__daily_climate(
-            historical@source,
-            "historical climate"
-        ),
-        options = options
-    )
+    temperature__preprocess_inputs(inputs, options)
 }
 
 # Interpret each model's native calendar before the signal kernel so the kernel

--- a/R/backend-ek-daily-temperature.R
+++ b/R/backend-ek-daily-temperature.R
@@ -310,21 +310,7 @@ ek__daily_temperature_targets <- function(
 ek__preprocess_apply <- function(inputs, context, options) {
     morpher__validate_context(context)
     options <- ek__daily_temperature_options(options)
-    future <- weather__get_input(inputs, "model_future")
-    historical <- weather__get_input(inputs, "model_historical")
-    template <- weather__get_input(inputs, "weather_template")
-    list(
-        baseline = temperature__epw_template(template@source),
-        future = temperature__daily_climate(
-            future@source,
-            "future climate"
-        ),
-        historical = temperature__daily_climate(
-            historical@source,
-            "historical climate"
-        ),
-        options = options
-    )
+    temperature__preprocess_inputs(inputs, options)
 }
 
 # Map each native CF year to the shared annual coordinate before averaging the
@@ -382,14 +368,7 @@ ek__signal_apply_group <- function(inputs, settings, key) {
 # Retain the baseline EPW day order so the Ek comparison changes only the
 # climate signal and published within-day transformation.
 ek__sequence_generate <- function(data, inputs, context, options) {
-    if (!S7::S7_inherits(data, SignalExecutionResult) ||
-        length(data@values) != 1L ||
-        is.null(data@values[[1L]])) {
-        cli::cli_abort(
-            "Ek sequence input must contain one successful signal group."
-        )
-    }
-    data@values[[1L]]
+    signal__single_value(data, "Ek")
 }
 
 # Apply Ek equation (5) day by day using relative DTR change as the anomaly

--- a/R/backend-sobie-curry.R
+++ b/R/backend-sobie-curry.R
@@ -516,14 +516,7 @@ sobie__signal_apply_group <- function(inputs, settings, key) {
 # Preserve the baseline CWEC/EPW sequence exactly, as the published method
 # changes hourly values but does not synthesize a new event sequence.
 sobie__sequence_generate <- function(data, inputs, context, options) {
-    if (!S7::S7_inherits(data, SignalExecutionResult) ||
-        length(data@values) != 1L ||
-        is.null(data@values[[1L]])) {
-        cli::cli_abort(
-            "Sobie-Curry sequence input must contain one successful signal group."
-        )
-    }
-    value <- data@values[[1L]]
+    value <- signal__single_value(data, "Sobie-Curry")
     value$options <- sobie__backend_options(options)
     value
 }

--- a/R/component-temperature-epw.R
+++ b/R/component-temperature-epw.R
@@ -103,14 +103,7 @@ temperature__sequence_generate <- function(
     context,
     options
 ) {
-    if (!S7::S7_inherits(data, SignalExecutionResult) ||
-        length(data@values) != 1L ||
-        is.null(data@values[[1L]])) {
-        cli::cli_abort(
-            "Daily temperature sequence input must contain one successful signal group."
-        )
-    }
-    data@values[[1L]]
+    signal__single_value(data, "Daily temperature")
 }
 
 # Select and validate only options owned by the shared hourly temperature

--- a/R/weather-component.R
+++ b/R/weather-component.R
@@ -587,19 +587,18 @@ component__requirement_errors <- function(requirement, input) {
     errors
 }
 
-# Validate all required inputs and every supplied optional input before a
-# component starts fitting or transforming data.
-component__input_errors <- function(component, inputs) {
-    if (!S7::S7_inherits(component, WeatherComponentSpec)) {
-        cli::cli_abort(
-            "{.arg component} must be a WeatherComponentSpec object."
-        )
-    }
+# Traverse one pair of required and optional role contracts so component and
+# recipe validation cannot drift in how they interpret the same WeatherInput.
+weather__input_requirement_errors <- function(
+    required_inputs,
+    optional_inputs,
+    inputs
+) {
     if (!S7::S7_inherits(inputs, WeatherInputs)) {
         cli::cli_abort("{.arg inputs} must be a WeatherInputs object.")
     }
     errors <- character()
-    for (role in names(component@required_inputs)) {
+    for (role in names(required_inputs)) {
         input <- weather__get_input(inputs, role)
         if (is.null(input)) {
             errors <- c(errors, sprintf("required role `%s` is missing", role))
@@ -608,12 +607,12 @@ component__input_errors <- function(component, inputs) {
         errors <- c(
             errors,
             component__requirement_errors(
-                component@required_inputs[[role]],
+                required_inputs[[role]],
                 input
             )
         )
     }
-    for (role in names(component@optional_inputs)) {
+    for (role in names(optional_inputs)) {
         input <- weather__get_input(inputs, role)
         if (is.null(input)) {
             next
@@ -621,12 +620,27 @@ component__input_errors <- function(component, inputs) {
         errors <- c(
             errors,
             component__requirement_errors(
-                component@optional_inputs[[role]],
+                optional_inputs[[role]],
                 input
             )
         )
     }
     unique(errors)
+}
+
+# Validate all required inputs and every supplied optional input before a
+# component starts fitting or transforming data.
+component__input_errors <- function(component, inputs) {
+    if (!S7::S7_inherits(component, WeatherComponentSpec)) {
+        cli::cli_abort(
+            "{.arg component} must be a WeatherComponentSpec object."
+        )
+    }
+    weather__input_requirement_errors(
+        component@required_inputs,
+        component@optional_inputs,
+        inputs
+    )
 }
 
 # Abort with all input-contract failures together so discovery and workflow

--- a/R/weather-recipe.R
+++ b/R/weather-recipe.R
@@ -1136,41 +1136,11 @@ recipe__input_errors <- function(spec, inputs) {
             "{.arg spec} must be a WeatherRecipeSpec object."
         )
     }
-    if (!S7::S7_inherits(inputs, WeatherInputs)) {
-        cli::cli_abort("{.arg inputs} must be a WeatherInputs object.")
-    }
-    errors <- character()
-    for (role in names(spec@required_inputs)) {
-        input <- weather__get_input(inputs, role)
-        if (is.null(input)) {
-            errors <- c(
-                errors,
-                sprintf("required role `%s` is missing", role)
-            )
-            next
-        }
-        errors <- c(
-            errors,
-            component__requirement_errors(
-                spec@required_inputs[[role]],
-                input
-            )
-        )
-    }
-    for (role in names(spec@optional_inputs)) {
-        input <- weather__get_input(inputs, role)
-        if (is.null(input)) {
-            next
-        }
-        errors <- c(
-            errors,
-            component__requirement_errors(
-                spec@optional_inputs[[role]],
-                input
-            )
-        )
-    }
-    unique(errors)
+    weather__input_requirement_errors(
+        spec@required_inputs,
+        spec@optional_inputs,
+        inputs
+    )
 }
 
 # Abort with the complete role diagnostics so queued and foreground execution

--- a/R/weather-signal.R
+++ b/R/weather-signal.R
@@ -9,6 +9,20 @@ SIGNAL_PROFILE_EVIDENCE <- c("published", "experimental")
 # failure explicitly alongside successful group results.
 SIGNAL_ERROR_POLICIES <- c("abort", "collect")
 
+# Return the only successful signal-group payload shared by sequence-preserving
+# methods, while allowing each method to retain its own diagnostic identity.
+signal__single_value <- function(data, label) {
+    checkmate::assert_string(label, min.chars = 1L)
+    if (!S7::S7_inherits(data, SignalExecutionResult) ||
+        length(data@values) != 1L ||
+        is.null(data@values[[1L]])) {
+        cli::cli_abort(
+            "{label} sequence input must contain one successful signal group."
+        )
+    }
+    data@values[[1L]]
+}
+
 # SignalVariableProfile records variable-specific defaults without embedding
 # them in an algorithm function or losing their evidence status.
 SignalVariableProfile <- S7::new_class(

--- a/R/weather-temperature.R
+++ b/R/weather-temperature.R
@@ -74,6 +74,32 @@ temperature__backend_options <- function(
     options
 }
 
+# Normalize the three role-addressable inputs shared by daily-source
+# temperature backends after each method has resolved its own option contract.
+temperature__preprocess_inputs <- function(inputs, options) {
+    if (!S7::S7_inherits(inputs, WeatherInputs)) {
+        cli::cli_abort("{.arg inputs} must be a WeatherInputs object.")
+    }
+    future <- weather__get_input(inputs, "model_future")
+    historical <- weather__get_input(inputs, "model_historical")
+    template <- weather__get_input(inputs, "weather_template")
+
+    # Component and recipe contracts guarantee the roles exist; keeping all
+    # normalization here gives every backend the same table and unit boundary.
+    list(
+        baseline = temperature__epw_template(template@source),
+        future = temperature__daily_climate(
+            future@source,
+            "future climate"
+        ),
+        historical = temperature__daily_climate(
+            historical@source,
+            "historical climate"
+        ),
+        options = options
+    )
+}
+
 # Convert mixed supported temperature units to degrees Celsius through the
 # package-wide checked unit converter after a caller validates source metadata.
 temperature__to_celsius <- function(value, units) {

--- a/tests/testthat/helper-cli-shift-workflow.R
+++ b/tests/testthat/helper-cli-shift-workflow.R
@@ -1,16 +1,5 @@
 cli_shift_test_response <- function(docs) {
-    list(
-        responseHeader = list(status = 0L, QTime = 0L, params = stats::setNames(list(), character())),
-        response = list(numFound = nrow(docs), start = 0L, docs = docs, maxScore = 1),
-        facet_counts = list(
-            facet_queries = stats::setNames(list(), character()),
-            facet_fields = stats::setNames(list(), character()),
-            facet_ranges = stats::setNames(list(), character()),
-            facet_intervals = stats::setNames(list(), character()),
-            facet_heatmaps = stats::setNames(list(), character())
-        ),
-        timestamp = as.POSIXct("2026-01-01 00:00:00", tz = "UTC")
-    )
+    esgf_test__response(docs)
 }
 
 cli_shift_test_dataset_docs <- function(variable_id = "tas") {

--- a/tests/testthat/helper-cli.R
+++ b/tests/testthat/helper-cli.R
@@ -1,25 +1,5 @@
 cli_test_response <- function(docs) {
-    list(
-        responseHeader = list(
-            status = 0L,
-            QTime = 0L,
-            params = stats::setNames(list(), character())
-        ),
-        response = list(
-            numFound = nrow(docs),
-            start = 0L,
-            docs = docs,
-            maxScore = 1
-        ),
-        facet_counts = list(
-            facet_queries = stats::setNames(list(), character()),
-            facet_fields = stats::setNames(list(), character()),
-            facet_ranges = stats::setNames(list(), character()),
-            facet_intervals = stats::setNames(list(), character()),
-            facet_heatmaps = stats::setNames(list(), character())
-        ),
-        timestamp = as.POSIXct("2026-01-01 00:00:00", tz = "UTC")
-    )
+    esgf_test__response(docs)
 }
 
 cli_test_file_docs <- function(path = "cli-file.nc", download_url = NULL) {

--- a/tests/testthat/helper-epw-morpher.R
+++ b/tests/testthat/helper-epw-morpher.R
@@ -1,26 +1,6 @@
 # Build a stable Solr response envelope for local morphing integration tests.
 epw_morpher_test_response <- function(docs) {
-    list(
-        responseHeader = list(
-            status = 0L,
-            QTime = 0L,
-            params = stats::setNames(list(), character())
-        ),
-        response = list(
-            numFound = nrow(docs),
-            start = 0L,
-            docs = docs,
-            maxScore = 1
-        ),
-        facet_counts = list(
-            facet_queries = stats::setNames(list(), character()),
-            facet_fields = stats::setNames(list(), character()),
-            facet_ranges = stats::setNames(list(), character()),
-            facet_intervals = stats::setNames(list(), character()),
-            facet_heatmaps = stats::setNames(list(), character())
-        ),
-        timestamp = as.POSIXct("2026-01-01 00:00:00", tz = "UTC")
-    )
+    esgf_test__response(docs)
 }
 
 # Return the file-query parameters shared by local morphing fixtures.

--- a/tests/testthat/helper-esgf-fixtures.R
+++ b/tests/testthat/helper-esgf-fixtures.R
@@ -11,6 +11,38 @@ read_fixture_json <- function(...) {
     readLines(fixture_path(...), warn = FALSE)
 }
 
+# Build the canonical Solr response envelope shared by query, Store, CLI, and
+# staged-workflow tests while allowing time-sensitive tests to supply a timestamp.
+esgf_test__response <- function(
+    docs,
+    timestamp = as.POSIXct("2026-01-01 00:00:00", tz = "UTC"),
+    params = stats::setNames(list(), character()),
+    facet_fields = stats::setNames(list(), character()),
+    num_found = if (is.data.frame(docs)) nrow(docs) else length(docs)
+) {
+    list(
+        responseHeader = list(
+            status = 0L,
+            QTime = 0L,
+            params = params
+        ),
+        response = list(
+            numFound = as.integer(num_found),
+            start = 0L,
+            docs = docs,
+            maxScore = 1
+        ),
+        facet_counts = list(
+            facet_queries = stats::setNames(list(), character()),
+            facet_fields = facet_fields,
+            facet_ranges = stats::setNames(list(), character()),
+            facet_intervals = stats::setNames(list(), character()),
+            facet_heatmaps = stats::setNames(list(), character())
+        ),
+        timestamp = timestamp
+    )
+}
+
 esgf_fixture_response <- function(name) {
     response <- fixture_json("esgf", name)
     response$timestamp <- as.POSIXct("2020-02-02 22:22:22", tz = "UTC")

--- a/tests/testthat/helper-signal-methods.R
+++ b/tests/testthat/helper-signal-methods.R
@@ -31,21 +31,81 @@ bias_adjustment_test__series <- function(
     )
 }
 
+# Build consecutive native-calendar daily rows shared by statistical signal
+# method tests without coercing 360-, 365-, or 366-day dates through base Date.
+signal_test__series <- function(
+    variable_id,
+    year,
+    values,
+    calendar = "noleap",
+    units = if (identical(variable_id, "pr")) {
+        "kg m-2 s-1"
+    } else if (identical(variable_id, "hurs")) {
+        "%"
+    } else {
+        "K"
+    }
+) {
+    origin <- data.frame(
+        year = as.integer(year),
+        month = 1L,
+        day = 1L
+    )
+    fields <- cf_time_offset2date(
+        seq.int(0L, length(values) - 1L),
+        origin,
+        calendar
+    )
+    fields$hour <- 12L
+    fields$minute <- 0L
+    fields$second <- 0
+    data.frame(
+        variable_id = rep.int(variable_id, length(values)),
+        value = as.numeric(values),
+        units = rep.int(units, length(values)),
+        frequency = rep.int("day", length(values)),
+        cf_time__coordinates(fields, calendar),
+        stringsAsFactors = FALSE
+    )
+}
+
+# Construct the role metadata and aligned group shared by signal component
+# execution tests so every method exercises the same package boundary.
+signal_test__execution_inputs <- function(
+    observed,
+    historical,
+    future,
+    key = list(site = "A")
+) {
+    list(
+        inputs = weather__new_inputs(
+            observed_reference = weather__new_input(
+                "observed_reference",
+                observed
+            ),
+            model_historical = weather__new_input(
+                "model_historical",
+                historical
+            ),
+            model_future = weather__new_input(
+                "model_future",
+                future
+            )
+        ),
+        group = signal__group(
+            key = key,
+            inputs = list(
+                observed_reference = observed,
+                model_historical = historical,
+                model_future = future
+            ),
+            variables = unique(future$variable_id)
+        )
+    )
+}
+
 # Build all three role-labelled WeatherInput objects required by monthly
 # mean-change signals while retaining the same tables in the aligned group.
 bias_adjustment_test__inputs <- function(observed, historical, future) {
-    weather__new_inputs(
-        observed_reference = weather__new_input(
-            "observed_reference",
-            observed
-        ),
-        model_historical = weather__new_input(
-            "model_historical",
-            historical
-        ),
-        model_future = weather__new_input(
-            "model_future",
-            future
-        )
-    )
+    signal_test__execution_inputs(observed, historical, future)$inputs
 }

--- a/tests/testthat/test-backend-belcher.R
+++ b/tests/testthat/test-backend-belcher.R
@@ -538,20 +538,7 @@ test_that("exact Amon and LImon partitions gate File rows and extraction plans",
             project = "CMIP6", distrib = TRUE, limit = 10L,
             type = "File", format = QUERY_PARAM__FORMAT_JSON
         ))
-        response <- list(
-            responseHeader = list(status = 0L, QTime = 0L,
-                params = stats::setNames(list(), character())),
-            response = list(numFound = nrow(docs), start = 0L,
-                docs = docs, maxScore = 1),
-            facet_counts = list(
-                facet_queries = stats::setNames(list(), character()),
-                facet_fields = stats::setNames(list(), character()),
-                facet_ranges = stats::setNames(list(), character()),
-                facet_intervals = stats::setNames(list(), character()),
-                facet_heatmaps = stats::setNames(list(), character())
-            ),
-            timestamp = as.POSIXct("2026-01-01", tz = "UTC")
-        )
+        response <- esgf_test__response(docs)
         query_result__new(
             EsgResultFile, index_node = "https://example.org",
             params = params, result = response

--- a/tests/testthat/test-method-cdf-transform.R
+++ b/tests/testthat/test-method-cdf-transform.R
@@ -1,73 +1,7 @@
-# Build native-calendar daily rows for CDF-t fixtures without coercing dates
-# through Gregorian base Date semantics.
-cdft_test__series <- function(
-  variable_id,
-  year,
-  values,
-  calendar = "noleap",
-  units = if (identical(variable_id, "pr")) {
-      "kg m-2 s-1"
-  } else {
-      "K"
-  }
-) {
-    origin <- data.frame(
-        year = as.integer(year),
-        month = 1L,
-        day = 1L
-    )
-    fields <- cf_time_offset2date(
-        seq.int(0L, length(values) - 1L),
-        origin,
-        calendar
-    )
-    fields$hour <- 12L
-    fields$minute <- 0L
-    fields$second <- 0
-    data.frame(
-        variable_id = rep.int(variable_id, length(values)),
-        value = as.numeric(values),
-        units = rep.int(units, length(values)),
-        frequency = rep.int("day", length(values)),
-        cf_time__coordinates(fields, calendar),
-        stringsAsFactors = FALSE
-    )
-}
-
-# Construct the package role metadata and aligned signal group used by CDF-t
-# component-execution tests.
-cdft_test__execution_inputs <- function(
-  observed,
-  historical,
-  future,
-  key = list(site = "A")
-) {
-    list(
-        inputs = weather__new_inputs(
-            observed_reference = weather__new_input(
-                "observed_reference",
-                observed
-            ),
-            model_historical = weather__new_input(
-                "model_historical",
-                historical
-            ),
-            model_future = weather__new_input(
-                "model_future",
-                future
-            )
-        ),
-        group = signal__group(
-            key = key,
-            inputs = list(
-                observed_reference = observed,
-                model_historical = historical,
-                model_future = future
-            ),
-            variables = unique(future$variable_id)
-        )
-    )
-}
+# Use the shared native-calendar series and signal-boundary fixtures while
+# retaining the CDF-t names used throughout this test module.
+cdft_test__series <- signal_test__series
+cdft_test__execution_inputs <- signal_test__execution_inputs
 
 # Execute compact one-year fixtures through the common signal lifecycle while
 # retaining the method defaults for empirical-CDF and SSR behavior.

--- a/tests/testthat/test-method-equidistant-cdf-matching.R
+++ b/tests/testthat/test-method-equidistant-cdf-matching.R
@@ -1,73 +1,7 @@
-# Build native-calendar daily rows for Equidistant CDF Matching fixtures
-# without coercing 360-, 365-, or 366-day coordinates through base Date.
-edcdf_test__series <- function(
-  variable_id,
-  year,
-  values,
-  calendar = "noleap",
-  units = if (identical(variable_id, "pr")) {
-      "kg m-2 s-1"
-  } else {
-      "K"
-  }
-) {
-    origin <- data.frame(
-        year = as.integer(year),
-        month = 1L,
-        day = 1L
-    )
-    fields <- cf_time_offset2date(
-        seq.int(0L, length(values) - 1L),
-        origin,
-        calendar
-    )
-    fields$hour <- 12L
-    fields$minute <- 0L
-    fields$second <- 0
-    data.frame(
-        variable_id = rep.int(variable_id, length(values)),
-        value = as.numeric(values),
-        units = rep.int(units, length(values)),
-        frequency = rep.int("day", length(values)),
-        cf_time__coordinates(fields, calendar),
-        stringsAsFactors = FALSE
-    )
-}
-
-# Construct the package role metadata and one aligned signal group used by
-# component lifecycle tests.
-edcdf_test__execution_inputs <- function(
-  observed,
-  historical,
-  future,
-  key = list(site = "A")
-) {
-    list(
-        inputs = weather__new_inputs(
-            observed_reference = weather__new_input(
-                "observed_reference",
-                observed
-            ),
-            model_historical = weather__new_input(
-                "model_historical",
-                historical
-            ),
-            model_future = weather__new_input(
-                "model_future",
-                future
-            )
-        ),
-        group = signal__group(
-            key = key,
-            inputs = list(
-                observed_reference = observed,
-                model_historical = historical,
-                model_future = future
-            ),
-            variables = unique(future$variable_id)
-        )
-    )
-}
+# Use the shared native-calendar series and signal-boundary fixtures while
+# retaining the EDCDFm names used throughout this test module.
+edcdf_test__series <- signal_test__series
+edcdf_test__execution_inputs <- signal_test__execution_inputs
 
 # Execute compact fixtures with reduced sample thresholds while retaining all
 # published distribution and package-adaptation settings.

--- a/tests/testthat/test-method-isimip3basd.R
+++ b/tests/testthat/test-method-isimip3basd.R
@@ -1,69 +1,15 @@
-# Build native-calendar daily fixtures without routing 360-, 365-, or 366-day
-# coordinates through a Gregorian Date conversion.
+# ISIMIP fixtures retain their dimensionless default while sharing all native
+# calendar construction and role-boundary mechanics with other signal methods.
 isimip_test__series <- function(
-  variable_id,
-  year,
-  values,
-  calendar = "noleap",
-  units = "1"
+    variable_id,
+    year,
+    values,
+    calendar = "noleap",
+    units = "1"
 ) {
-    origin <- data.frame(
-        year = as.integer(year),
-        month = 1L,
-        day = 1L
-    )
-    fields <- cf_time_offset2date(
-        seq.int(0L, length(values) - 1L),
-        origin,
-        calendar
-    )
-    fields$hour <- 12L
-    fields$minute <- 0L
-    fields$second <- 0
-    data.frame(
-        variable_id = rep.int(variable_id, length(values)),
-        value = as.numeric(values),
-        units = rep.int(units, length(values)),
-        frequency = rep.int("day", length(values)),
-        cf_time__coordinates(fields, calendar),
-        stringsAsFactors = FALSE
-    )
+    signal_test__series(variable_id, year, values, calendar, units)
 }
-
-# Construct the common input metadata and one aligned signal group for
-# end-to-end component tests.
-isimip_test__execution_inputs <- function(
-  observed,
-  historical,
-  future,
-  key = list(site = "A")
-) {
-    list(
-        inputs = weather__new_inputs(
-            observed_reference = weather__new_input(
-                "observed_reference",
-                observed
-            ),
-            model_historical = weather__new_input(
-                "model_historical",
-                historical
-            ),
-            model_future = weather__new_input(
-                "model_future",
-                future
-            )
-        ),
-        group = signal__group(
-            key = key,
-            inputs = list(
-                observed_reference = observed,
-                model_historical = historical,
-                model_future = future
-            ),
-            variables = unique(future$variable_id)
-        )
-    )
-}
+isimip_test__execution_inputs <- signal_test__execution_inputs
 
 # Retrieve one complete publication-backed variable profile.
 isimip_test__settings <- function(variable) {

--- a/tests/testthat/test-method-quantile-delta-mapping.R
+++ b/tests/testthat/test-method-quantile-delta-mapping.R
@@ -1,74 +1,7 @@
-# Build calendar-native daily rows without coercing non-Gregorian dates through
-# base Date, matching the package signal boundary.
-qdm_test__series <- function(
-    variable_id,
-    year,
-    values,
-    calendar = "noleap",
-    units = if (identical(variable_id, "pr")) {
-        "kg m-2 s-1"
-    } else if (identical(variable_id, "hurs")) {
-        "%"
-    } else {
-        "K"
-    }
-) {
-    origin <- data.frame(
-        year = as.integer(year),
-        month = 1L,
-        day = 1L
-    )
-    fields <- cf_time_offset2date(
-        seq.int(0L, length(values) - 1L),
-        origin,
-        calendar
-    )
-    fields$hour <- 12L
-    fields$minute <- 0L
-    fields$second <- 0
-    data.frame(
-        variable_id = rep.int(variable_id, length(values)),
-        value = as.numeric(values),
-        units = rep.int(units, length(values)),
-        frequency = rep.int("day", length(values)),
-        cf_time__coordinates(fields, calendar),
-        stringsAsFactors = FALSE
-    )
-}
-
-# Construct canonical role metadata and one aligned QDM signal group.
-qdm_test__execution_inputs <- function(
-    observed,
-    historical,
-    future,
-    key = list(site = "A")
-) {
-    list(
-        inputs = weather__new_inputs(
-            observed_reference = weather__new_input(
-                "observed_reference",
-                observed
-            ),
-            model_historical = weather__new_input(
-                "model_historical",
-                historical
-            ),
-            model_future = weather__new_input(
-                "model_future",
-                future
-            )
-        ),
-        group = signal__group(
-            key = key,
-            inputs = list(
-                observed_reference = observed,
-                model_historical = historical,
-                model_future = future
-            ),
-            variables = unique(future$variable_id)
-        )
-    )
-}
+# Use the shared native-calendar series and signal-boundary fixtures while
+# retaining the QDM names used throughout this test module.
+qdm_test__series <- signal_test__series
+qdm_test__execution_inputs <- signal_test__execution_inputs
 
 # Execute compact fixtures through the common signal lifecycle with a
 # full-annual seasonal pool and an explicit minimum sample count.

--- a/tests/testthat/test-method-quantile-mapping.R
+++ b/tests/testthat/test-method-quantile-mapping.R
@@ -1,75 +1,7 @@
-# Build one calendar-native daily series from consecutive CF-calendar days so
-# Quantile Mapping tests never rely on Gregorian Date coercion.
-qm_test__series <- function(
-    variable_id,
-    year,
-    values,
-    calendar = "noleap",
-    units = if (identical(variable_id, "pr")) {
-        "kg m-2 s-1"
-    } else if (identical(variable_id, "hurs")) {
-        "%"
-    } else {
-        "K"
-    }
-) {
-    origin <- data.frame(
-        year = as.integer(year),
-        month = 1L,
-        day = 1L
-    )
-    fields <- cf_time_offset2date(
-        seq.int(0L, length(values) - 1L),
-        origin,
-        calendar
-    )
-    fields$hour <- 12L
-    fields$minute <- 0L
-    fields$second <- 0
-    data.frame(
-        variable_id = rep.int(variable_id, length(values)),
-        value = as.numeric(values),
-        units = rep.int(units, length(values)),
-        frequency = rep.int("day", length(values)),
-        cf_time__coordinates(fields, calendar),
-        stringsAsFactors = FALSE
-    )
-}
-
-# Construct role metadata and the aligned group from the same three canonical
-# tables, matching the package's standalone signal execution boundary.
-qm_test__execution_inputs <- function(
-    observed,
-    historical,
-    future,
-    key = list(site = "A")
-) {
-    list(
-        inputs = weather__new_inputs(
-            observed_reference = weather__new_input(
-                "observed_reference",
-                observed
-            ),
-            model_historical = weather__new_input(
-                "model_historical",
-                historical
-            ),
-            model_future = weather__new_input(
-                "model_future",
-                future
-            )
-        ),
-        group = signal__group(
-            key = key,
-            inputs = list(
-                observed_reference = observed,
-                model_historical = historical,
-                model_future = future
-            ),
-            variables = unique(future$variable_id)
-        )
-    )
-}
+# Use the shared native-calendar series and signal-boundary fixtures while
+# retaining the Quantile Mapping names used throughout this test module.
+qm_test__series <- signal_test__series
+qm_test__execution_inputs <- signal_test__execution_inputs
 
 # Execute one variable through the common signal lifecycle while replacing the
 # default seasonal window with a full-cycle window for compact test fixtures.

--- a/tests/testthat/test-method-scaled-distribution-mapping.R
+++ b/tests/testthat/test-method-scaled-distribution-mapping.R
@@ -1,72 +1,7 @@
-# Build calendar-native daily rows without coercing non-Gregorian dates through
-# base Date, matching the package signal boundary.
-sdm_test__series <- function(
-  variable_id,
-  year,
-  values,
-  calendar = "noleap",
-  units = if (identical(variable_id, "pr")) {
-      "kg m-2 s-1"
-  } else {
-      "K"
-  }
-) {
-    origin <- data.frame(
-        year = as.integer(year),
-        month = 1L,
-        day = 1L
-    )
-    fields <- cf_time_offset2date(
-        seq.int(0L, length(values) - 1L),
-        origin,
-        calendar
-    )
-    fields$hour <- 12L
-    fields$minute <- 0L
-    fields$second <- 0
-    data.frame(
-        variable_id = rep.int(variable_id, length(values)),
-        value = as.numeric(values),
-        units = rep.int(units, length(values)),
-        frequency = rep.int("day", length(values)),
-        cf_time__coordinates(fields, calendar),
-        stringsAsFactors = FALSE
-    )
-}
-
-# Construct canonical role metadata and one aligned SDM signal group.
-sdm_test__execution_inputs <- function(
-  observed,
-  historical,
-  future,
-  key = list(site = "A")
-) {
-    list(
-        inputs = weather__new_inputs(
-            observed_reference = weather__new_input(
-                "observed_reference",
-                observed
-            ),
-            model_historical = weather__new_input(
-                "model_historical",
-                historical
-            ),
-            model_future = weather__new_input(
-                "model_future",
-                future
-            )
-        ),
-        group = signal__group(
-            key = key,
-            inputs = list(
-                observed_reference = observed,
-                model_historical = historical,
-                model_future = future
-            ),
-            variables = unique(future$variable_id)
-        )
-    )
-}
+# Use the shared native-calendar series and signal-boundary fixtures while
+# retaining the SDM names used throughout this test module.
+sdm_test__series <- signal_test__series
+sdm_test__execution_inputs <- signal_test__execution_inputs
 
 # Execute compact fixtures through the common signal lifecycle with one
 # retained year and explicit sample requirements.

--- a/tests/testthat/test-query-result.R
+++ b/tests/testthat/test-query-result.R
@@ -3,27 +3,7 @@ local_test_cache(scope = "persist")
 withr::local_options(list(epwshiftr.progress = FALSE))
 
 query_result_test_response <- function(docs) {
-    list(
-        responseHeader = list(
-            status = 0L,
-            QTime = 0L,
-            params = stats::setNames(list(), character())
-        ),
-        response = list(
-            numFound = nrow(docs),
-            start = 0L,
-            docs = docs,
-            maxScore = 1
-        ),
-        facet_counts = list(
-            facet_queries = stats::setNames(list(), character()),
-            facet_fields = stats::setNames(list(), character()),
-            facet_ranges = stats::setNames(list(), character()),
-            facet_intervals = stats::setNames(list(), character()),
-            facet_heatmaps = stats::setNames(list(), character())
-        ),
-        timestamp = Sys.time()
-    )
+    esgf_test__response(docs, timestamp = Sys.time())
 }
 
 query_result_test_params <- function(type = "Dataset", ...) {

--- a/tests/testthat/test-query.R
+++ b/tests/testthat/test-query.R
@@ -21,18 +21,7 @@ local_query_test_response <- function(docs = NULL) {
         docs$access <- I(list("HTTPServer"))
     }
 
-    list(
-        responseHeader = list(status = 0L, QTime = 0L, params = stats::setNames(list(), character())),
-        response = list(numFound = nrow(docs), start = 0L, docs = docs, maxScore = 1),
-        facet_counts = list(
-            facet_queries = stats::setNames(list(), character()),
-            facet_fields = stats::setNames(list(), character()),
-            facet_ranges = stats::setNames(list(), character()),
-            facet_intervals = stats::setNames(list(), character()),
-            facet_heatmaps = stats::setNames(list(), character())
-        ),
-        timestamp = Sys.time()
-    )
+    esgf_test__response(docs, timestamp = Sys.time())
 }
 
 local_query_listing_response <- function(
@@ -45,17 +34,12 @@ local_query_listing_response <- function(
         num_found <- if (is.data.frame(docs)) nrow(docs) else length(docs)
     }
 
-    list(
-        responseHeader = list(status = 0L, QTime = 0L, params = params),
-        response = list(numFound = as.integer(num_found), start = 0L, docs = docs, maxScore = 1),
-        facet_counts = list(
-            facet_queries = stats::setNames(list(), character()),
-            facet_fields = facet_fields,
-            facet_ranges = stats::setNames(list(), character()),
-            facet_intervals = stats::setNames(list(), character()),
-            facet_heatmaps = stats::setNames(list(), character())
-        ),
-        timestamp = Sys.time()
+    esgf_test__response(
+        docs,
+        timestamp = Sys.time(),
+        params = params,
+        facet_fields = facet_fields,
+        num_found = num_found
     )
 }
 
@@ -932,18 +916,7 @@ test_that("EsgQuery$collect(type=) collects child results through Dataset workfl
 
     calls <- list()
     local_response <- function(docs) {
-        list(
-            responseHeader = list(status = 0L, QTime = 0L, params = stats::setNames(list(), character())),
-            response = list(numFound = nrow(docs), start = 0L, docs = docs, maxScore = 1),
-            facet_counts = list(
-                facet_queries = stats::setNames(list(), character()),
-                facet_fields = stats::setNames(list(), character()),
-                facet_ranges = stats::setNames(list(), character()),
-                facet_intervals = stats::setNames(list(), character()),
-                facet_heatmaps = stats::setNames(list(), character())
-            ),
-            timestamp = Sys.time()
-        )
+        esgf_test__response(docs, timestamp = Sys.time())
     }
     local_dataset_docs <- data.frame(
         id = c("dataset-1", "dataset-2"),

--- a/tests/testthat/test-schema.R
+++ b/tests/testthat/test-schema.R
@@ -127,25 +127,8 @@ test_that("SCHEMA_QUERY validates saved query JSON fixtures", {
 # }}}
 # schema_test_response() {{{
 schema_test_response <- function(docs) {
-    list(
-        responseHeader = list(
-            status = 0L,
-            QTime = 0L,
-            params = stats::setNames(list(), character())
-        ),
-        response = list(
-            numFound = nrow(docs),
-            start = 0L,
-            docs = docs,
-            maxScore = 1
-        ),
-        facet_counts = list(
-            facet_queries = stats::setNames(list(), character()),
-            facet_fields = stats::setNames(list(), character()),
-            facet_ranges = stats::setNames(list(), character()),
-            facet_intervals = stats::setNames(list(), character()),
-            facet_heatmaps = stats::setNames(list(), character())
-        ),
+    esgf_test__response(
+        docs,
         timestamp = format.POSIXct(
             Sys.time(),
             digits = 6,

--- a/tests/testthat/test-shift-stage.R
+++ b/tests/testthat/test-shift-stage.R
@@ -1,16 +1,5 @@
 shift_test_response <- function(docs) {
-    list(
-        responseHeader = list(status = 0L, QTime = 0L, params = stats::setNames(list(), character())),
-        response = list(numFound = nrow(docs), start = 0L, docs = docs, maxScore = 1),
-        facet_counts = list(
-            facet_queries = stats::setNames(list(), character()),
-            facet_fields = stats::setNames(list(), character()),
-            facet_ranges = stats::setNames(list(), character()),
-            facet_intervals = stats::setNames(list(), character()),
-            facet_heatmaps = stats::setNames(list(), character())
-        ),
-        timestamp = as.POSIXct("2026-01-01 00:00:00", tz = "UTC")
-    )
+    esgf_test__response(docs)
 }
 
 shift_test_is_absolute_path <- function(path) {

--- a/tests/testthat/test-store.R
+++ b/tests/testthat/test-store.R
@@ -1,26 +1,6 @@
 # store_test__response() / store_test__params() / store_test__result() / store_test__file_docs() / store_test__completed_store() {{{
 store_test__response <- function(docs) {
-    list(
-        responseHeader = list(
-            status = 0L,
-            QTime = 0L,
-            params = stats::setNames(list(), character())
-        ),
-        response = list(
-            numFound = nrow(docs),
-            start = 0L,
-            docs = docs,
-            maxScore = 1
-        ),
-        facet_counts = list(
-            facet_queries = stats::setNames(list(), character()),
-            facet_fields = stats::setNames(list(), character()),
-            facet_ranges = stats::setNames(list(), character()),
-            facet_intervals = stats::setNames(list(), character()),
-            facet_heatmaps = stats::setNames(list(), character())
-        ),
-        timestamp = as.POSIXct("2026-01-01 00:00:00", tz = "UTC")
-    )
+    esgf_test__response(docs)
 }
 
 store_test__params <- function(type = "File") {


### PR DESCRIPTION
## Summary

- Centralizes repeated weather input validation, daily temperature preprocessing, and successful signal-value extraction without changing method equations or public APIs.
- Consolidates native-calendar statistical fixtures and Solr response fixtures so tests exercise one shared contract.

## Changes

- Adds `weather__input_requirement_errors()`, `temperature__preprocess_inputs()`, and `signal__single_value()` and routes the existing component, recipe, Daily, Eames, Arima, Ek, and Sobie-Curry adapters through them.
- Reuses configurable signal-series, signal-boundary, and Solr response builders across method, query, schema, Belcher, CLI, Store, and staged-workflow tests.
- Preserves registered recipe and component identifiers, physical policies, settings, diagnostics, provenance, result types, and row ordering.
- Closes #200.
