### PR TITLE
refactor: reuse typed sequence invariants

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -545,6 +545,11 @@
 
 ## Internal changes
 
+* Consolidated typed weather-sequence identifier, year, member-class,
+  provenance, uniqueness, ordering, and shared-identity validation while
+  preserving each sequence type's calendar, variable, row, and physical rules
+  (#212).
+
 * Consolidated concurrent data-node reachability, service URL reachability,
   and latency check scheduling into one callback-driven executor while
   preserving each check's HTTP-status, Range fallback, timing, and result

--- a/R/adapter-direct-model-calendar.R
+++ b/R/adapter-direct-model-calendar.R
@@ -106,11 +106,9 @@ hourmap__series_error <- function(self) {
         nrow(self@diagnostics) != length(self@variables)) {
         return("`diagnostics` must contain one row per mapped variable.")
     }
-    if (length(self@provenance) &&
-        (is.null(names(self@provenance)) ||
-            any(!nzchar(names(self@provenance))) ||
-            anyDuplicated(names(self@provenance)))) {
-        return("`provenance` must be a uniquely named list.")
+    error <- sequence__provenance_error(self@provenance)
+    if (!is.null(error)) {
+        return(error)
     }
     NULL
 }
@@ -133,44 +131,52 @@ MappedHourlyClimateSeries <- S7::new_class(
 # Validate one future-model year after all variable groups share the same EPW
 # target grid while retaining their independent source metadata.
 hourmap__member_error <- function(self) {
-    if (length(self@sequence_id) != 1L ||
-        is.na(self@sequence_id) ||
-        !grepl("^[A-Za-z0-9][A-Za-z0-9._-]*$", self@sequence_id)) {
-        return("`sequence_id` contains unsupported characters.")
+    error <- sequence__identifier_error(
+        self@sequence_id,
+        "`sequence_id` contains unsupported characters."
+    )
+    if (!is.null(error)) {
+        return(error)
     }
-    if (length(self@weather_year) != 1L ||
-        is.na(self@weather_year) ||
-        self@weather_year < 1L) {
-        return("`weather_year` must be one positive integer.")
+    error <- sequence__positive_year_error(self@weather_year)
+    if (!is.null(error)) {
+        return(error)
     }
     if (length(self@source_calendar) != 1L ||
         is.na(self@source_calendar) ||
         !self@source_calendar %in% CF_TIME_CALENDARS) {
         return("`source_calendar` must identify one supported CF calendar.")
     }
-    if (!length(self@series) ||
-        !all(vapply(
-            self@series,
-            S7::S7_inherits,
-            logical(1L),
-            class = MappedHourlyClimateSeries
-        ))) {
-        return("`series` must contain MappedHourlyClimateSeries objects.")
+    error <- sequence__member_class_error(
+        self@series,
+        MappedHourlyClimateSeries,
+        "`series` must contain MappedHourlyClimateSeries objects."
+    )
+    if (!is.null(error)) {
+        return(error)
     }
     group_ids <- vapply(
         self@series,
         function(series) series@group_id,
         character(1L)
     )
-    if (anyDuplicated(group_ids)) {
-        return("Mapped hourly group identities must be unique within a year.")
+    error <- sequence__unique_values_error(
+        group_ids,
+        "Mapped hourly group identities must be unique within a year."
+    )
+    if (!is.null(error)) {
+        return(error)
     }
     variables <- unlist(lapply(
         self@series,
         function(series) series@variables
     ), use.names = FALSE)
-    if (anyDuplicated(variables)) {
-        return("Each mapped hourly variable must occur in exactly one group.")
+    error <- sequence__unique_values_error(
+        variables,
+        "Each mapped hourly variable must occur in exactly one group."
+    )
+    if (!is.null(error)) {
+        return(error)
     }
     years <- unique(unlist(lapply(self@series, function(series) {
         as.integer(series@data[["year"]])
@@ -178,11 +184,9 @@ hourmap__member_error <- function(self) {
     if (!identical(years, self@weather_year)) {
         return("Every mapped hourly row must match `weather_year`.")
     }
-    if (length(self@provenance) &&
-        (is.null(names(self@provenance)) ||
-            any(!nzchar(names(self@provenance))) ||
-            anyDuplicated(names(self@provenance)))) {
-        return("`provenance` must be a uniquely named list.")
+    error <- sequence__provenance_error(self@provenance)
+    if (!is.null(error)) {
+        return(error)
     }
     NULL
 }
@@ -204,14 +208,13 @@ MappedHourlyClimateMember <- S7::new_class(
 # Validate the complete mapped sequence independently of the number of source
 # years retained by the selected future-model period.
 hourmap__sequence_error <- function(self) {
-    if (!length(self@members) ||
-        !all(vapply(
-            self@members,
-            S7::S7_inherits,
-            logical(1L),
-            class = MappedHourlyClimateMember
-        ))) {
-        return("`members` must contain MappedHourlyClimateMember objects.")
+    error <- sequence__member_class_error(
+        self@members,
+        MappedHourlyClimateMember,
+        "`members` must contain MappedHourlyClimateMember objects."
+    )
+    if (!is.null(error)) {
+        return(error)
     }
     if (!identical(self@frequency, "hour") ||
         !identical(as.numeric(self@time_step_seconds), 3600)) {
@@ -225,16 +228,24 @@ hourmap__sequence_error <- function(self) {
         function(member) member@weather_year,
         integer(1L)
     )
-    if (anyDuplicated(years) || !identical(years, sort(years))) {
-        return("Mapped hourly members must use unique ascending weather years.")
+    error <- sequence__ordered_years_error(
+        years,
+        "Mapped hourly members must use unique ascending weather years."
+    )
+    if (!is.null(error)) {
+        return(error)
     }
     sequence_ids <- vapply(
         self@members,
         function(member) member@sequence_id,
         character(1L)
     )
-    if (length(unique(sequence_ids)) != 1L) {
-        return("Mapped hourly members must share one `sequence_id`.")
+    error <- sequence__shared_values_error(
+        sequence_ids,
+        "Mapped hourly members must share one `sequence_id`."
+    )
+    if (!is.null(error)) {
+        return(error)
     }
     variable_sets <- lapply(self@members, function(member) {
         sort(unlist(lapply(
@@ -242,20 +253,16 @@ hourmap__sequence_error <- function(self) {
             function(series) series@variables
         ), use.names = FALSE))
     })
-    if (length(variable_sets) > 1L &&
-        !all(vapply(
-            variable_sets[-1L],
-            identical,
-            logical(1L),
-            variable_sets[[1L]]
-        ))) {
-        return("Every mapped hourly member must contain the same variables.")
+    error <- sequence__shared_sets_error(
+        variable_sets,
+        "Every mapped hourly member must contain the same variables."
+    )
+    if (!is.null(error)) {
+        return(error)
     }
-    if (length(self@provenance) &&
-        (is.null(names(self@provenance)) ||
-            any(!nzchar(names(self@provenance))) ||
-            anyDuplicated(names(self@provenance)))) {
-        return("`provenance` must be a uniquely named list.")
+    error <- sequence__provenance_error(self@provenance)
+    if (!is.null(error)) {
+        return(error)
     }
     NULL
 }

--- a/R/adapter-direct-model-epw.R
+++ b/R/adapter-direct-model-epw.R
@@ -30,15 +30,16 @@ DIRECT_EPW_CONSTRUCTED_FIELDS <- c(
 # Validate one physically closed future year without depending on a complete
 # recipe or the final WeatherSequenceResult output wrapper.
 direct_epw__member_error <- function(self) {
-    if (length(self@sequence_id) != 1L ||
-        is.na(self@sequence_id) ||
-        !grepl("^[A-Za-z0-9][A-Za-z0-9._-]*$", self@sequence_id)) {
-        return("`sequence_id` contains unsupported characters.")
+    error <- sequence__identifier_error(
+        self@sequence_id,
+        "`sequence_id` contains unsupported characters."
+    )
+    if (!is.null(error)) {
+        return(error)
     }
-    if (length(self@weather_year) != 1L ||
-        is.na(self@weather_year) ||
-        self@weather_year < 1L) {
-        return("`weather_year` must be one positive integer.")
+    error <- sequence__positive_year_error(self@weather_year)
+    if (!is.null(error)) {
+        return(error)
     }
     if (length(self@source_calendar) != 1L ||
         is.na(self@source_calendar) ||
@@ -63,11 +64,9 @@ direct_epw__member_error <- function(self) {
     if (!is.data.frame(self@diagnostics) || nrow(self@diagnostics) != 1L) {
         return("`diagnostics` must contain one row for the closed weather year.")
     }
-    if (length(self@provenance) &&
-        (is.null(names(self@provenance)) ||
-            any(!nzchar(names(self@provenance))) ||
-            anyDuplicated(names(self@provenance)))) {
-        return("`provenance` must be a uniquely named list.")
+    error <- sequence__provenance_error(self@provenance)
+    if (!is.null(error)) {
+        return(error)
     }
     NULL
 }
@@ -90,14 +89,13 @@ EpwHourlyWeatherMember <- S7::new_class(
 # Validate the ordered collection of closed years before an output component
 # converts it into the package's public multi-year result contract.
 direct_epw__sequence_error <- function(self) {
-    if (!length(self@members) ||
-        !all(vapply(
-            self@members,
-            S7::S7_inherits,
-            logical(1L),
-            class = EpwHourlyWeatherMember
-        ))) {
-        return("`members` must contain EpwHourlyWeatherMember objects.")
+    error <- sequence__member_class_error(
+        self@members,
+        EpwHourlyWeatherMember,
+        "`members` must contain EpwHourlyWeatherMember objects."
+    )
+    if (!is.null(error)) {
+        return(error)
     }
     if (!identical(self@target_calendar, "epw_365_day")) {
         return("`target_calendar` must be `epw_365_day`.")
@@ -115,22 +113,28 @@ direct_epw__sequence_error <- function(self) {
         function(member) member@weather_year,
         integer(1L)
     )
-    if (anyDuplicated(years) || !identical(years, sort(years))) {
-        return("Closed EPW weather members must use unique ascending years.")
+    error <- sequence__ordered_years_error(
+        years,
+        "Closed EPW weather members must use unique ascending years."
+    )
+    if (!is.null(error)) {
+        return(error)
     }
     sequence_ids <- vapply(
         self@members,
         function(member) member@sequence_id,
         character(1L)
     )
-    if (length(unique(sequence_ids)) != 1L) {
-        return("Closed EPW weather members must share one `sequence_id`.")
+    error <- sequence__shared_values_error(
+        sequence_ids,
+        "Closed EPW weather members must share one `sequence_id`."
+    )
+    if (!is.null(error)) {
+        return(error)
     }
-    if (length(self@provenance) &&
-        (is.null(names(self@provenance)) ||
-            any(!nzchar(names(self@provenance))) ||
-            anyDuplicated(names(self@provenance)))) {
-        return("`provenance` must be a uniquely named list.")
+    error <- sequence__provenance_error(self@provenance)
+    if (!is.null(error)) {
+        return(error)
     }
     NULL
 }

--- a/R/weather-sequence.R
+++ b/R/weather-sequence.R
@@ -2,6 +2,88 @@
 # identity already belongs to the surrounding morphing case.
 DIRECT_MODEL_SEQUENCE_ID <- "direct-model"
 
+# Return the supplied error when a sequence identifier is not one safe scalar.
+sequence__identifier_error <- function(value, message) {
+    if (length(value) != 1L ||
+        is.na(value) ||
+        !grepl("^[A-Za-z0-9][A-Za-z0-9._-]*$", value)) {
+        return(message)
+    }
+    NULL
+}
+
+# Keep year validation identical across every typed weather-sequence member.
+sequence__positive_year_error <- function(value) {
+    if (length(value) != 1L || is.na(value) || value < 1L) {
+        return("`weather_year` must be one positive integer.")
+    }
+    NULL
+}
+
+# Validate optional sequence metadata without imposing a value schema.
+sequence__provenance_error <- function(value) {
+    # Empty provenance is valid; populated provenance must have stable keys.
+    if (length(value) &&
+        (is.null(names(value)) ||
+            any(!nzchar(names(value))) ||
+            anyDuplicated(names(value)))) {
+        return("`provenance` must be a uniquely named list.")
+    }
+    NULL
+}
+
+# Require a non-empty homogeneous collection of one declared S7 member class.
+sequence__member_class_error <- function(members, class, message) {
+    if (!length(members) ||
+        !all(vapply(
+            members,
+            S7::S7_inherits,
+            logical(1L),
+            class = class
+        ))) {
+        return(message)
+    }
+    NULL
+}
+
+# Reject repeated identities while leaving identity construction to each class.
+sequence__unique_values_error <- function(values, message) {
+    if (anyDuplicated(values)) {
+        return(message)
+    }
+    NULL
+}
+
+# Require member years to be both unique and already in ascending order.
+sequence__ordered_years_error <- function(years, message) {
+    if (anyDuplicated(years) || !identical(years, sort(years))) {
+        return(message)
+    }
+    NULL
+}
+
+# Require every member to carry one common scalar sequence identity.
+sequence__shared_values_error <- function(values, message) {
+    if (length(unique(values)) != 1L) {
+        return(message)
+    }
+    NULL
+}
+
+# Compare normalized identity sets across years without defining their contents.
+sequence__shared_sets_error <- function(sets, message) {
+    if (length(sets) > 1L &&
+        !all(vapply(
+            sets[-1L],
+            identical,
+            logical(1L),
+            sets[[1L]]
+        ))) {
+        return(message)
+    }
+    NULL
+}
+
 # Return a deterministic identity for one aligned signal group without
 # serializing its input payloads into the downstream sequence.
 sequence__direct_group_id <- function(group) {
@@ -171,37 +253,41 @@ DirectModelSequenceMember <- S7::new_class(
         provenance = S7::new_property(S7::class_list, default = list())
     ),
     validator = function(self) {
-        if (length(self@sequence_id) != 1L ||
-            is.na(self@sequence_id) ||
-            !grepl("^[A-Za-z0-9][A-Za-z0-9._-]*$", self@sequence_id)) {
-            return("`sequence_id` contains unsupported characters.")
+        error <- sequence__identifier_error(
+            self@sequence_id,
+            "`sequence_id` contains unsupported characters."
+        )
+        if (!is.null(error)) {
+            return(error)
         }
-        if (length(self@weather_year) != 1L ||
-            is.na(self@weather_year) ||
-            self@weather_year < 1L) {
-            return("`weather_year` must be one positive integer.")
+        error <- sequence__positive_year_error(self@weather_year)
+        if (!is.null(error)) {
+            return(error)
         }
         if (length(self@calendar) != 1L ||
             is.na(self@calendar) ||
             !self@calendar %in% CF_TIME_CALENDARS) {
             return("`calendar` must identify one supported CF calendar.")
         }
-        if (!length(self@series) ||
-            !all(vapply(
-                self@series,
-                S7::S7_inherits,
-                logical(1L),
-                class = DirectModelSeries
-            ))) {
-            return("`series` must contain DirectModelSeries objects.")
+        error <- sequence__member_class_error(
+            self@series,
+            DirectModelSeries,
+            "`series` must contain DirectModelSeries objects."
+        )
+        if (!is.null(error)) {
+            return(error)
         }
         group_ids <- vapply(
             self@series,
             function(item) item@group_id,
             character(1L)
         )
-        if (anyDuplicated(group_ids)) {
-            return("Direct-model group identities must be unique within a year.")
+        error <- sequence__unique_values_error(
+            group_ids,
+            "Direct-model group identities must be unique within a year."
+        )
+        if (!is.null(error)) {
+            return(error)
         }
         for (item in self@series) {
             error <- sequence__direct_year_error(
@@ -213,11 +299,9 @@ DirectModelSequenceMember <- S7::new_class(
                 return(error)
             }
         }
-        if (length(self@provenance) &&
-            (is.null(names(self@provenance)) ||
-                any(!nzchar(names(self@provenance))) ||
-                anyDuplicated(names(self@provenance)))) {
-            return("`provenance` must be a uniquely named list.")
+        error <- sequence__provenance_error(self@provenance)
+        if (!is.null(error)) {
+            return(error)
         }
         NULL
     }
@@ -234,14 +318,13 @@ DirectModelSequence <- S7::new_class(
         provenance = S7::new_property(S7::class_list, default = list())
     ),
     validator = function(self) {
-        if (!length(self@members) ||
-            !all(vapply(
-                self@members,
-                S7::S7_inherits,
-                logical(1L),
-                class = DirectModelSequenceMember
-            ))) {
-            return("`members` must contain DirectModelSequenceMember objects.")
+        error <- sequence__member_class_error(
+            self@members,
+            DirectModelSequenceMember,
+            "`members` must contain DirectModelSequenceMember objects."
+        )
+        if (!is.null(error)) {
+            return(error)
         }
         if (length(self@frequency) != 1L ||
             is.na(self@frequency) ||
@@ -259,8 +342,12 @@ DirectModelSequence <- S7::new_class(
             function(member) member@weather_year,
             integer(1L)
         )
-        if (anyDuplicated(years) || !identical(years, sort(years))) {
-            return("Direct-model members must use unique ascending weather years.")
+        error <- sequence__ordered_years_error(
+            years,
+            "Direct-model members must use unique ascending weather years."
+        )
+        if (!is.null(error)) {
+            return(error)
         }
         sequence_ids <- vapply(
             self@members,
@@ -272,11 +359,19 @@ DirectModelSequence <- S7::new_class(
             function(member) member@calendar,
             character(1L)
         )
-        if (length(unique(sequence_ids)) != 1L) {
-            return("Direct-model members must share one `sequence_id`.")
+        error <- sequence__shared_values_error(
+            sequence_ids,
+            "Direct-model members must share one `sequence_id`."
+        )
+        if (!is.null(error)) {
+            return(error)
         }
-        if (length(unique(calendars)) != 1L) {
-            return("Direct-model members must share one CF calendar.")
+        error <- sequence__shared_values_error(
+            calendars,
+            "Direct-model members must share one CF calendar."
+        )
+        if (!is.null(error)) {
+            return(error)
         }
         group_ids <- lapply(self@members, function(member) {
             sort(vapply(
@@ -285,13 +380,12 @@ DirectModelSequence <- S7::new_class(
                 character(1L)
             ))
         })
-        if (!all(vapply(
-            group_ids[-1L],
-            identical,
-            logical(1L),
-            group_ids[[1L]]
-        ))) {
-            return("Every direct-model year must contain the same signal groups.")
+        error <- sequence__shared_sets_error(
+            group_ids,
+            "Every direct-model year must contain the same signal groups."
+        )
+        if (!is.null(error)) {
+            return(error)
         }
         for (member in self@members) {
             for (item in member@series) {
@@ -306,11 +400,9 @@ DirectModelSequence <- S7::new_class(
                 }
             }
         }
-        if (length(self@provenance) &&
-            (is.null(names(self@provenance)) ||
-                any(!nzchar(names(self@provenance))) ||
-                anyDuplicated(names(self@provenance)))) {
-            return("`provenance` must be a uniquely named list.")
+        error <- sequence__provenance_error(self@provenance)
+        if (!is.null(error)) {
+            return(error)
         }
         NULL
     }
@@ -550,17 +642,16 @@ WeatherSequenceMember <- S7::new_class(
         provenance = S7::new_property(S7::class_list, default = list())
     ),
     validator = function(self) {
-        if (length(self@sequence_id) != 1L ||
-            is.na(self@sequence_id) ||
-            !grepl("^[A-Za-z0-9][A-Za-z0-9._-]*$", self@sequence_id)) {
-            return(
-                "`sequence_id` must contain only letters, numbers, dots, underscores, or hyphens."
-            )
+        error <- sequence__identifier_error(
+            self@sequence_id,
+            "`sequence_id` must contain only letters, numbers, dots, underscores, or hyphens."
+        )
+        if (!is.null(error)) {
+            return(error)
         }
-        if (length(self@weather_year) != 1L ||
-            is.na(self@weather_year) ||
-            self@weather_year < 1L) {
-            return("`weather_year` must be one positive integer.")
+        error <- sequence__positive_year_error(self@weather_year)
+        if (!is.null(error)) {
+            return(error)
         }
         if (length(self@calendar) != 1L ||
             is.na(self@calendar) ||
@@ -582,11 +673,9 @@ WeatherSequenceMember <- S7::new_class(
             !identical(years, self@weather_year)) {
             return("Every hourly row must match `weather_year`.")
         }
-        if (length(self@provenance) &&
-            (is.null(names(self@provenance)) ||
-                any(!nzchar(names(self@provenance))) ||
-                anyDuplicated(names(self@provenance)))) {
-            return("`provenance` must be a uniquely named list.")
+        error <- sequence__provenance_error(self@provenance)
+        if (!is.null(error)) {
+            return(error)
         }
         NULL
     }
@@ -621,14 +710,13 @@ WeatherSequenceResult <- S7::new_class(
             !self@output_type %in% c("future_year", "multi_year")) {
             return("`output_type` must be `future_year` or `multi_year`.")
         }
-        if (!length(self@members) ||
-            !all(vapply(
-                self@members,
-                S7::S7_inherits,
-                logical(1L),
-                class = WeatherSequenceMember
-            ))) {
-            return("`members` must contain WeatherSequenceMember objects.")
+        error <- sequence__member_class_error(
+            self@members,
+            WeatherSequenceMember,
+            "`members` must contain WeatherSequenceMember objects."
+        )
+        if (!is.null(error)) {
+            return(error)
         }
         if (identical(self@output_type, "future_year") &&
             length(self@members) != 1L) {
@@ -641,8 +729,12 @@ WeatherSequenceResult <- S7::new_class(
         keys <- vapply(self@members, function(member) {
             paste(member@sequence_id, member@weather_year, sep = "\r")
         }, character(1L))
-        if (anyDuplicated(keys)) {
-            return("Sequence member `sequence_id` and `weather_year` pairs must be unique.")
+        error <- sequence__unique_values_error(
+            keys,
+            "Sequence member `sequence_id` and `weather_year` pairs must be unique."
+        )
+        if (!is.null(error)) {
+            return(error)
         }
         template <- self@epw$data()
         required <- setdiff(names(template), "datetime")
@@ -655,11 +747,9 @@ WeatherSequenceResult <- S7::new_class(
                 "Every sequence member must contain a complete baseline-shaped EPW year."
             )
         }
-        if (length(self@provenance) &&
-            (is.null(names(self@provenance)) ||
-                any(!nzchar(names(self@provenance))) ||
-                anyDuplicated(names(self@provenance)))) {
-            return("`provenance` must be a uniquely named list.")
+        error <- sequence__provenance_error(self@provenance)
+        if (!is.null(error)) {
+            return(error)
         }
         NULL
     }

--- a/tests/testthat/test-adapter-direct-model-calendar.R
+++ b/tests/testthat/test-adapter-direct-model-calendar.R
@@ -143,6 +143,16 @@ test_that("365-day direct-model hours map exactly onto EPW rows", {
         "identity_365_day"
     )
     expect_identical(result@provenance$physical_conversion, "deferred")
+    expect_error(
+        MappedHourlyClimateSequence(
+            members = list(member, member),
+            frequency = result@frequency,
+            time_step_seconds = result@time_step_seconds,
+            target_calendar = result@target_calendar,
+            provenance = result@provenance
+        ),
+        "unique ascending weather years"
+    )
 })
 
 test_that("point variables use circular annual-phase interpolation", {

--- a/tests/testthat/test-adapter-direct-model-epw.R
+++ b/tests/testthat/test-adapter-direct-model-epw.R
@@ -189,6 +189,15 @@ test_that("relative humidity and scalar wind close an EPW weather year", {
     )
     expect_gt(member@diagnostics$radiation_excess_beam_reallocated, 0L)
     expect_lt(member@diagnostics$radiation_maximum_closure_error, 1e-8)
+    expect_error(
+        EpwHourlyWeatherSequence(
+            members = list(member, member),
+            target_calendar = result@target_calendar,
+            constructed_fields = result@constructed_fields,
+            provenance = result@provenance
+        ),
+        "unique ascending years"
+    )
 })
 
 test_that("specific humidity and vector wind derive dependent EPW fields", {

--- a/tests/testthat/test-direct-model-sequence.R
+++ b/tests/testthat/test-direct-model-sequence.R
@@ -182,6 +182,71 @@ direct_sequence_test__execution <- function(
     )
 }
 
+test_that("typed sequence validators share structural invariants", {
+    error <- "sequence invariant failed"
+
+    expect_null(sequence__identifier_error("member-1", error))
+    expect_identical(sequence__identifier_error("bad member", error), error)
+    expect_null(sequence__positive_year_error(2061L))
+    expect_identical(
+        sequence__positive_year_error(0L),
+        "`weather_year` must be one positive integer."
+    )
+    expect_null(sequence__provenance_error(list(source = "synthetic")))
+    expect_identical(
+        sequence__provenance_error(list("synthetic")),
+        "`provenance` must be a uniquely named list."
+    )
+
+    sequence <- sequence__direct_model_generate(
+        direct_sequence_test__execution(list(
+            direct_sequence_test__adjusted("tas", 2061L)
+        )),
+        NULL,
+        NULL,
+        list()
+    )
+    expect_null(sequence__member_class_error(
+        sequence@members,
+        DirectModelSequenceMember,
+        error
+    ))
+    expect_identical(
+        sequence__member_class_error(
+            list("not-a-member"),
+            DirectModelSequenceMember,
+            error
+        ),
+        error
+    )
+    expect_null(sequence__unique_values_error(c("a", "b"), error))
+    expect_identical(
+        sequence__unique_values_error(c("a", "a"), error),
+        error
+    )
+    expect_null(sequence__ordered_years_error(2061:2062, error))
+    expect_identical(
+        sequence__ordered_years_error(2062:2061, error),
+        error
+    )
+    expect_null(sequence__shared_values_error(c("same", "same"), error))
+    expect_identical(
+        sequence__shared_values_error(c("first", "second"), error),
+        error
+    )
+    expect_null(sequence__shared_sets_error(
+        list(c("hurs", "tas"), c("hurs", "tas")),
+        error
+    ))
+    expect_identical(
+        sequence__shared_sets_error(
+            list(c("hurs", "tas"), c("huss", "tas")),
+            error
+        ),
+        error
+    )
+})
+
 test_that("direct model sequence preserves and partitions future chronology", {
     execution <- direct_sequence_test__execution(list(
         direct_sequence_test__adjusted(
@@ -244,6 +309,15 @@ test_that("direct model sequence preserves and partitions future chronology", {
             )
         }
     }
+    expect_error(
+        DirectModelSequence(
+            members = list(first@members[[1L]], first@members[[1L]]),
+            frequency = first@frequency,
+            time_step_seconds = first@time_step_seconds,
+            provenance = first@provenance
+        ),
+        "unique ascending weather years"
+    )
 })
 
 test_that("direct model sequence accepts every supported native CF calendar", {


### PR DESCRIPTION
## Summary

- Reuses structural validation invariants across direct-model, mapped-hourly, closed-EPW, and final weather-sequence types.
- Keeps frequency, calendar, variable, row-shape, and physical rules in their owning validators without changing public APIs or scientific behavior.

## Changes

- Adds small internal sequence validation helpers for identifiers, years, provenance, member classes, uniqueness, ordering, and shared identities.
- Routes the typed sequence validators through those helpers while preserving validation order and existing error messages.
- Adds focused helper coverage, boundary-level regression tests, and the development NEWS entry.
- Closes #211.