### PR TITLE
refactor: reuse time-range enrichment

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -545,6 +545,10 @@
 
 ## Internal changes
 
+* Consolidated fixed-length ESGF time-field normalization and metadata-first
+  DRS range filling while retaining query warnings, label selection, output
+  formatting, and workflow catalog behavior (#214).
+
 * Consolidated typed weather-sequence identifier, year, member-class,
   provenance, uniqueness, ordering, and shared-identity validation while
   preserving each sequence type's calendar, variable, row, and physical rules

--- a/R/query-result.R
+++ b/R/query-result.R
@@ -699,30 +699,11 @@ EsgResult <- R6::R6Class(
         # CMIP/DRS filenames. ESGF nodes commonly omit the requested datetime
         # fields, while local fixtures and some providers already supply them.
         filter_time_ranges_auto = function(docs, result_label = "file") {
-            n <- nrow(docs)
-            # Normalize a potentially absent provider field to one value per
-            # result row before parsing it as a UTC timestamp.
-            field <- function(name) {
-                value <- docs[[name]]
-                if (is.null(value)) {
-                    return(rep(NA_character_, n))
-                }
-                value <- as.character(value)
-                if (length(value) < n) {
-                    value <- c(value, rep(NA_character_, n - length(value)))
-                }
-                value[seq_len(n)]
-            }
-            start <- solrdate__parse(field("datetime_start"), tz = "UTC")
-            end <- solrdate__parse(field("datetime_end"), tz = "UTC")
-            missing <- is.na(start) | is.na(end)
-            if (any(missing)) {
-                labels <- query_result__drs_labels(docs)
-                drs <- query_result__drs_ranges(labels$value)
-                start[missing] <- drs$datetime_start[missing]
-                end[missing] <- drs$datetime_end[missing]
-            }
-            unknown <- is.na(start) | is.na(end)
+            ranges <- query_result__fill_time_ranges(docs, function() {
+                query_result__drs_labels(docs)$value
+            })
+            unknown <- is.na(ranges$datetime_start) |
+                is.na(ranges$datetime_end)
             if (any(unknown)) {
                 warning(
                     sprintf(
@@ -735,11 +716,7 @@ EsgResult <- R6::R6Class(
                     call. = FALSE
                 )
             }
-            data.frame(
-                datetime_start = start,
-                datetime_end = end,
-                check.names = FALSE
-            )
+            ranges
         },
         # }}}
 
@@ -1255,6 +1232,20 @@ query_result__query_urls <- function(urls, named = TRUE) {
     }
 }
 
+# Normalize a result column to the fixed character length required by callers.
+query_result__character_column <- function(data, name, size = nrow(data)) {
+    value <- data[[name]]
+    if (is.null(value)) {
+        return(rep(NA_character_, size))
+    }
+
+    value <- as.character(value)
+    if (length(value) < size) {
+        value <- c(value, rep(NA_character_, size - length(value)))
+    }
+    value[seq_len(size)]
+}
+
 query_result__time_iso <- function(x) {
     if (is.null(x)) {
         return(character())
@@ -1265,6 +1256,38 @@ query_result__time_iso <- function(x) {
     ok <- !is.na(x)
     out[ok] <- format.POSIXct(x[ok], tz = "UTC", format = "%Y-%m-%dT%H:%M:%SZ")
     out
+}
+
+# Fill incomplete metadata time ranges from caller-selected CMIP/DRS labels.
+query_result__fill_time_ranges <- function(data, labels) {
+    size <- nrow(data)
+    start <- solrdate__parse(
+        query_result__character_column(data, "datetime_start", size),
+        tz = "UTC"
+    )
+    end <- solrdate__parse(
+        query_result__character_column(data, "datetime_end", size),
+        tz = "UTC"
+    )
+    incomplete <- is.na(start) | is.na(end)
+    if (any(incomplete)) {
+        # Resolve labels lazily so complete provider metadata never touches a
+        # caller's URL or identity fallback fields.
+        if (is.function(labels)) {
+            labels <- labels()
+        }
+        drs <- query_result__drs_ranges(labels)
+        # One absent boundary invalidates the metadata pair; replace both
+        # boundaries to retain the existing whole-range fallback semantics.
+        start[incomplete] <- drs$datetime_start[incomplete]
+        end[incomplete] <- drs$datetime_end[incomplete]
+    }
+
+    data.frame(
+        datetime_start = start,
+        datetime_end = end,
+        check.names = FALSE
+    )
 }
 
 query_result__time_window <- function(start, stop) {

--- a/R/shift-stage.R
+++ b/R/shift-stage.R
@@ -6571,35 +6571,19 @@ shift__catalog_fill_time_ranges <- function(catalog) {
         return(catalog)
     }
     n <- nrow(catalog)
-    # Normalize a potentially absent catalog column to one scalar per record.
-    column <- function(name) {
-        value <- catalog[[name]]
-        if (is.null(value)) {
-            return(rep(NA_character_, n))
-        }
-        value <- as.character(value)
-        if (length(value) < n) {
-            value <- c(value, rep(NA_character_, n - length(value)))
-        }
-        value[seq_len(n)]
-    }
-    start <- solrdate__parse(column("datetime_start"), tz = "UTC")
-    end <- solrdate__parse(column("datetime_end"), tz = "UTC")
-    missing <- is.na(start) | is.na(end)
-    if (any(missing)) {
-        labels <- column("title")
-        fallback <- column("filename")
+    ranges <- query_result__fill_time_ranges(catalog, function() {
+        labels <- query_result__character_column(catalog, "title", n)
+        fallback <- query_result__character_column(catalog, "filename", n)
         labels[is.na(labels) | !nzchar(labels)] <-
             fallback[is.na(labels) | !nzchar(labels)]
-        fallback <- column("esgf_id")
+        fallback <- query_result__character_column(catalog, "esgf_id", n)
         labels[is.na(labels) | !nzchar(labels)] <-
             fallback[is.na(labels) | !nzchar(labels)]
-        ranges <- query_result__drs_ranges(labels)
-        start[missing] <- ranges$datetime_start[missing]
-        end[missing] <- ranges$datetime_end[missing]
-    }
-    catalog[["datetime_start"]] <- query_result__time_iso(start)
-    catalog[["datetime_end"]] <- query_result__time_iso(end)
+        labels
+    })
+    catalog[["datetime_start"]] <-
+        query_result__time_iso(ranges$datetime_start)
+    catalog[["datetime_end"]] <- query_result__time_iso(ranges$datetime_end)
     catalog[]
 }
 

--- a/tests/testthat/test-query-result.R
+++ b/tests/testthat/test-query-result.R
@@ -1082,6 +1082,69 @@ test_that("EsgResult$repair_urls() keeps original records when repair is impossi
 })
 # }}}
 # EsgResult$filter_time() {{{
+test_that("time-range helpers normalize columns and preserve paired fallback", {
+    short <- list(datetime_start = "2050-01-01T00:00:00Z")
+    expect_identical(
+        query_result__character_column(short, "datetime_start", 3L),
+        c("2050-01-01T00:00:00Z", NA_character_, NA_character_)
+    )
+    expect_identical(
+        query_result__character_column(short, "datetime_end", 3L),
+        rep(NA_character_, 3L)
+    )
+
+    docs <- data.frame(
+        datetime_start = c(
+            "2040-01-01T00:00:00Z",
+            "2059-06-01T00:00:00Z",
+            NA_character_
+        ),
+        datetime_end = c(
+            "2040-12-31T23:59:59Z",
+            NA_character_,
+            NA_character_
+        ),
+        check.names = FALSE
+    )
+    calls <- new.env(parent = emptyenv())
+    calls$count <- 0L
+    ranges <- query_result__fill_time_ranges(docs, function() {
+        calls$count <- calls$count + 1L
+        c(
+            "tas_day_Model_x_20400101-20401231.nc",
+            "tas_day_Model_x_20500101-20501231.nc",
+            "tas_day_Model_x_unknown.nc"
+        )
+    })
+
+    expect_identical(calls$count, 1L)
+    expect_s3_class(ranges$datetime_start, "POSIXct")
+    expect_identical(
+        format(ranges$datetime_start[[1L]], "%Y-%m-%dT%H:%M:%SZ", tz = "UTC"),
+        "2040-01-01T00:00:00Z"
+    )
+    expect_identical(
+        format(ranges$datetime_start[[2L]], "%Y-%m-%dT%H:%M:%SZ", tz = "UTC"),
+        "2050-01-01T00:00:00Z"
+    )
+    expect_identical(
+        format(ranges$datetime_end[[2L]], "%Y-%m-%dT%H:%M:%SZ", tz = "UTC"),
+        "2050-12-31T23:59:59Z"
+    )
+    expect_true(is.na(ranges$datetime_start[[3L]]))
+    expect_true(is.na(ranges$datetime_end[[3L]]))
+
+    complete <- docs[1L, , drop = FALSE]
+    untouched <- expect_silent(query_result__fill_time_ranges(
+        complete,
+        function() stop("complete metadata must not resolve labels")
+    ))
+    expect_identical(
+        format(untouched$datetime_start, "%Y-%m-%dT%H:%M:%SZ", tz = "UTC"),
+        "2040-01-01T00:00:00Z"
+    )
+})
+
 test_that("EsgResult$filter_time() filters File and Aggregation results using DRS filename ranges", {
     for (type in c("File", "Aggregation")) {
         result <- query_result_test_object(type, query_result_test_file_time_docs(type), query_result_test_params(type))

--- a/tests/testthat/test-shift-stage.R
+++ b/tests/testthat/test-shift-stage.R
@@ -595,6 +595,10 @@ test_that("resolver coverage defensively repairs cached catalogs without times",
     catalog$frequency <- "mon"
     catalog$table_id <- "Amon"
     catalog$grid_label <- "gn"
+    catalog$filename <- catalog$title
+    catalog$title <- NA_character_
+    catalog$datetime_start <- NULL
+    catalog$datetime_end <- NULL
     candidates <- shift__cmip6_candidates(
         catalog,
         models = "BCC-CSM2-MR",
@@ -607,6 +611,45 @@ test_that("resolver coverage defensively repairs cached catalogs without times",
 
     expect_true(candidates$complete[[1L]])
     expect_true(is.na(candidates$missing[[1L]]))
+})
+
+test_that("catalog time enrichment keeps its label fallback order", {
+    catalog <- data.table::rbindlist(list(
+        shift_test_file_docs(
+            "tas_day_Model_ssp245_r1i1p1f1_gn_20410101-20411231.nc"
+        ),
+        shift_test_file_docs(
+            "tas_day_Model_ssp245_r1i1p1f1_gn_20420101-20421231.nc"
+        ),
+        shift_test_file_docs(
+            "tas_day_Model_ssp245_r1i1p1f1_gn_20430101-20431231.nc"
+        )
+    ), fill = TRUE)
+    catalog$filename <- c(
+        "tas_day_Model_ssp245_r1i1p1f1_gn_20910101-20911231.nc",
+        "tas_day_Model_ssp245_r1i1p1f1_gn_20420101-20421231.nc",
+        NA_character_
+    )
+    catalog$esgf_id <- c(
+        "tas_day_Model_ssp245_r1i1p1f1_gn_20920101-20921231.nc",
+        "tas_day_Model_ssp245_r1i1p1f1_gn_20930101-20931231.nc",
+        "tas_day_Model_ssp245_r1i1p1f1_gn_20430101-20431231.nc"
+    )
+    catalog$title[[2L]] <- NA_character_
+    catalog$title[[3L]] <- ""
+    catalog$datetime_start <- NULL
+    catalog$datetime_end <- NULL
+
+    repaired <- shift__catalog_fill_time_ranges(catalog)
+
+    expect_identical(
+        substr(repaired$datetime_start, 1L, 4L),
+        c("2041", "2042", "2043")
+    )
+    expect_identical(
+        substr(repaired$datetime_end, 1L, 4L),
+        c("2041", "2042", "2043")
+    )
 })
 
 test_that("resolver inputs are not masked by provider convenience columns", {


### PR DESCRIPTION
## Summary

- Reuses one metadata-first ESGF time-range enrichment path across query filtering and workflow catalog repair.
- Preserves each caller's label sources, warning behavior, time representation, and mutation contract.

## Changes

- Adds shared fixed-length character-column normalization and lazy DRS range filling.
- Routes automatic result filtering and cached catalog repair through the shared helpers.
- Covers absent and short columns, partial metadata pairs, unknown ranges, and the workflow label fallback order.
- Closes #213.
