### PR TITLE
refactor: reuse Store download plan construction

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -545,6 +545,10 @@
 
 ## Internal changes
 
+* Consolidated Store catalog download-plan identity and base-row construction,
+  and replaced duplicate plan decorators with one file-row implementation while
+  preserving candidate selection and layout behavior (#205).
+
 * Consolidated the shared settings envelope, schema validation, integer and
   bound checks, deterministic seed normalization, and role-wise precipitation
   threshold randomization used by statistical signal methods while preserving

--- a/R/store.R
+++ b/R/store.R
@@ -1205,7 +1205,7 @@ EsgStore <- R6::R6Class(
                 probe_concurrency = probe_concurrency,
                 probe_cache_seconds = probe_cache_seconds
             )
-            candidates <- private$decorate_download_plan_with_files(candidates, preview$file_rows)
+            candidates <- private$decorate_download_plan(candidates, preview$file_rows)
             summary <- private$download_preflight_summary(row, preview$file_rows, candidates, downloader = downloader)
             list(
                 summary = summary[],
@@ -2035,7 +2035,7 @@ EsgStore <- R6::R6Class(
                     ...
                 )
                 plan <- do.call(files$download_plan, plan_args)
-                plan <- private$decorate_download_plan_with_files(plan, current)
+                plan <- private$decorate_download_plan(plan, current)
                 plan <- plan[plan[["file_key"]] %in% current$file_key]
                 plan
             } else {
@@ -2989,35 +2989,7 @@ EsgStore <- R6::R6Class(
             if (!nrow(catalog)) {
                 return(data.table::data.table())
             }
-            plan <- data.table::data.table(
-                logical_file_id = vapply(
-                    seq_len(nrow(catalog)),
-                    function(i) {
-                        pieces <- c(
-                            store__chr1(catalog$tracking_id[[i]]),
-                            store__chr1(catalog$checksum[[i]]),
-                            store__chr1(catalog$filename[[i]]),
-                            store__chr1(catalog$esgf_id[[i]])
-                        )
-                        paste(pieces[!is.na(pieces) & nzchar(pieces)], collapse = ":")
-                    },
-                    character(1L)
-                ),
-                file_key = catalog$file_key,
-                esgf_id = catalog$esgf_id,
-                dataset_id = catalog$dataset_id,
-                filename = catalog$filename,
-                subdir = NA_character_,
-                checksum = catalog$checksum,
-                checksum_type = catalog$checksum_type,
-                size = suppressWarnings(as.numeric(catalog$size)),
-                url = catalog$url_download,
-                service = "HTTPServer",
-                data_node = catalog$data_node,
-                priority = seq_len(nrow(catalog)),
-                probe_latency = NA_real_,
-                probe_throughput = NA_real_
-            )
+            plan <- store__download_plan_rows(catalog)
             plan <- plan[!is.na(url) & nzchar(url)]
             if (!nrow(plan)) {
                 return(plan)
@@ -3130,40 +3102,7 @@ EsgStore <- R6::R6Class(
             groups[n > 1L & checksum_count > 1L & top_signature_count == 1L]
         },
 
-        decorate_download_plan = function(plan, query_id) {
-            plan <- data.table::copy(data.table::as.data.table(plan))
-            plan <- data.table::setalloccol(plan)
-            if (!nrow(plan)) {
-                return(plan)
-            }
-            catalog <- data.table::as.data.table(ddb_read_table(private$conn, "file_catalog"))
-            wanted_query_id <- query_id
-            catalog <- catalog[catalog[["query_id"]] == wanted_query_id]
-            if (!nrow(catalog)) {
-                return(plan)
-            }
-            if (!"file_key" %in% names(plan)) {
-                plan$file_key <- NA_character_
-            }
-            for (i in seq_len(nrow(plan))) {
-                if (!is.na(plan$file_key[[i]]) && nzchar(plan$file_key[[i]])) {
-                    next
-                }
-                hit <- catalog[catalog[["esgf_id"]] == plan$esgf_id[[i]]]
-                if (!nrow(hit) && "checksum" %in% names(plan)) {
-                    hit <- catalog[
-                        catalog[["filename"]] == plan$filename[[i]] &
-                            catalog[["checksum"]] == plan$checksum[[i]]
-                    ]
-                }
-                if (nrow(hit)) {
-                    plan$file_key[[i]] <- hit$file_key[[1L]]
-                }
-            }
-            private$apply_download_layout(plan, catalog)
-        },
-
-        decorate_download_plan_with_files = function(plan, file_rows) {
+        decorate_download_plan = function(plan, file_rows) {
             plan <- data.table::copy(data.table::as.data.table(plan))
             file_rows <- data.table::copy(data.table::as.data.table(file_rows))
             plan <- data.table::setalloccol(plan)
@@ -4610,7 +4549,7 @@ EsgStore <- R6::R6Class(
                 probe_concurrency = probe_concurrency,
                 probe_cache_seconds = probe_cache_seconds
             )
-            plan <- private$decorate_download_plan_with_files(plan, current)
+            plan <- private$decorate_download_plan(plan, current)
             plan <- plan[plan[["file_key"]] %in% current$file_key]
             if (!nrow(plan)) {
                 if (isTRUE(error_if_empty)) {
@@ -5173,35 +5112,7 @@ EsgStore <- R6::R6Class(
             if (!nrow(catalog)) {
                 return(data.table::data.table())
             }
-            plan <- data.table::data.table(
-                logical_file_id = vapply(
-                    seq_len(nrow(catalog)),
-                    function(i) {
-                        pieces <- c(
-                            store__chr1(catalog$tracking_id[[i]]),
-                            store__chr1(catalog$checksum[[i]]),
-                            store__chr1(catalog$filename[[i]]),
-                            store__chr1(catalog$esgf_id[[i]])
-                        )
-                        paste(pieces[!is.na(pieces) & nzchar(pieces)], collapse = ":")
-                    },
-                    character(1L)
-                ),
-                file_key = catalog$file_key,
-                esgf_id = catalog$esgf_id,
-                dataset_id = catalog$dataset_id,
-                filename = catalog$filename,
-                subdir = NA_character_,
-                checksum = catalog$checksum,
-                checksum_type = catalog$checksum_type,
-                size = suppressWarnings(as.numeric(catalog$size)),
-                url = catalog$url_download,
-                service = "HTTPServer",
-                data_node = catalog$data_node,
-                priority = seq_len(nrow(catalog)),
-                probe_latency = NA_real_,
-                probe_throughput = NA_real_
-            )
+            plan <- store__download_plan_rows(catalog)
             private$apply_download_layout(plan, catalog)
         },
 
@@ -6811,6 +6722,51 @@ store__file_keys <- function(dt) {
             paste0("fallback:", store__hash(pieces))
         },
         character(1L)
+    )
+}
+
+# Build the composite logical identity used to keep catalog download tasks distinct.
+store__logical_file_id <- function(catalog) {
+    catalog <- data.table::as.data.table(catalog)
+    if (!nrow(catalog)) {
+        return(character())
+    }
+
+    vapply(
+        seq_len(nrow(catalog)),
+        function(i) {
+            # Preserve the existing identity order while omitting unavailable metadata.
+            pieces <- c(
+                store__chr1(catalog$tracking_id[[i]]),
+                store__chr1(catalog$checksum[[i]]),
+                store__chr1(catalog$filename[[i]]),
+                store__chr1(catalog$esgf_id[[i]])
+            )
+            paste(pieces[!is.na(pieces) & nzchar(pieces)], collapse = ":")
+        },
+        character(1L)
+    )
+}
+
+# Construct the shared base schema for operational and validation download plans.
+store__download_plan_rows <- function(catalog) {
+    catalog <- data.table::as.data.table(catalog)
+    data.table::data.table(
+        logical_file_id = store__logical_file_id(catalog),
+        file_key = catalog$file_key,
+        esgf_id = catalog$esgf_id,
+        dataset_id = catalog$dataset_id,
+        filename = catalog$filename,
+        subdir = NA_character_,
+        checksum = catalog$checksum,
+        checksum_type = catalog$checksum_type,
+        size = suppressWarnings(as.numeric(catalog$size)),
+        url = catalog$url_download,
+        service = "HTTPServer",
+        data_node = catalog$data_node,
+        priority = seq_len(nrow(catalog)),
+        probe_latency = NA_real_,
+        probe_throughput = NA_real_
     )
 }
 

--- a/tests/testthat/test-store.R
+++ b/tests/testthat/test-store.R
@@ -1933,6 +1933,80 @@ test_that("EsgStore$download_files() selects catalog candidates before enqueuein
     expect_equal(tasks$file_key, plan$file_key)
 })
 
+test_that("store download plan helpers preserve catalog identity and schema", {
+    catalog <- data.table::data.table(
+        tracking_id = c("tracking-a", NA_character_, NA_character_),
+        checksum = c("checksum-a", "checksum-b", NA_character_),
+        filename = c("a.nc", "b.nc", NA_character_),
+        esgf_id = c("esgf-a", "esgf-b", NA_character_),
+        file_key = c("file-a", "file-b", "file-c"),
+        dataset_id = c("dataset-a", "dataset-b", "dataset-c"),
+        checksum_type = c("SHA256", "MD5", NA_character_),
+        size = c("123", "invalid", NA_character_),
+        url_download = c("https://example.org/a.nc", "https://example.org/b.nc", NA_character_),
+        data_node = c("a.example.org", "b.example.org", NA_character_)
+    )
+
+    expect_identical(
+        store__logical_file_id(catalog),
+        c(
+            "tracking-a:checksum-a:a.nc:esgf-a",
+            "checksum-b:b.nc:esgf-b",
+            ""
+        )
+    )
+
+    plan <- store__download_plan_rows(catalog)
+    expect_identical(
+        names(plan),
+        c(
+            "logical_file_id", "file_key", "esgf_id", "dataset_id", "filename",
+            "subdir", "checksum", "checksum_type", "size", "url", "service",
+            "data_node", "priority", "probe_latency", "probe_throughput"
+        )
+    )
+    expect_identical(plan$logical_file_id, store__logical_file_id(catalog))
+    expect_identical(plan$size, c(123, NA_real_, NA_real_))
+    expect_identical(plan$priority, 1:3)
+    expect_identical(plan$service, rep("HTTPServer", 3L))
+    expect_true(all(is.na(plan$subdir)))
+    expect_true(all(is.na(plan$probe_latency)))
+    expect_true(all(is.na(plan$probe_throughput)))
+})
+
+test_that("EsgStore download plan decoration recovers file keys from supplied rows", {
+    skip_if_not_installed("duckdb")
+
+    dir <- tempfile("esg-store-")
+    store <- EsgStore$new(dir)
+    on.exit(store$close(), add = TRUE)
+
+    plan <- data.table::data.table(
+        logical_file_id = c("logical-a", "logical-b", "logical-c"),
+        file_key = c("keep-this-key", NA_character_, NA_character_),
+        esgf_id = c("esgf-a", "esgf-b", "esgf-unmatched"),
+        filename = c("a.nc", "b.nc", "fallback.nc"),
+        checksum = c("checksum-a", "checksum-b", "checksum-c"),
+        subdir = NA_character_
+    )
+    file_rows <- data.table::data.table(
+        file_key = c("replacement-key", "esgf-key", "checksum-key"),
+        esgf_id = c("esgf-a", "esgf-b", "different-esgf-id"),
+        filename = c("a.nc", "b.nc", "fallback.nc"),
+        checksum = c("checksum-a", "checksum-b", "checksum-c")
+    )
+
+    decorated <- priv(store)$decorate_download_plan(plan, file_rows)
+
+    expect_identical(
+        decorated$file_key,
+        c("keep-this-key", "esgf-key", "checksum-key")
+    )
+    expect_identical(decorated$target_rel_path, plan$filename)
+    expected_root <- normalizePath(dir, winslash = "/", mustWork = TRUE)
+    expect_identical(decorated$target_path, file.path(expected_root, "downloads", plan$filename))
+})
+
 test_that("EsgStore$download_files() aborts ambiguous catalog target collisions", {
     skip_if_not_installed("duckdb")
 


### PR DESCRIPTION
## Summary

- Reuses one catalog-to-plan schema and logical-file identity rule across Store download and validation workflows.
- Keeps URL filtering, candidate ranking, ambiguity detection, and download layout behavior in their existing callers.

## Changes

- Adds `store__logical_file_id()` and `store__download_plan_rows()` for shared base plan construction.
- Routes operational and validation catalog planning through the shared helpers.
- Removes the unused query-reading decorator and uses one file-row decorator for preflight and download paths.
- Adds regression coverage for identity construction, plan schema, file-key recovery, and target layout.
- Records the internal refactoring in the development changelog.
- Closes #204.
