### PR TITLE
refactor: share Belcher monthly-extrema attachment

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -545,6 +545,10 @@
 
 ## Internal changes
 
+* Consolidated projected and historical Belcher monthly-extrema aggregation
+  and attachment while preserving their distinct scientific case identities,
+  missing-input behavior, and alignment diagnostics (#224).
+
 * Consolidated absolute-target and change-factor Belcher runner assembly while
   retaining their separate field builders, no-reference fallback, equations,
   policies, diagnostics, factor metadata, part order, and result values (#222).

--- a/R/backend-belcher.R
+++ b/R/backend-belcher.R
@@ -1167,23 +1167,39 @@ morpher__monthly_target_vector <- function(data, column) {
 # Identify only stable scientific case columns. Variable-specific table IDs and
 # floating-point site coordinates are metadata: including either would split a
 # single model/member/period into false monthly cases after spatial averaging.
+BELCHER_PROJECTED_EXTREME_IDENTITY_COLUMNS <- c(
+    "activity_drs", "institution_id", "source_id", "experiment_id",
+    "member_id", "interval", "month"
+)
 
-# Attach monthly extrema using model/member/period identity rather than table
-# identity. This supports tas in Amon and tasmax/tasmin in a different CMIP table.
-morpher__attach_extreme_value <- function(target, extreme, value_name) {
+BELCHER_REFERENCE_EXTREME_IDENTITY_COLUMNS <- c(
+    "activity_drs", "institution_id", "source_id", "member_id", "month"
+)
+
+# Aggregate and attach one monthly-extreme field using an explicitly supplied
+# scientific identity. Callers retain ownership of the projected-versus-
+# historical identity and its user-facing alignment diagnostic.
+morpher__attach_monthly_extreme <- function(target, extreme, value_name,
+                                             identity_columns,
+                                             missing_month_message) {
     target <- data.table::copy(target)
     if (is.null(extreme) || !nrow(extreme)) {
         target[, (value_name) := NA_real_]
         return(target)
     }
+
+    # Restrict the join to identity columns represented by both inputs. Month
+    # remains mandatory because the values are monthly extrema.
     join_cols <- intersect(
-        c("activity_drs", "institution_id", "source_id", "experiment_id",
-          "member_id", "interval", "month"),
+        identity_columns,
         intersect(names(target), names(extreme))
     )
     if (!"month" %in% join_cols) {
-        cli::cli_abort("Cannot align monthly extrema without a month column.")
+        cli::cli_abort(missing_month_message)
     }
+
+    # Multiple table or spatial rows for one scientific case represent one
+    # monthly value and retain the established all-missing behavior.
     extreme <- data.table::copy(extreme)
     extreme[, .extreme_value := as.numeric(value)]
     extreme <- extreme[, .(
@@ -1191,6 +1207,18 @@ morpher__attach_extreme_value <- function(target, extreme, value_name) {
     ), by = join_cols]
     target[extreme, on = join_cols, (value_name) := i..extreme_value]
     target[]
+}
+
+# Attach monthly extrema using model/member/period identity rather than table
+# identity. This supports tas in Amon and tasmax/tasmin in a different CMIP table.
+morpher__attach_extreme_value <- function(target, extreme, value_name) {
+    morpher__attach_monthly_extreme(
+        target,
+        extreme,
+        value_name,
+        identity_columns = BELCHER_PROJECTED_EXTREME_IDENTITY_COLUMNS,
+        missing_month_message = "Cannot align monthly extrema without a month column."
+    )
 }
 
 # Smooth delta and alpha independently, then compensate the combined method for
@@ -1531,25 +1559,13 @@ morpher__belcher_from_monthly_change <- function(var, data_epw, data_mean, refer
 # Attach historical extrema across experiments and variable-specific tables,
 # retaining model/member/month as the scientific case identity.
 morpher__attach_reference_extreme <- function(target, reference, value_name) {
-    target <- data.table::copy(target)
-    if (is.null(reference) || !nrow(reference)) {
-        target[, (value_name) := NA_real_]
-        return(target)
-    }
-    join_cols <- intersect(
-        c("activity_drs", "institution_id", "source_id", "member_id", "month"),
-        intersect(names(target), names(reference))
+    morpher__attach_monthly_extreme(
+        target,
+        reference,
+        value_name,
+        identity_columns = BELCHER_REFERENCE_EXTREME_IDENTITY_COLUMNS,
+        missing_month_message = "Cannot align historical monthly extrema without a month column."
     )
-    if (!"month" %in% join_cols) {
-        cli::cli_abort("Cannot align historical monthly extrema without a month column.")
-    }
-    reference <- data.table::copy(reference)
-    reference[, .reference_extreme := as.numeric(value)]
-    reference <- reference[, .(
-        .reference_extreme = if (all(is.na(.reference_extreme))) NA_real_ else mean(.reference_extreme, na.rm = TRUE)
-    ), by = join_cols]
-    target[reference, on = join_cols, (value_name) := i..reference_extreme]
-    target[]
 }
 
 # Enhanced change-factor morphing applies

--- a/tests/testthat/test-backend-belcher.R
+++ b/tests/testthat/test-backend-belcher.R
@@ -489,6 +489,73 @@ test_that("enhanced temperature uses mean daily DTR and guarded auto fallback", 
 })
 
 
+test_that("monthly extrema share aggregation with explicit scientific identities", {
+    target <- data.table::data.table(
+        activity_drs = "ScenarioMIP",
+        institution_id = "Institute",
+        source_id = "Model-A",
+        experiment_id = c("ssp245", "ssp585"),
+        member_id = "r1i1p1f1",
+        interval = c("near", "far"),
+        month = 1L
+    )
+    projected <- data.table::data.table(
+        activity_drs = "ScenarioMIP",
+        institution_id = "Institute",
+        source_id = "Model-A",
+        experiment_id = rep(c("ssp245", "ssp585"), each = 2L),
+        member_id = "r1i1p1f1",
+        interval = rep(c("near", "far"), each = 2L),
+        month = 1L,
+        table_id = rep(c("day", "Amon"), 2L),
+        value = c(10, 14, 20, 22)
+    )
+    attached <- morpher__attach_extreme_value(
+        target, projected, "projected_max"
+    )
+    expect_equal(attached$projected_max, c(12, 21))
+
+    # Historical extrema intentionally aggregate across experiment and interval
+    # while retaining the model, member, and month identity.
+    reference <- data.table::data.table(
+        activity_drs = "ScenarioMIP",
+        institution_id = "Institute",
+        source_id = "Model-A",
+        experiment_id = c("historical", "hist-nat"),
+        member_id = "r1i1p1f1",
+        interval = c("baseline-a", "baseline-b"),
+        month = 1L,
+        value = c(4, 8)
+    )
+    attached <- morpher__attach_reference_extreme(
+        target, reference, "reference_max"
+    )
+    expect_equal(attached$reference_max, c(6, 6))
+
+    missing <- morpher__attach_extreme_value(
+        target, NULL, "projected_max"
+    )
+    expect_true(all(is.na(missing$projected_max)))
+
+    without_month <- data.table::copy(target)
+    without_month[, month := NULL]
+    expect_error(
+        morpher__attach_extreme_value(
+            without_month, projected, "projected_max"
+        ),
+        "Cannot align monthly extrema without a month column.",
+        fixed = TRUE
+    )
+    expect_error(
+        morpher__attach_reference_extreme(
+            without_month, reference, "reference_max"
+        ),
+        "Cannot align historical monthly extrema without a month column.",
+        fixed = TRUE
+    )
+})
+
+
 test_that("cyclic smoothing is continuous and conserves every monthly target", {
     epw <- enhanced_test__hourly_year()
     target <- seq(-3, 8, length.out = 12L)


### PR DESCRIPTION
## Summary

- Shares the aggregate-and-join mechanism used to attach projected and historical monthly extrema.
- Preserves the distinct scientific identities and diagnostics of both Belcher paths.

## Changes

- Adds one internal monthly-extrema attachment helper with explicit identity columns and missing-month diagnostics.
- Keeps thin projected and historical wrappers responsible for their existing case definitions.
- Adds focused tests for aggregation, case isolation, historical pooling, missing input, and alignment errors.
- Closes #223.