### PR TITLE
fix: filter CLI retry candidates by status

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -74,6 +74,7 @@ Collate:
     'cli-parse.R'
     'cli-query.R'
     'cli-render.R'
+    'cli-retry.R'
     'cli-shift-config.R'
     'cli-shift-watch.R'
     'cli-shift.R'

--- a/NEWS.md
+++ b/NEWS.md
@@ -452,6 +452,11 @@
 
 ## Bug fixes
 
+* `extract retry` and `morph retry` now filter candidates by the requested
+  status instead of resolving the selector as the candidate table's `status`
+  column. Their shared status validation and preview preparation retain each
+  command's separate candidate source and retry execution (#232).
+
 * Point extraction now retains canonical CF calendar coordinates and annual
   phase, uses them for non-Gregorian range selection and yearly Parquet
   partitions, and prefers them in morphing summaries with legacy artifact

--- a/R/cli-extract.R
+++ b/R/cli-extract.R
@@ -73,28 +73,22 @@ epwshiftr_cli_extract_retry <- function(store, args, json = FALSE,
         options = c("--plan", "--status", "--fallback")
     )
     epwshiftr_cli_assert_no_positionals(parsed)
-    status <- epwshiftr_cli_csv(parsed$options[["--status"]])
-    if (is.null(status)) {
-        status <- "failed"
-    }
     status_choices <- c("pending", "failed", "empty", "done")
-    if (any(!status %in% status_choices)) {
-        epwshiftr_cli_usage_abort(sprintf(
-            "--status must be one of: %s.",
-            paste(status_choices, collapse = ", ")
-        ))
-    }
+    statuses <- cli_retry__resolve_statuses(
+        parsed$options[["--status"]],
+        status_choices
+    )
     fallback <- epwshiftr_cli_choice(parsed$options[["--fallback"]], c("auto", "error"), "--fallback", default = "auto")
     candidates <- store$coverage(plan_id = epwshiftr_cli_ids(parsed$options[["--plan"]], "--plan", required = FALSE))
-    if (nrow(candidates)) {
-        candidates <- candidates[candidates[["status"]] %in% status]
+    retry <- cli_retry__prepare_candidates(
+        candidates,
+        statuses,
+        parsed$flags[["--run"]]
+    )
+    if (!retry$execute) {
+        return(retry$candidates)
     }
-    if (!isTRUE(parsed$flags[["--run"]]) || !nrow(candidates)) {
-        if (nrow(candidates)) {
-            candidates[, dry_run := TRUE]
-        }
-        return(candidates)
-    }
+    candidates <- retry$candidates
     climate <- shift__extract_plans_task(
         store,
         plan_id = unique(candidates$plan_id),

--- a/R/cli-morph.R
+++ b/R/cli-morph.R
@@ -166,30 +166,24 @@ epwshiftr_cli_morph_retry <- function(store, args, json = FALSE,
         options = c("--morph", "--status")
     )
     epwshiftr_cli_assert_no_positionals(parsed)
-    status <- epwshiftr_cli_csv(parsed$options[["--status"]])
-    if (is.null(status)) {
-        status <- "failed"
-    }
     status_choices <- c("planned", "running", "blocked", "failed", "result_done", "epw_written")
-    if (any(!status %in% status_choices)) {
-        epwshiftr_cli_usage_abort(sprintf(
-            "--status must be one of: %s.",
-            paste(status_choices, collapse = ", ")
-        ))
-    }
+    statuses <- cli_retry__resolve_statuses(
+        parsed$options[["--status"]],
+        status_choices
+    )
     candidates <- epwshiftr_cli_morph_status_rows(
         store,
         epwshiftr_cli_ids(parsed$options[["--morph"]], "--morph", required = FALSE)
     )
-    if (nrow(candidates)) {
-        candidates <- candidates[candidates[["status"]] %in% status]
+    retry <- cli_retry__prepare_candidates(
+        candidates,
+        statuses,
+        parsed$flags[["--run"]]
+    )
+    if (!retry$execute) {
+        return(retry$candidates)
     }
-    if (!isTRUE(parsed$flags[["--run"]]) || !nrow(candidates)) {
-        if (nrow(candidates)) {
-            candidates[, dry_run := TRUE]
-        }
-        return(candidates)
-    }
+    candidates <- retry$candidates
     results <- vector("list", nrow(candidates))
     for (i in seq_len(nrow(candidates))) {
         morph_id <- candidates$morph_id[[i]]

--- a/R/cli-retry.R
+++ b/R/cli-retry.R
@@ -1,0 +1,34 @@
+# Resolve and validate statuses selected for a retry command.
+cli_retry__resolve_statuses <- function(value, choices) {
+    statuses <- epwshiftr_cli_csv(value)
+    # Both retry commands use failed work as the default selection.
+    if (is.null(statuses)) {
+        statuses <- "failed"
+    }
+    if (any(!statuses %in% choices)) {
+        epwshiftr_cli_usage_abort(sprintf(
+            "--status must be one of: %s.",
+            paste(choices, collapse = ", ")
+        ))
+    }
+    statuses
+}
+
+
+# Filter retry candidates and decide whether execution should proceed.
+cli_retry__prepare_candidates <- function(candidates, statuses, run) {
+    if (nrow(candidates)) {
+        # The plural selector avoids data.table resolving it as the candidate
+        # table's singular status column.
+        candidates <- candidates[candidates[["status"]] %in% statuses]
+    }
+
+    execute <- isTRUE(run) && nrow(candidates) > 0L
+    # Preview rows are explicitly marked, while empty results retain their
+    # command-specific schema.
+    if (!execute && nrow(candidates)) {
+        candidates[, dry_run := TRUE]
+    }
+
+    list(candidates = candidates, execute = execute)
+}

--- a/tests/testthat/test-cli-extract.R
+++ b/tests/testthat/test-cli-extract.R
@@ -54,6 +54,15 @@ test_that("extract CLI plans, runs, checks coverage, and lists artifacts", {
     expect_equal(retry_preview$result$status, "failed")
     expect_true(retry_preview$result$dry_run)
 
+    retry_other_status <- epwshiftr_cli(c(
+        "--quiet", "--store", setup$dir,
+        "extract", "retry",
+        "--plan", plan$result$plan_id[[1L]],
+        "--status", "done"
+    ))
+    expect_equal(retry_other_status$status, 0L)
+    expect_equal(nrow(retry_other_status$result), 0L)
+
     retry_bad_status <- epwshiftr_cli(c("--quiet", "--store", setup$dir, "extract", "retry", "--status", "bogus"))
     expect_equal(retry_bad_status$status, 2L)
     expect_match(retry_bad_status$error, "--status")

--- a/tests/testthat/test-cli-morph.R
+++ b/tests/testthat/test-cli-morph.R
@@ -58,6 +58,15 @@ test_that("morph CLI lists metadata, runs morphing, writes EPW, and reports outp
     expect_equal(retry_preview$result$status, "failed")
     expect_true(retry_preview$result$dry_run)
 
+    retry_other_status <- epwshiftr_cli(c(
+        "--quiet", "--store", setup$dir,
+        "morph", "retry",
+        "--morph", run$result$morph_id,
+        "--status", "result_done"
+    ))
+    expect_equal(retry_other_status$status, 0L)
+    expect_equal(nrow(retry_other_status$result), 0L)
+
     retry_bad_status <- epwshiftr_cli(c("--quiet", "--store", setup$dir, "morph", "retry", "--status", "bogus"))
     expect_equal(retry_bad_status$status, 2L)
     expect_match(retry_bad_status$error, "--status")

--- a/tests/testthat/test-cli-retry.R
+++ b/tests/testthat/test-cli-retry.R
@@ -1,0 +1,38 @@
+test_that("retry status resolution preserves defaults and command choices", {
+    expect_identical(
+        cli_retry__resolve_statuses(NULL, c("failed", "done")),
+        "failed"
+    )
+    expect_identical(
+        cli_retry__resolve_statuses("failed,done", c("failed", "done")),
+        c("failed", "done")
+    )
+    expect_error(
+        cli_retry__resolve_statuses("missing", c("failed", "done")),
+        "--status must be one of: failed, done.",
+        fixed = TRUE
+    )
+})
+
+
+test_that("retry candidate preparation preserves preview and execution rules", {
+    candidates <- data.table::data.table(
+        id = 1:3,
+        status = c("failed", "done", "failed")
+    )
+
+    preview <- cli_retry__prepare_candidates(candidates, "failed", FALSE)
+    expect_false(preview$execute)
+    expect_identical(preview$candidates$id, c(1L, 3L))
+    expect_true(all(preview$candidates$dry_run))
+
+    execution <- cli_retry__prepare_candidates(candidates, "done", TRUE)
+    expect_true(execution$execute)
+    expect_identical(execution$candidates$id, 2L)
+    expect_false("dry_run" %in% names(execution$candidates))
+
+    empty <- candidates[0L]
+    prepared_empty <- cli_retry__prepare_candidates(empty, "failed", TRUE)
+    expect_false(prepared_empty$execute)
+    expect_identical(names(prepared_empty$candidates), names(empty))
+})


### PR DESCRIPTION
## Summary

- Fixes status selection for `extract retry` and `morph retry`.
- Shares retry candidate preparation while keeping command-specific execution independent.

## Changes

- Adds internal `cli_retry__resolve_statuses()` and `cli_retry__prepare_candidates()`.
- Uses a non-conflicting `statuses` selector so `data.table` filters requested states correctly.
- Adds helper and public CLI regression coverage for filtering, previews, execution, and empty results.
- Closes #231.
