### PR TITLE
refactor: reuse signal settings and randomization helpers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -545,6 +545,11 @@
 
 ## Internal changes
 
+* Consolidated the shared settings envelope, schema validation, integer and
+  bound checks, deterministic seed normalization, and role-wise precipitation
+  threshold randomization used by statistical signal methods while preserving
+  each method's equations and threshold semantics (#203).
+
 * Consolidated repeated weather input validation, daily temperature
   preprocessing, successful signal-value extraction, native-calendar method
   fixtures, and Solr response fixtures into method-neutral helpers while

--- a/R/method-cdf-transform.R
+++ b/R/method-cdf-transform.R
@@ -96,15 +96,6 @@ cdft__profiles <- function() {
 # Validate every CDF-t numerical convention at the signal-kernel boundary so
 # user overrides cannot silently select an unimplemented empirical variant.
 cdft__settings <- function(settings) {
-    if (length(settings) != 1L ||
-        is.null(names(settings)) ||
-        !nzchar(names(settings)[[1L]]) ||
-        !is.list(settings[[1L]])) {
-        cli::cli_abort(
-            "CDF-t requires settings for exactly one variable."
-        )
-    }
-    resolved <- settings[[1L]]
     expected <- c(
         "range_alignment",
         "seasonal_grouping",
@@ -123,15 +114,7 @@ cdft__settings <- function(settings) {
         "ssr_threshold",
         "random_seed"
     )
-    missing <- setdiff(expected, names(resolved))
-    unexpected <- setdiff(names(resolved), expected)
-    if (length(missing) || length(unexpected)) {
-        cli::cli_abort(c(
-            "CDF-t settings must use the complete supported schema.",
-            "x" = "Missing setting(s): {.val {missing}}.",
-            "x" = "Unexpected setting(s): {.val {unexpected}}."
-        ))
-    }
+    resolved <- signal__resolve_settings(settings, expected, "CDF-t")
     if (!identical(resolved$range_alignment, "additive_mean") ||
         !identical(resolved$seasonal_grouping, "calendar_month") ||
         !identical(resolved$edge_policy, "truncate") ||
@@ -143,17 +126,15 @@ cdft__settings <- function(settings) {
             "CDF-t currently requires additive-mean range alignment, native calendar-month grouping, truncated edge windows, empirical step CDFs, type-7 inverse quantiles, left-endpoint target inversion, and constant-correction tails."
         )
     }
-    checkmate::assert_integerish(
+    resolved$future_window_years <- signal__integer_setting(
         resolved$future_window_years,
-        lower = 1L,
-        len = 1L,
-        any.missing = FALSE
+        "future_window_years",
+        lower = 1L
     )
-    checkmate::assert_integerish(
+    resolved$output_block_years <- signal__integer_setting(
         resolved$output_block_years,
-        lower = 1L,
-        len = 1L,
-        any.missing = FALSE
+        "output_block_years",
+        lower = 1L
     )
     if (resolved$output_block_years > resolved$future_window_years ||
         (resolved$future_window_years -
@@ -162,17 +143,15 @@ cdft__settings <- function(settings) {
             "`future_window_years` must exceed `output_block_years` by an even, non-negative number of years."
         )
     }
-    checkmate::assert_integerish(
+    resolved$min_samples <- signal__integer_setting(
         resolved$min_samples,
-        lower = 2L,
-        len = 1L,
-        any.missing = FALSE
+        "min_samples",
+        lower = 2L
     )
-    checkmate::assert_integerish(
+    resolved$target_grid_points <- signal__integer_setting(
         resolved$target_grid_points,
-        lower = 100L,
-        len = 1L,
-        any.missing = FALSE
+        "target_grid_points",
+        lower = 100L
     )
     checkmate::assert_number(
         resolved$tail_development_factor,
@@ -182,16 +161,10 @@ cdft__settings <- function(settings) {
     if (resolved$tail_development_factor <= 0) {
         cli::cli_abort("`tail_development_factor` must be positive.")
     }
-    checkmate::assert_numeric(
+    signal__ordered_bounds(
         resolved$bounds,
-        len = 2L,
-        any.missing = FALSE
+        "CDF-t bounds must be ordered from lower to upper."
     )
-    if (resolved$bounds[[1L]] > resolved$bounds[[2L]]) {
-        cli::cli_abort(
-            "CDF-t bounds must be ordered from lower to upper."
-        )
-    }
     checkmate::assert_choice(
         resolved$distribution_model,
         c("continuous", "precipitation_ssr")
@@ -213,25 +186,7 @@ cdft__settings <- function(settings) {
             "Continuous CDF-t requires `ssr_threshold = 0`."
         )
     }
-    checkmate::assert_integerish(
-        resolved$random_seed,
-        lower = 0,
-        upper = .Machine$integer.max - 1L,
-        len = 1L,
-        any.missing = FALSE
-    )
-
-    resolved$future_window_years <- as.integer(
-        resolved$future_window_years
-    )
-    resolved$output_block_years <- as.integer(
-        resolved$output_block_years
-    )
-    resolved$min_samples <- as.integer(resolved$min_samples)
-    resolved$target_grid_points <- as.integer(
-        resolved$target_grid_points
-    )
-    resolved$random_seed <- as.integer(resolved$random_seed)
+    resolved$random_seed <- signal__random_seed(resolved$random_seed)
     resolved
 }
 
@@ -537,34 +492,21 @@ cdft__prepared_values <- function(series, resolved, key, variable) {
         ))
     }
 
-    values <- vector("list", length(series))
-    names(values) <- names(series)
-    randomized <- integer(length(series))
-    names(randomized) <- names(series)
-    seeds <- integer(length(series))
-    names(seeds) <- names(series)
-    for (role in names(series)) {
-        role_key <- c(key, list(input_role = role))
-        seeds[[role]] <- quantile__group_seed(
-            resolved$random_seed,
-            role_key,
-            variable
-        )
-        uniform <- quantile__uniform(nrow(series[[role]]), seeds[[role]])
-        source <- series[[role]][["value"]]
-        singular <- source < resolved$ssr_threshold
-        source[singular] <- uniform[singular] *
-            resolved$ssr_threshold
-        values[[role]] <- source
-        randomized[[role]] <- sum(singular)
-    }
+    randomized <- signal__randomize_threshold_values(
+        series,
+        resolved$random_seed,
+        key,
+        variable,
+        resolved$ssr_threshold,
+        inclusive = FALSE
+    )
     list(
-        values = values,
+        values = randomized$values,
         precipitation = list(
             ssr_threshold = resolved$ssr_threshold,
-            input_randomized_values = randomized,
+            input_randomized_values = randomized$counts,
             random_seed = resolved$random_seed,
-            effective_seeds = seeds,
+            effective_seeds = randomized$seeds,
             random_generator = "park_miller_16807"
         )
     )

--- a/R/method-equidistant-cdf-matching.R
+++ b/R/method-equidistant-cdf-matching.R
@@ -71,15 +71,6 @@ edcdf__profiles <- function() {
 # override cannot silently select a distribution or temporal variant that the
 # native kernel does not implement.
 edcdf__settings <- function(settings) {
-    if (length(settings) != 1L ||
-        is.null(names(settings)) ||
-        !nzchar(names(settings)[[1L]]) ||
-        !is.list(settings[[1L]])) {
-        cli::cli_abort(
-            "Equidistant CDF Matching requires settings for exactly one variable."
-        )
-    }
-    resolved <- settings[[1L]]
     expected <- c(
         "mapping",
         "seasonal_grouping",
@@ -97,15 +88,11 @@ edcdf__settings <- function(settings) {
         "fit_tolerance",
         "fit_max_iterations"
     )
-    missing <- setdiff(expected, names(resolved))
-    unexpected <- setdiff(names(resolved), expected)
-    if (length(missing) || length(unexpected)) {
-        cli::cli_abort(c(
-            "Equidistant CDF Matching settings must use the complete supported schema.",
-            "x" = "Missing setting(s): {.val {missing}}.",
-            "x" = "Unexpected setting(s): {.val {unexpected}}."
-        ))
-    }
+    resolved <- signal__resolve_settings(
+        settings,
+        expected,
+        "Equidistant CDF Matching"
+    )
     if (!identical(resolved$mapping, "additive_equidistant") ||
         !identical(resolved$seasonal_grouping, "calendar_month") ||
         !identical(
@@ -152,33 +139,25 @@ edcdf__settings <- function(settings) {
             "`cdf_epsilon` must lie strictly between zero and 0.5."
         )
     }
-    checkmate::assert_integerish(
+    resolved$min_samples <- signal__integer_setting(
         resolved$min_samples,
-        lower = 2L,
-        len = 1L,
-        any.missing = FALSE
+        "min_samples",
+        lower = 2L
     )
-    checkmate::assert_integerish(
+    resolved$min_positive_samples <- signal__integer_setting(
         resolved$min_positive_samples,
-        lower = 2L,
-        len = 1L,
-        any.missing = FALSE
+        "min_positive_samples",
+        lower = 2L
     )
     checkmate::assert_number(
         resolved$dry_threshold,
         lower = 0,
         finite = TRUE
     )
-    checkmate::assert_numeric(
+    signal__ordered_bounds(
         resolved$bounds,
-        len = 2L,
-        any.missing = FALSE
+        "Equidistant CDF Matching bounds must be ordered."
     )
-    if (resolved$bounds[[1L]] > resolved$bounds[[2L]]) {
-        cli::cli_abort(
-            "Equidistant CDF Matching bounds must be ordered."
-        )
-    }
     checkmate::assert_number(
         resolved$fit_tolerance,
         lower = 0,
@@ -187,11 +166,10 @@ edcdf__settings <- function(settings) {
     if (resolved$fit_tolerance <= 0) {
         cli::cli_abort("`fit_tolerance` must be positive.")
     }
-    checkmate::assert_integerish(
+    resolved$fit_max_iterations <- signal__integer_setting(
         resolved$fit_max_iterations,
-        lower = 1L,
-        len = 1L,
-        any.missing = FALSE
+        "fit_max_iterations",
+        lower = 1L
     )
     if (identical(
         resolved$distribution_model,
@@ -202,13 +180,6 @@ edcdf__settings <- function(settings) {
         )
     }
 
-    resolved$min_samples <- as.integer(resolved$min_samples)
-    resolved$min_positive_samples <- as.integer(
-        resolved$min_positive_samples
-    )
-    resolved$fit_max_iterations <- as.integer(
-        resolved$fit_max_iterations
-    )
     resolved
 }
 

--- a/R/method-isimip3basd.R
+++ b/R/method-isimip3basd.R
@@ -195,15 +195,6 @@ isimip__profiles <- function() {
 # Validate the complete method schema so partial overrides cannot silently
 # change the official application semantics or create invalid threshold pairs.
 isimip__settings <- function(settings) {
-    if (length(settings) != 1L ||
-        is.null(names(settings)) ||
-        !nzchar(names(settings)[[1L]]) ||
-        !is.list(settings[[1L]])) {
-        cli::cli_abort(
-            "ISIMIP3BASD requires settings for exactly one variable."
-        )
-    }
-    resolved <- settings[[1L]]
     expected <- c(
         "method_version",
         "seasonal_grouping",
@@ -234,15 +225,11 @@ isimip__settings <- function(settings) {
         "fit_tolerance",
         "fit_max_iterations"
     )
-    missing <- setdiff(expected, names(resolved))
-    unexpected <- setdiff(names(resolved), expected)
-    if (length(missing) || length(unexpected)) {
-        cli::cli_abort(c(
-            "ISIMIP3BASD settings must use the complete supported schema.",
-            "x" = "Missing setting(s): {.val {missing}}.",
-            "x" = "Unexpected setting(s): {.val {unexpected}}."
-        ))
-    }
+    resolved <- signal__resolve_settings(
+        settings,
+        expected,
+        "ISIMIP3BASD"
+    )
     if (!identical(resolved$method_version, "3.0.x") ||
         !identical(
             resolved$seasonal_grouping,
@@ -254,43 +241,38 @@ isimip__settings <- function(settings) {
             "ISIMIP3BASD currently implements the 3.0.x one-day circular-window application without event-likelihood adjustment."
         )
     }
-    checkmate::assert_integerish(
+    resolved$running_window_days <- signal__integer_setting(
         resolved$running_window_days,
-        lower = 1L,
-        len = 1L,
-        any.missing = FALSE
+        "running_window_days",
+        lower = 1L
     )
-    checkmate::assert_integerish(
+    resolved$target_year_days <- signal__integer_setting(
         resolved$target_year_days,
-        lower = 3L,
-        len = 1L,
-        any.missing = FALSE
+        "target_year_days",
+        lower = 3L
     )
-    checkmate::assert_integerish(
+    resolved$upper_bound_window_days <- signal__integer_setting(
         resolved$upper_bound_window_days,
-        lower = 1L,
-        len = 1L,
-        any.missing = FALSE
+        "upper_bound_window_days",
+        lower = 1L
     )
     daily__window_spec(
-        as.integer(resolved$running_window_days),
-        as.integer(resolved$target_year_days)
+        resolved$running_window_days,
+        resolved$target_year_days
     )
     daily__window_spec(
-        as.integer(resolved$upper_bound_window_days),
-        as.integer(resolved$target_year_days)
+        resolved$upper_bound_window_days,
+        resolved$target_year_days
     )
-    checkmate::assert_integerish(
+    resolved$n_quantiles <- signal__integer_setting(
         resolved$n_quantiles,
-        lower = 1L,
-        len = 1L,
-        any.missing = FALSE
+        "n_quantiles",
+        lower = 1L
     )
-    checkmate::assert_integerish(
+    resolved$min_samples <- signal__integer_setting(
         resolved$min_samples,
-        lower = 2L,
-        len = 1L,
-        any.missing = FALSE
+        "min_samples",
+        lower = 2L
     )
     checkmate::assert_choice(
         resolved$mapping_model,
@@ -300,14 +282,11 @@ isimip__settings <- function(settings) {
         resolved$trend_preservation,
         c("additive", "multiplicative", "mixed", "bounded")
     )
-    checkmate::assert_numeric(
+    signal__ordered_bounds(
         resolved$bounds,
-        len = 2L,
-        any.missing = FALSE
+        "ISIMIP3BASD bounds must be strictly ordered.",
+        strict = TRUE
     )
-    if (resolved$bounds[[1L]] >= resolved$bounds[[2L]]) {
-        cli::cli_abort("ISIMIP3BASD bounds must be strictly ordered.")
-    }
 
     lower <- resolved$lower_threshold
     upper <- resolved$upper_threshold
@@ -424,33 +403,12 @@ isimip__settings <- function(settings) {
         upper = 1,
         finite = TRUE
     )
-    checkmate::assert_integerish(
-        resolved$random_seed,
-        lower = 0,
-        upper = .Machine$integer.max - 1L,
-        len = 1L,
-        any.missing = FALSE
-    )
-    checkmate::assert_integerish(
+    resolved$random_seed <- signal__random_seed(resolved$random_seed)
+    resolved$fit_max_iterations <- signal__integer_setting(
         resolved$fit_max_iterations,
-        lower = 1L,
-        len = 1L,
-        any.missing = FALSE
+        "fit_max_iterations",
+        lower = 1L
     )
-
-    integer_names <- c(
-        "running_window_days",
-        "running_window_step_days",
-        "target_year_days",
-        "n_quantiles",
-        "upper_bound_window_days",
-        "min_samples",
-        "random_seed",
-        "fit_max_iterations"
-    )
-    for (name in integer_names) {
-        resolved[[name]] <- as.integer(resolved[[name]])
-    }
     resolved
 }
 

--- a/R/method-kernel-qdm.R
+++ b/R/method-kernel-qdm.R
@@ -102,15 +102,6 @@ kqdm__profiles <- function() {
 # Validate every executable convention at the signal boundary so user
 # overrides cannot silently introduce an unsupported numerical method.
 kqdm__settings <- function(settings) {
-    if (length(settings) != 1L ||
-        is.null(names(settings)) ||
-        !nzchar(names(settings)[[1L]]) ||
-        !is.list(settings[[1L]])) {
-        cli::cli_abort(
-            "Kernel-density Quantile Delta Mapping requires settings for exactly one variable."
-        )
-    }
-    resolved <- settings[[1L]]
     expected <- c(
         "transformation",
         "window_months",
@@ -126,27 +117,22 @@ kqdm__settings <- function(settings) {
         "zero_tolerance",
         "zero_denominator_policy"
     )
-    missing <- setdiff(expected, names(resolved))
-    unexpected <- setdiff(names(resolved), expected)
-    if (length(missing) || length(unexpected)) {
-        cli::cli_abort(c(
-            "Kernel-density Quantile Delta Mapping settings must use the complete supported schema.",
-            "x" = "Missing setting(s): {.val {missing}}.",
-            "x" = "Unexpected setting(s): {.val {unexpected}}."
-        ))
-    }
+    resolved <- signal__resolve_settings(
+        settings,
+        expected,
+        "Kernel-density Quantile Delta Mapping"
+    )
     checkmate::assert_choice(
         resolved$transformation,
         c("additive", "multiplicative")
     )
-    checkmate::assert_integerish(
+    resolved$window_months <- signal__integer_setting(
         resolved$window_months,
+        "window_months",
         lower = 1L,
-        upper = 12L,
-        len = 1L,
-        any.missing = FALSE
+        upper = 12L
     )
-    if (!identical(as.integer(resolved$window_months), 3L) ||
+    if (!identical(resolved$window_months, 3L) ||
         !identical(resolved$window_alignment, "centered")) {
         cli::cli_abort(
             "Kernel-density Quantile Delta Mapping currently requires the published centered three-month window."
@@ -181,13 +167,12 @@ kqdm__settings <- function(settings) {
     if (resolved$bandwidth_adjust <= 0) {
         cli::cli_abort("`bandwidth_adjust` must be positive.")
     }
-    checkmate::assert_integerish(
+    resolved$grid_points <- signal__integer_setting(
         resolved$grid_points,
-        lower = 128L,
-        len = 1L,
-        any.missing = FALSE
+        "grid_points",
+        lower = 128L
     )
-    grid_points <- as.integer(resolved$grid_points)
+    grid_points <- resolved$grid_points
     if (abs(log2(grid_points) - round(log2(grid_points))) >
         sqrt(.Machine$double.eps)) {
         cli::cli_abort("`grid_points` must be a power of two.")
@@ -196,22 +181,15 @@ kqdm__settings <- function(settings) {
         resolved$tail_policy,
         c("density_grid_clamp", "error")
     )
-    checkmate::assert_integerish(
+    resolved$min_samples <- signal__integer_setting(
         resolved$min_samples,
-        lower = 3L,
-        len = 1L,
-        any.missing = FALSE
+        "min_samples",
+        lower = 3L
     )
-    checkmate::assert_numeric(
+    signal__ordered_bounds(
         resolved$bounds,
-        len = 2L,
-        any.missing = FALSE
+        "Kernel-density Quantile Delta Mapping bounds must be ordered from lower to upper."
     )
-    if (resolved$bounds[[1L]] > resolved$bounds[[2L]]) {
-        cli::cli_abort(
-            "Kernel-density Quantile Delta Mapping bounds must be ordered from lower to upper."
-        )
-    }
     checkmate::assert_number(
         resolved$zero_tolerance,
         lower = 0,
@@ -222,9 +200,7 @@ kqdm__settings <- function(settings) {
         c("zero_future_else_error", "error")
     )
 
-    resolved$window_months <- as.integer(resolved$window_months)
     resolved$grid_points <- grid_points
-    resolved$min_samples <- as.integer(resolved$min_samples)
     resolved
 }
 

--- a/R/method-quantile-delta-mapping.R
+++ b/R/method-quantile-delta-mapping.R
@@ -96,15 +96,6 @@ qdm__profiles <- function() {
 # Validate every QDM convention at the signal-kernel boundary so overrides
 # cannot silently change the published transfer semantics.
 qdm__settings <- function(settings) {
-    if (length(settings) != 1L ||
-        is.null(names(settings)) ||
-        !nzchar(names(settings)[[1L]]) ||
-        !is.list(settings[[1L]])) {
-        cli::cli_abort(
-            "Quantile Delta Mapping requires settings for exactly one variable."
-        )
-    }
-    resolved <- settings[[1L]]
     expected <- c(
         "mapping_type",
         "trend_preservation",
@@ -122,15 +113,11 @@ qdm__settings <- function(settings) {
         "zero_denominator_policy",
         "random_seed"
     )
-    missing <- setdiff(expected, names(resolved))
-    unexpected <- setdiff(names(resolved), expected)
-    if (length(missing) || length(unexpected)) {
-        cli::cli_abort(c(
-            "Quantile Delta Mapping settings must use the complete supported schema.",
-            "x" = "Missing setting(s): {.val {missing}}.",
-            "x" = "Unexpected setting(s): {.val {unexpected}}."
-        ))
-    }
+    resolved <- signal__resolve_settings(
+        settings,
+        expected,
+        "Quantile Delta Mapping"
+    )
     if (!identical(resolved$mapping_type, "nonparametric")) {
         cli::cli_abort(
             "Quantile Delta Mapping currently supports only nonparametric mapping."
@@ -148,49 +135,39 @@ qdm__settings <- function(settings) {
             "Quantile Delta Mapping currently requires linear empirical CDF interpolation, type-7 inverse quantiles, average-rank ties, and future-window endpoint support."
         )
     }
-    checkmate::assert_integerish(
+    resolved$seasonal_window_days <- signal__integer_setting(
         resolved$seasonal_window_days,
-        lower = 1L,
-        len = 1L,
-        any.missing = FALSE
+        "seasonal_window_days",
+        lower = 1L
     )
-    checkmate::assert_integerish(
+    resolved$future_window_years <- signal__integer_setting(
         resolved$future_window_years,
-        lower = 1L,
-        len = 1L,
-        any.missing = FALSE
+        "future_window_years",
+        lower = 1L
     )
-    checkmate::assert_integerish(
+    resolved$target_year_days <- signal__integer_setting(
         resolved$target_year_days,
-        lower = 3L,
-        len = 1L,
-        any.missing = FALSE
+        "target_year_days",
+        lower = 3L
     )
-    checkmate::assert_integerish(
+    resolved$min_samples <- signal__integer_setting(
         resolved$min_samples,
-        lower = 2L,
-        len = 1L,
-        any.missing = FALSE
+        "min_samples",
+        lower = 2L
     )
     daily__window_spec(
-        as.integer(resolved$seasonal_window_days),
-        as.integer(resolved$target_year_days)
+        resolved$seasonal_window_days,
+        resolved$target_year_days
     )
     if (resolved$future_window_years %% 2L != 1L) {
         cli::cli_abort(
             "Quantile Delta Mapping requires an odd `future_window_years` for a symmetric centered window."
         )
     }
-    checkmate::assert_numeric(
+    signal__ordered_bounds(
         resolved$bounds,
-        len = 2L,
-        any.missing = FALSE
+        "Quantile Delta Mapping bounds must be ordered from lower to upper."
     )
-    if (resolved$bounds[[1L]] > resolved$bounds[[2L]]) {
-        cli::cli_abort(
-            "Quantile Delta Mapping bounds must be ordered from lower to upper."
-        )
-    }
     checkmate::assert_choice(
         resolved$distribution_model,
         c("continuous", "precipitation_censored")
@@ -221,23 +198,7 @@ qdm__settings <- function(settings) {
             "Quantile Delta Mapping currently requires `zero_denominator_policy = \"error\"`."
         )
     }
-    checkmate::assert_integerish(
-        resolved$random_seed,
-        lower = 0,
-        upper = .Machine$integer.max - 1L,
-        len = 1L,
-        any.missing = FALSE
-    )
-
-    resolved$seasonal_window_days <- as.integer(
-        resolved$seasonal_window_days
-    )
-    resolved$future_window_years <- as.integer(
-        resolved$future_window_years
-    )
-    resolved$target_year_days <- as.integer(resolved$target_year_days)
-    resolved$min_samples <- as.integer(resolved$min_samples)
-    resolved$random_seed <- as.integer(resolved$random_seed)
+    resolved$random_seed <- signal__random_seed(resolved$random_seed)
     resolved
 }
 
@@ -301,19 +262,6 @@ qdm__future_year_window <- function(year, center, width) {
     year >= center - half_width & year <= center + half_width
 }
 
-# Replace censored precipitation values with deterministic positive uniforms
-# below the trace threshold, following the published dry-day treatment.
-qdm__randomize_censored <- function(values, threshold, uniform) {
-    censored <- values <= threshold
-    randomized <- as.numeric(values)
-    randomized[censored] <- uniform[censored] * threshold
-    list(
-        value = randomized,
-        censored = censored,
-        randomized_values = sum(censored)
-    )
-}
-
 # Preprocess each role once so a source row receives one reproducible censored
 # value even when it contributes to several overlapping QDM windows.
 qdm__prepared_values <- function(series, resolved, key, variable) {
@@ -327,34 +275,20 @@ qdm__prepared_values <- function(series, resolved, key, variable) {
         ))
     }
 
-    values <- vector("list", length(series))
-    names(values) <- names(series)
-    randomized <- integer(length(series))
-    names(randomized) <- names(series)
-    seeds <- integer(length(series))
-    names(seeds) <- names(series)
-    for (role in names(series)) {
-        role_key <- c(key, list(input_role = role))
-        seeds[[role]] <- quantile__group_seed(
-            resolved$random_seed,
-            role_key,
-            variable
-        )
-        uniform <- quantile__uniform(nrow(series[[role]]), seeds[[role]])
-        prepared <- qdm__randomize_censored(
-            series[[role]][["value"]],
-            resolved$dry_threshold,
-            uniform
-        )
-        values[[role]] <- prepared$value
-        randomized[[role]] <- prepared$randomized_values
-    }
+    randomized <- signal__randomize_threshold_values(
+        series,
+        resolved$random_seed,
+        key,
+        variable,
+        resolved$dry_threshold,
+        inclusive = TRUE
+    )
     list(
-        values = values,
+        values = randomized$values,
         precipitation = list(
-            input_censored_values = randomized,
+            input_censored_values = randomized$counts,
             random_seed = resolved$random_seed,
-            effective_seeds = seeds,
+            effective_seeds = randomized$seeds,
             random_generator = "park_miller_16807",
             dry_threshold = resolved$dry_threshold
         )

--- a/R/method-quantile-mapping.R
+++ b/R/method-quantile-mapping.R
@@ -91,15 +91,6 @@ qm__profiles <- function() {
 # Validate all method conventions at the kernel boundary so unsupported
 # empirical-CDF variants cannot be selected silently through an override.
 qm__settings <- function(settings) {
-    if (length(settings) != 1L ||
-        is.null(names(settings)) ||
-        !nzchar(names(settings)[[1L]]) ||
-        !is.list(settings[[1L]])) {
-        cli::cli_abort(
-            "Quantile Mapping requires settings for exactly one variable."
-        )
-    }
-    resolved <- settings[[1L]]
     expected <- c(
         "mapping_type",
         "detrending",
@@ -115,15 +106,11 @@ qm__settings <- function(settings) {
         "dry_threshold",
         "random_seed"
     )
-    missing <- setdiff(expected, names(resolved))
-    unexpected <- setdiff(names(resolved), expected)
-    if (length(missing) || length(unexpected)) {
-        cli::cli_abort(c(
-            "Quantile Mapping settings must use the complete supported schema.",
-            "x" = "Missing setting(s): {.val {missing}}.",
-            "x" = "Unexpected setting(s): {.val {unexpected}}."
-        ))
-    }
+    resolved <- signal__resolve_settings(
+        settings,
+        expected,
+        "Quantile Mapping"
+    )
     if (!identical(resolved$mapping_type, "nonparametric")) {
         cli::cli_abort(
             "Quantile Mapping currently supports only nonparametric mapping."
@@ -142,40 +129,31 @@ qm__settings <- function(settings) {
             "Quantile Mapping currently requires linear empirical CDF interpolation, type-7 inverse quantiles, average-rank ties, and clamped tails."
         )
     }
-    checkmate::assert_integerish(
+    resolved$seasonal_window_days <- signal__integer_setting(
         resolved$seasonal_window_days,
-        lower = 1L,
-        len = 1L,
-        any.missing = FALSE
+        "seasonal_window_days",
+        lower = 1L
     )
-    checkmate::assert_integerish(
+    resolved$target_year_days <- signal__integer_setting(
         resolved$target_year_days,
-        lower = 3L,
-        len = 1L,
-        any.missing = FALSE
+        "target_year_days",
+        lower = 3L
     )
-    checkmate::assert_integerish(
+    resolved$min_samples <- signal__integer_setting(
         resolved$min_samples,
-        lower = 2L,
-        len = 1L,
-        any.missing = FALSE
+        "min_samples",
+        lower = 2L
     )
     # Reuse the calendar-neutral window validator to enforce odd widths and
     # prevent a wider-than-year seasonal window.
     daily__window_spec(
-        as.integer(resolved$seasonal_window_days),
-        as.integer(resolved$target_year_days)
+        resolved$seasonal_window_days,
+        resolved$target_year_days
     )
-    checkmate::assert_numeric(
+    signal__ordered_bounds(
         resolved$bounds,
-        len = 2L,
-        any.missing = FALSE
+        "Quantile Mapping bounds must be ordered from lower to upper."
     )
-    if (resolved$bounds[[1L]] > resolved$bounds[[2L]]) {
-        cli::cli_abort(
-            "Quantile Mapping bounds must be ordered from lower to upper."
-        )
-    }
     checkmate::assert_choice(
         resolved$distribution_model,
         c("continuous", "precipitation_hurdle")
@@ -185,20 +163,7 @@ qm__settings <- function(settings) {
         lower = 0,
         finite = TRUE
     )
-    checkmate::assert_integerish(
-        resolved$random_seed,
-        lower = 0,
-        upper = .Machine$integer.max - 1L,
-        len = 1L,
-        any.missing = FALSE
-    )
-
-    resolved$seasonal_window_days <- as.integer(
-        resolved$seasonal_window_days
-    )
-    resolved$target_year_days <- as.integer(resolved$target_year_days)
-    resolved$min_samples <- as.integer(resolved$min_samples)
-    resolved$random_seed <- as.integer(resolved$random_seed)
+    resolved$random_seed <- signal__random_seed(resolved$random_seed)
     resolved
 }
 

--- a/R/method-scaled-distribution-mapping.R
+++ b/R/method-scaled-distribution-mapping.R
@@ -112,15 +112,6 @@ sdm__profiles <- function() {
 # Validate all published and numerical SDM choices at the signal-kernel
 # boundary so no incompatible distribution branch can be selected silently.
 sdm__settings <- function(settings) {
-    if (length(settings) != 1L ||
-        is.null(names(settings)) ||
-        !nzchar(names(settings)[[1L]]) ||
-        !is.list(settings[[1L]])) {
-        cli::cli_abort(
-            "Scaled Distribution Mapping requires settings for exactly one variable."
-        )
-    }
-    resolved <- settings[[1L]]
     expected <- c(
         "mapping_type",
         "distribution",
@@ -139,15 +130,11 @@ sdm__settings <- function(settings) {
         "gamma_fit_max_iterations",
         "rank_interpolation"
     )
-    missing <- setdiff(expected, names(resolved))
-    unexpected <- setdiff(names(resolved), expected)
-    if (length(missing) || length(unexpected)) {
-        cli::cli_abort(c(
-            "Scaled Distribution Mapping settings must use the complete supported schema.",
-            "x" = "Missing setting(s): {.val {missing}}.",
-            "x" = "Unexpected setting(s): {.val {unexpected}}."
-        ))
-    }
+    resolved <- signal__resolve_settings(
+        settings,
+        expected,
+        "Scaled Distribution Mapping"
+    )
     checkmate::assert_choice(resolved$mapping_type, c("absolute", "relative"))
     checkmate::assert_choice(resolved$distribution, c("normal", "gamma"))
     checkmate::assert_choice(resolved$detrending, c("linear", "none"))
@@ -183,17 +170,15 @@ sdm__settings <- function(settings) {
             "Relative Scaled Distribution Mapping requires a Gamma distribution without detrending."
         )
     }
-    checkmate::assert_integerish(
+    resolved$future_window_years <- signal__integer_setting(
         resolved$future_window_years,
-        lower = 1L,
-        len = 1L,
-        any.missing = FALSE
+        "future_window_years",
+        lower = 1L
     )
-    checkmate::assert_integerish(
+    resolved$output_block_years <- signal__integer_setting(
         resolved$output_block_years,
-        lower = 1L,
-        len = 1L,
-        any.missing = FALSE
+        "output_block_years",
+        lower = 1L
     )
     if (resolved$output_block_years > resolved$future_window_years ||
         (resolved$future_window_years -
@@ -202,11 +187,10 @@ sdm__settings <- function(settings) {
             "`future_window_years` must exceed `output_block_years` by an even, non-negative number of years."
         )
     }
-    checkmate::assert_integerish(
+    resolved$min_samples <- signal__integer_setting(
         resolved$min_samples,
-        lower = 2L,
-        len = 1L,
-        any.missing = FALSE
+        "min_samples",
+        lower = 2L
     )
     checkmate::assert_number(
         resolved$cdf_epsilon,
@@ -217,16 +201,10 @@ sdm__settings <- function(settings) {
     if (resolved$cdf_epsilon <= 0 || resolved$cdf_epsilon >= 0.5) {
         cli::cli_abort("`cdf_epsilon` must lie strictly between zero and 0.5.")
     }
-    checkmate::assert_numeric(
+    signal__ordered_bounds(
         resolved$bounds,
-        len = 2L,
-        any.missing = FALSE
+        "Scaled Distribution Mapping bounds must be ordered from lower to upper."
     )
-    if (resolved$bounds[[1L]] > resolved$bounds[[2L]]) {
-        cli::cli_abort(
-            "Scaled Distribution Mapping bounds must be ordered from lower to upper."
-        )
-    }
     checkmate::assert_number(
         resolved$dry_threshold,
         lower = 0,
@@ -246,22 +224,10 @@ sdm__settings <- function(settings) {
     if (resolved$gamma_fit_tolerance <= 0) {
         cli::cli_abort("`gamma_fit_tolerance` must be positive.")
     }
-    checkmate::assert_integerish(
+    resolved$gamma_fit_max_iterations <- signal__integer_setting(
         resolved$gamma_fit_max_iterations,
-        lower = 1L,
-        len = 1L,
-        any.missing = FALSE
-    )
-
-    resolved$future_window_years <- as.integer(
-        resolved$future_window_years
-    )
-    resolved$output_block_years <- as.integer(
-        resolved$output_block_years
-    )
-    resolved$min_samples <- as.integer(resolved$min_samples)
-    resolved$gamma_fit_max_iterations <- as.integer(
-        resolved$gamma_fit_max_iterations
+        "gamma_fit_max_iterations",
+        lower = 1L
     )
     resolved
 }

--- a/R/weather-signal.R
+++ b/R/weather-signal.R
@@ -23,6 +23,150 @@ signal__single_value <- function(data, label) {
     data@values[[1L]]
 }
 
+# Resolve the one-variable settings envelope used by signal kernels and require
+# the complete method schema before method-specific validation begins.
+signal__resolve_settings <- function(settings, expected, label) {
+    checkmate::assert_character(
+        expected,
+        min.len = 1L,
+        any.missing = FALSE,
+        unique = TRUE
+    )
+    checkmate::assert_string(label, min.chars = 1L)
+    if (length(settings) != 1L ||
+        is.null(names(settings)) ||
+        !nzchar(names(settings)[[1L]]) ||
+        !is.list(settings[[1L]])) {
+        cli::cli_abort(
+            "{label} requires settings for exactly one variable."
+        )
+    }
+
+    resolved <- settings[[1L]]
+    missing <- setdiff(expected, names(resolved))
+    unexpected <- setdiff(names(resolved), expected)
+    if (length(missing) || length(unexpected)) {
+        cli::cli_abort(c(
+            "{label} settings must use the complete supported schema.",
+            "x" = "Missing setting(s): {.val {missing}}.",
+            "x" = "Unexpected setting(s): {.val {unexpected}}."
+        ))
+    }
+    resolved
+}
+
+# Validate a two-value signal bound while allowing each method to retain its
+# published rule for equal endpoints and its existing user-facing message.
+signal__ordered_bounds <- function(bounds, message, strict = FALSE) {
+    checkmate::assert_string(message, min.chars = 1L)
+    checkmate::assert_flag(strict)
+    checkmate::assert_numeric(
+        bounds,
+        len = 2L,
+        any.missing = FALSE,
+        .var.name = "resolved$bounds"
+    )
+    unordered <- if (strict) {
+        bounds[[1L]] >= bounds[[2L]]
+    } else {
+        bounds[[1L]] > bounds[[2L]]
+    }
+    if (unordered) {
+        cli::cli_abort(message)
+    }
+    invisible(bounds)
+}
+
+# Validate and normalize an integer-valued signal setting with a stable
+# diagnostic name even though validation is delegated to this shared helper.
+signal__integer_setting <- function(value, name, lower, upper = Inf) {
+    checkmate::assert_string(name, pattern = "^[A-Za-z][A-Za-z0-9_]*$")
+    checkmate::assert_number(lower)
+    checkmate::assert_number(upper)
+    checkmate::assert_integerish(
+        value,
+        lower = lower,
+        upper = upper,
+        len = 1L,
+        any.missing = FALSE,
+        .var.name = paste0("resolved$", name)
+    )
+    as.integer(value)
+}
+
+# Validate the common deterministic-seed range used by stochastic signal
+# preprocessors and return the normalized integer seed.
+signal__random_seed <- function(value) {
+    signal__integer_setting(
+        value,
+        "random_seed",
+        lower = 0,
+        upper = .Machine$integer.max - 1L
+    )
+}
+
+# Randomize threshold-selected values independently by input role with the
+# package's deterministic generator, without touching R's global RNG state.
+signal__randomize_threshold_values <- function(
+    series,
+    random_seed,
+    key,
+    variable,
+    threshold,
+    inclusive
+) {
+    checkmate::assert_list(series, min.len = 1L, names = "unique")
+    if (is.null(names(series)) || any(!nzchar(names(series)))) {
+        cli::cli_abort(
+            "Threshold randomization requires named input-role series."
+        )
+    }
+    checkmate::assert_int(
+        random_seed,
+        lower = 0L,
+        upper = .Machine$integer.max - 1L
+    )
+    checkmate::assert_list(key, names = "unique")
+    checkmate::assert_string(variable, min.chars = 1L)
+    checkmate::assert_number(threshold, lower = 0, finite = TRUE)
+    checkmate::assert_flag(inclusive)
+
+    values <- vector("list", length(series))
+    names(values) <- names(series)
+    randomized <- integer(length(series))
+    names(randomized) <- names(series)
+    seeds <- integer(length(series))
+    names(seeds) <- names(series)
+
+    # Include the role in the derived seed so aligned inputs never reuse an
+    # identical pseudo-random sequence accidentally.
+    for (role in names(series)) {
+        source <- series[[role]][["value"]]
+        checkmate::assert_numeric(
+            source,
+            finite = TRUE,
+            any.missing = FALSE
+        )
+        role_key <- c(key, list(input_role = role))
+        seeds[[role]] <- quantile__group_seed(
+            random_seed,
+            role_key,
+            variable
+        )
+        uniform <- quantile__uniform(length(source), seeds[[role]])
+        selected <- if (inclusive) {
+            source <= threshold
+        } else {
+            source < threshold
+        }
+        source[selected] <- uniform[selected] * threshold
+        values[[role]] <- source
+        randomized[[role]] <- sum(selected)
+    }
+
+    list(values = values, counts = randomized, seeds = seeds)
+}
+
 # SignalVariableProfile records variable-specific defaults without embedding
 # them in an algorithm function or losing their evidence status.
 SignalVariableProfile <- S7::new_class(

--- a/tests/testthat/test-weather-signal.R
+++ b/tests/testthat/test-weather-signal.R
@@ -25,6 +25,111 @@ test_that("signal profiles keep published and experimental defaults distinct", {
     expect_identical(experimental@evidence, "experimental")
 })
 
+test_that("signal settings helpers preserve complete method schemas", {
+    settings <- list(tas = list(alpha = 1, iterations = 3))
+
+    expect_identical(
+        signal__resolve_settings(
+            settings,
+            c("alpha", "iterations"),
+            "Example Method"
+        ),
+        settings$tas
+    )
+    expect_error(
+        signal__resolve_settings(
+            list(),
+            c("alpha", "iterations"),
+            "Example Method"
+        ),
+        "requires settings for exactly one variable"
+    )
+    expect_error(
+        signal__resolve_settings(
+            list(tas = list(alpha = 1, extra = 2)),
+            c("alpha", "iterations"),
+            "Example Method"
+        ),
+        "complete supported schema"
+    )
+    expect_identical(
+        signal__integer_setting(3, "iterations", lower = 1L),
+        3L
+    )
+    expect_identical(signal__random_seed(17), 17L)
+    expect_error(
+        signal__integer_setting(0, "iterations", lower = 1L),
+        "resolved\\$iterations"
+    )
+    expect_no_error(
+        signal__ordered_bounds(c(1, 1), "Bounds must be ordered.")
+    )
+    expect_error(
+        signal__ordered_bounds(
+            c(1, 1),
+            "Bounds must be strictly ordered.",
+            strict = TRUE
+        ),
+        "strictly ordered"
+    )
+})
+
+test_that("threshold randomization keeps method boundary semantics", {
+    series <- list(
+        observed_reference = data.frame(value = c(0, 0.5, 1)),
+        model_historical = data.frame(value = c(0.25, 0.5, 2))
+    )
+    key <- list(site = "A")
+    set.seed(2718)
+    rng_state <- .Random.seed
+
+    inclusive <- signal__randomize_threshold_values(
+        series,
+        random_seed = 19L,
+        key = key,
+        variable = "pr",
+        threshold = 0.5,
+        inclusive = TRUE
+    )
+    strict <- signal__randomize_threshold_values(
+        series,
+        random_seed = 19L,
+        key = key,
+        variable = "pr",
+        threshold = 0.5,
+        inclusive = FALSE
+    )
+
+    expect_identical(.Random.seed, rng_state)
+    expect_identical(
+        inclusive$counts,
+        c(observed_reference = 2L, model_historical = 2L)
+    )
+    expect_identical(
+        strict$counts,
+        c(observed_reference = 1L, model_historical = 1L)
+    )
+    expect_identical(strict$values$observed_reference[[2L]], 0.5)
+    expect_identical(strict$values$model_historical[[2L]], 0.5)
+    expect_false(
+        identical(
+            inclusive$seeds[["observed_reference"]],
+            inclusive$seeds[["model_historical"]]
+        )
+    )
+    expect_identical(
+        inclusive,
+        signal__randomize_threshold_values(
+            series,
+            random_seed = 19L,
+            key = key,
+            variable = "pr",
+            threshold = 0.5,
+            inclusive = TRUE
+        )
+    )
+})
+
 test_that("different signal kernels share one execution lifecycle", {
     requirement <- component__input_requirement(
         "model_future",


### PR DESCRIPTION
## Summary

Consolidates repeated signal-setting contracts and role-wise precipitation threshold randomization without changing method equations, defaults, or diagnostics.

## Changes

- Adds shared one-variable schema, ordered-bound, integer-setting, and deterministic-seed helpers for seven statistical signal methods.
- Routes QDM and CDF-t through one role-wise Park-Miller randomizer while preserving their inclusive and strict threshold rules.
- Adds regression coverage for schema validation, bound policies, role-specific seeds, deterministic values, and global RNG isolation.
- Closes #202.