### PR TITLE
refactor: share selection-context updates

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -545,6 +545,10 @@
 
 ## Internal changes
 
+* Consolidated selection-context updates across `EsgDataset` and `EsgResult`
+  while preserving their class-specific initial state, original source totals,
+  and source-index order across consecutive slices (#228).
+
 * Consolidated ordered NetCDF variable and dimension name enumeration inside
   `EsgDataset` while preserving its public methods, file-index behavior,
   metadata order, return types, and closed-dataset errors (#226).

--- a/R/dataset.R
+++ b/R/dataset.R
@@ -1153,14 +1153,11 @@ EsgDataset <- R6::R6Class(
 
         # update_selection_context {{{
         update_selection_context = function(index, context = private$context) {
-            selection <- private$get_selection_context()
-            context$selection <- list(
-                source_count = selection$source_count,
-                source_num_found = selection$source_num_found,
-                source_indices = selection$source_indices[index]
+            context__update_selection(
+                context,
+                private$get_selection_context(),
+                index
             )
-
-            context
         },
         # }}}
 

--- a/R/query-result.R
+++ b/R/query-result.R
@@ -517,14 +517,11 @@ EsgResult <- R6::R6Class(
 
         # update_selection_context {{{
         update_selection_context = function(index, context = private$context) {
-            selection <- private$get_selection_context()
-            context$selection <- list(
-                source_count = selection$source_count,
-                source_num_found = selection$source_num_found,
-                source_indices = selection$source_indices[index]
+            context__update_selection(
+                context,
+                private$get_selection_context(),
+                index
             )
-
-            context
         },
         # }}}
 
@@ -1216,6 +1213,19 @@ query_result__selection <- function(selection) {
         source_num_found = source_num_found,
         source_indices = source_indices
     )
+}
+
+# Update a result context with selected source positions.
+context__update_selection <- function(context, selection, index) {
+    # Source totals describe the original result; only its retained positions
+    # change when a dataset or query result is sliced again.
+    context$selection <- list(
+        source_count = selection$source_count,
+        source_num_found = selection$source_num_found,
+        source_indices = selection$source_indices[index]
+    )
+
+    context
 }
 
 query_result__query_urls <- function(urls, named = TRUE) {

--- a/tests/testthat/test-dataset.R
+++ b/tests/testthat/test-dataset.R
@@ -866,6 +866,14 @@ test_that("EsgDataset$slice() selects files and preserves runtime context", {
         source_indices = c(5L, 2L)
     ))
 
+    chained <- sliced$slice(2L)
+    expect_identical(chained$url, paths[[1L]])
+    expect_identical(chained$selection(), list(
+        source_count = 5L,
+        source_num_found = 10L,
+        source_indices = 2L
+    ))
+
     logical_slice <- ds$slice(c(TRUE, FALSE, TRUE))
     expect_identical(logical_slice$url, paths[c(1L, 3L)])
     expect_identical(logical_slice$selection()$source_indices, c(2L, 5L))


### PR DESCRIPTION
## Summary

- Shares the source-selection update used after local slicing.
- Keeps `EsgDataset` and `EsgResult` initial selection derivation separate.

## Changes

- Adds internal `context__update_selection()` to preserve original source totals and remap source indices.
- Routes both class-specific update methods through the shared helper.
- Adds public-behavior coverage for consecutive `EsgDataset$slice()` calls.
- Closes #227.
