### PR TITLE
refactor: reuse hourly calendar traversal

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -545,6 +545,10 @@
 
 ## Internal changes
 
+* Consolidated direct-model hourly calendar traversal while retaining separate
+  circular point interpolation and conservative interval-mean kernels,
+  identity behavior, row order, time-of-day provenance, and diagnostics (#218).
+
 * Consolidated Shift dynamic-scope nesting and artifact-row iteration while
   preserving per-stage readers, metadata, column selection, diagnostics,
   ordering, and global row limits (#216).

--- a/R/adapter-direct-model-calendar.R
+++ b/R/adapter-direct-model-calendar.R
@@ -368,9 +368,9 @@ hourmap__daily_offsets <- function(data) {
     lattice$offsets
 }
 
-# Map point samples separately at each source time of day by circular annual
-# phase, preventing 360/366-day conversion from drifting the diurnal cycle.
-hourmap__circular_point_values <- function(data, target_days) {
+# Traverse each time-of-day series on the shared native-year-to-EPW lattice.
+hourmap__map_daily_slots <- function(data, target_days, mapper) {
+    checkmate::assert_function(mapper)
     source_count <- nrow(data)
     target_count <- target_days * 24L
     offsets <- hourmap__daily_offsets(data)
@@ -388,23 +388,16 @@ hourmap__circular_point_values <- function(data, target_days) {
     mapped <- numeric(target_count)
     target_phase <- numeric(target_count)
     source_second_of_day <- numeric(target_count)
+    target_day <- seq.int(0L, target_days - 1L)
     for (offset_index in seq_along(offsets)) {
         offset <- offsets[[offset_index]]
         source_rows <- which(data[["cf_second_of_day"]] == offset)
         target_rows <- seq.int(offset_index, target_count, by = 24L)
-        source_phase <- as.numeric(data[["annual_phase"]][source_rows])
-        source_value <- as.numeric(data[["value"]][source_rows])
-        phase <- (
-            seq.int(0L, target_days - 1L) + offset / 86400
-        ) / target_days
+        phase <- (target_day + offset / 86400) / target_days
 
-        # Repeat one source year on each side so January and December use the
-        # same circular chronology as all interior target days.
-        mapped[target_rows] <- daily__circular_interpolate(
-            source_phase,
-            source_value,
-            phase
-        )
+        # The callback owns only the numerical mapping kernel. This shell owns
+        # target placement and time-of-day provenance for every variable type.
+        mapped[target_rows] <- mapper(source_rows, phase)
         target_phase[target_rows] <- phase
         source_second_of_day[target_rows] <- offset
     }
@@ -416,44 +409,39 @@ hourmap__circular_point_values <- function(data, target_days) {
     )
 }
 
+# Map point samples separately at each source time of day by circular annual
+# phase, preventing 360/366-day conversion from drifting the diurnal cycle.
+hourmap__circular_point_values <- function(data, target_days) {
+    hourmap__map_daily_slots(
+        data,
+        target_days,
+        mapper = function(source_rows, target_phase) {
+            source_phase <- as.numeric(data[["annual_phase"]][source_rows])
+            source_value <- as.numeric(data[["value"]][source_rows])
+
+            # Repeat one source year on each side so January and December use
+            # the same circular chronology as all interior target days.
+            daily__circular_interpolate(
+                source_phase,
+                source_value,
+                target_phase
+            )
+        }
+    )
+}
+
 # Conservatively remap each time-of-day series across calendar days so
 # interval means retain both their diurnal slot and normalized annual mean.
 hourmap__conservative_interval_values <- function(data, target_days) {
-    source_count <- nrow(data)
-    target_count <- target_days * 24L
-    offsets <- hourmap__daily_offsets(data)
-    if (source_count == target_count) {
-        return(list(
-            value = as.numeric(data[["value"]]),
-            target_phase = as.numeric(data[["annual_phase"]]),
-            source_second_of_day = as.numeric(
-                data[["cf_second_of_day"]]
-            ),
-            hour_phase_seconds = offsets[[1L]] %% 3600
-        ))
-    }
-
-    mapped <- numeric(target_count)
-    target_phase <- numeric(target_count)
-    source_second_of_day <- numeric(target_count)
-    for (offset_index in seq_along(offsets)) {
-        offset <- offsets[[offset_index]]
-        source_rows <- which(data[["cf_second_of_day"]] == offset)
-        target_rows <- seq.int(offset_index, target_count, by = 24L)
-        mapped[target_rows] <- hourmap__conservative_interval_mean(
-            data[["value"]][source_rows],
-            target_days
-        )
-        target_phase[target_rows] <- (
-            seq.int(0L, target_days - 1L) + offset / 86400
-        ) / target_days
-        source_second_of_day[target_rows] <- offset
-    }
-    list(
-        value = mapped,
-        target_phase = target_phase,
-        source_second_of_day = source_second_of_day,
-        hour_phase_seconds = offsets[[1L]] %% 3600
+    hourmap__map_daily_slots(
+        data,
+        target_days,
+        mapper = function(source_rows, target_phase) {
+            hourmap__conservative_interval_mean(
+                data[["value"]][source_rows],
+                length(target_phase)
+            )
+        }
     )
 }
 

--- a/tests/testthat/test-adapter-direct-model-calendar.R
+++ b/tests/testthat/test-adapter-direct-model-calendar.R
@@ -155,6 +155,70 @@ test_that("365-day direct-model hours map exactly onto EPW rows", {
     )
 })
 
+test_that("daily slot traversal shares identity and mapped placement", {
+    identity_data <- hourmap_test__adjusted(
+        "tas",
+        2061L,
+        value = function(phase) seq_along(phase)
+    )@data
+    identity <- hourmap__map_daily_slots(
+        identity_data,
+        HOURMAP_TARGET_DAYS,
+        mapper = function(source_rows, target_phase) {
+            stop("identity mapping should bypass the numerical kernel")
+        }
+    )
+
+    expect_identical(identity$value, as.numeric(identity_data[["value"]]))
+    expect_identical(
+        identity$target_phase,
+        as.numeric(identity_data[["annual_phase"]])
+    )
+    expect_identical(
+        identity$source_second_of_day,
+        as.numeric(identity_data[["cf_second_of_day"]])
+    )
+    expect_identical(identity$hour_phase_seconds, 0)
+
+    data <- hourmap_test__adjusted(
+        "tas",
+        2061L,
+        "360_day",
+        value = function(phase, second_of_day) second_of_day / 3600
+    )@data
+    source_lengths <- integer()
+    target_lengths <- integer()
+    mapped <- hourmap__map_daily_slots(
+        data,
+        HOURMAP_TARGET_DAYS,
+        mapper = function(source_rows, target_phase) {
+            source_lengths <<- c(source_lengths, length(source_rows))
+            target_lengths <<- c(target_lengths, length(target_phase))
+            rep.int(
+                data[["cf_second_of_day"]][source_rows[[1L]]] / 3600,
+                length(target_phase)
+            )
+        }
+    )
+
+    expect_identical(source_lengths, rep.int(360L, 24L))
+    expect_identical(target_lengths, rep.int(HOURMAP_TARGET_DAYS, 24L))
+    expect_identical(
+        mapped$value,
+        rep(as.numeric(0:23), HOURMAP_TARGET_DAYS)
+    )
+    expect_equal(
+        mapped$target_phase,
+        seq.int(0L, HOURMAP_TARGET_HOURS - 1L) / HOURMAP_TARGET_HOURS,
+        tolerance = 1e-12
+    )
+    expect_identical(
+        mapped$source_second_of_day,
+        rep(as.numeric(0:23) * 3600, HOURMAP_TARGET_DAYS)
+    )
+    expect_identical(mapped$hour_phase_seconds, 0)
+})
+
 test_that("point variables use circular annual-phase interpolation", {
     calendars <- CF_TIME_CALENDARS
     years <- ifelse(


### PR DESCRIPTION
## Summary

- Consolidates the repeated 24-position traversal used by direct-model hourly calendar mapping.
- Keeps circular point interpolation and conservative interval integration as separate numerical kernels.
- Closes #217.

## Changes

- Adds `hourmap__map_daily_slots()` for the shared daily-lattice validation, identity path, target placement, annual-phase construction, and time-of-day provenance.
- Routes `hourmap__circular_point_values()` and `hourmap__conservative_interval_values()` through mapper callbacks without changing their equations.
- Adds regression coverage for callback traversal, source and target slot lengths, row order, provenance arrays, and identity bypass.
