### PR TITLE
refactor: share `EsgDataset` inquiry-name enumeration

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -545,6 +545,10 @@
 
 ## Internal changes
 
+* Consolidated ordered NetCDF variable and dimension name enumeration inside
+  `EsgDataset` while preserving its public methods, file-index behavior,
+  metadata order, return types, and closed-dataset errors (#226).
+
 * Consolidated projected and historical Belcher monthly-extrema aggregation
   and attachment while preserving their distinct scientific case identities,
   missing-input behavior, and alignment diagnostics (#224).

--- a/R/dataset.R
+++ b/R/dataset.R
@@ -680,12 +680,11 @@ EsgDataset <- R6::R6Class(
             private$check_index(index)
 
             info <- self$file_inq(index)
-            vars <- character(info$nvars)
-            for (i in seq_len(info$nvars)) {
-                var_info <- RNetCDF::var.inq.nc(private$nc_handles[[index]], i - 1L)
-                vars[i] <- var_info$name
-            }
-            vars
+            private$inquiry_names(
+                private$nc_handles[[index]],
+                info$nvars,
+                RNetCDF::var.inq.nc
+            )
         },
         # }}}
 
@@ -706,12 +705,11 @@ EsgDataset <- R6::R6Class(
             private$check_index(index)
 
             info <- self$file_inq(index)
-            dims <- character(info$ndims)
-            for (i in seq_len(info$ndims)) {
-                dim_info <- RNetCDF::dim.inq.nc(private$nc_handles[[index]], i - 1L)
-                dims[i] <- dim_info$name
-            }
-            dims
+            private$inquiry_names(
+                private$nc_handles[[index]],
+                info$ndims,
+                RNetCDF::dim.inq.nc
+            )
         },
         # }}}
 
@@ -1549,6 +1547,22 @@ EsgDataset <- R6::R6Class(
             )
 
             private$collect_async_task(task)
+        },
+        # }}}
+
+        # inquiry_names {{{
+        # Collect ordered NetCDF names for a validated handle. Public variable
+        # and dimension methods retain ownership of state and index checks and
+        # select the corresponding metadata count and inquiry function.
+        inquiry_names = function(handle, count, inquiry) {
+            names <- character(count)
+            for (i in seq_len(count)) {
+                # RNetCDF metadata identifiers are zero-based even though the
+                # returned R character vector uses ordinary one-based indices.
+                item_info <- inquiry(handle, i - 1L)
+                names[i] <- item_info$name
+            }
+            names
         },
         # }}}
 

--- a/tests/testthat/test-dataset.R
+++ b/tests/testthat/test-dataset.R
@@ -395,6 +395,40 @@ test_that("EsgDataset$get_dimensions()", {
     expect_true("lon" %in% dims)
 })
 # }}}
+
+# EsgDataset metadata-name enumeration {{{
+test_that("EsgDataset metadata names preserve direct inquiry order by file", {
+    paths <- local_dataset_cmip6_files(c(2060L, 2061L))
+    ds <- EsgDataset$new(paths)
+    ds$open()
+    on.exit(ds$close(), add = TRUE)
+
+    for (index in seq_along(paths)) {
+        info <- ds$file_inq(index)
+        expected_variables <- vapply(
+            seq_len(info$nvars) - 1L,
+            function(id) ds$var_inq(id, index)$name,
+            character(1L)
+        )
+        expected_dimensions <- vapply(
+            seq_len(info$ndims) - 1L,
+            function(id) ds$dim_inq(id, index)$name,
+            character(1L)
+        )
+
+        expect_identical(ds$get_variables(index), expected_variables)
+        expect_identical(ds$get_dimensions(index), expected_dimensions)
+    }
+})
+
+test_that("EsgDataset metadata-name methods reject closed datasets", {
+    ds <- EsgDataset$new("https://example.org/data.nc")
+
+    expect_error(ds$get_variables(), "not open")
+    expect_error(ds$get_dimensions(), "not open")
+})
+# }}}
+
 # EsgDataset$get_time_axis() {{{
 test_that("EsgDataset$get_time_axis()", {
     paths <- local_dataset_cmip6_files(c(2060L, 2061L))


### PR DESCRIPTION
## Summary

- Shares ordered NetCDF name enumeration behind `EsgDataset$get_variables()` and `EsgDataset$get_dimensions()`.
- Keeps both documented public methods and their validation behavior explicit.

## Changes

- Adds one private `inquiry_names()` method parameterized by a validated handle, metadata count, and RNetCDF inquiry function.
- Keeps variable and dimension count selection in their respective public wrappers.
- Adds public-behavior coverage for direct metadata order across two file indices and closed-dataset errors.
- Closes #225.