### PR TITLE
refactor: share truncation footer rendering

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -121,6 +121,7 @@ Collate:
     'method-quantile-mapping.R'
     'method-scaled-distribution-mapping.R'
     'netcdf.R'
+    'print-truncation.R'
     'solr-date.R'
     'query-param.R'
     'query-result.R'

--- a/NEWS.md
+++ b/NEWS.md
@@ -550,6 +550,10 @@
 
 ## Internal changes
 
+* Consolidated dictionary and ESGF query-result truncation footer rendering
+  while preserving their public print output, spacing, pluralization, and
+  ordering (#234).
+
 * Consolidated selection-context updates across `EsgDataset` and `EsgResult`
   while preserving their class-specific initial state, original source totals,
   and source-index order across consecutive slices (#228).

--- a/R/dict-print.R
+++ b/R/dict-print.R
@@ -1,13 +1,3 @@
-dict__trunc <- function(x, n, newline_before = is.data.frame(x)) {
-    d <- cli::cli_div(theme = list(body = list(`padding-left` = 0L, `margin-left` = 0L)))
-    total <- if (is.data.frame(x)) nrow(x) else length(x)
-    if (n < total) {
-        if (newline_before) cli::cli_text()
-        cli::cli_text(cli::col_grey("# ... with {total - n} more item{?s}"))
-    }
-    cli::cli_end(d)
-}
-
 dict__list <- function(x, elem = "") {
     if (!length(x)) return()
 
@@ -51,7 +41,7 @@ dict__cv_vec <- function(cv, n = 5L) {
     txt <- cli::cli_vec(unclass(cv), list(vec_trunc = n))
     cli::cli_text("{.val {txt}}")
 
-    dict__trunc(cv, n)
+    print__truncation_footer(cv, n)
     invisible(cv)
 }
 
@@ -73,7 +63,7 @@ dict__cv_list <- function(cv, n = 5L, to_title = FALSE) {
     cli::cli_end(ul)
     cli::cli_end(d)
 
-    dict__trunc(cv, n)
+    print__truncation_footer(cv, n)
     invisible(cv)
 }
 
@@ -101,7 +91,7 @@ dict__cv_table <- function(cv, n = 3L) {
         cli::cli_end(d)
     }
 
-    dict__trunc(cv, n)
+    print__truncation_footer(cv, n)
     invisible(cv)
 }
 

--- a/R/print-truncation.R
+++ b/R/print-truncation.R
@@ -1,0 +1,19 @@
+# Render the shared footer used when a print method displays only part of an
+# object.
+print__truncation_footer <- function(x, n, newline_before = is.data.frame(x)) {
+    # Remove CLI's default body indentation so the footer aligns with the
+    # surrounding dictionary or query-result content.
+    div <- cli::cli_div(theme = list(
+        body = list(`padding-left` = 0L, `margin-left` = 0L)
+    ))
+    total <- if (is.data.frame(x)) nrow(x) else length(x)
+    if (n < total) {
+        if (newline_before) {
+            cli::cli_text()
+        }
+        cli::cli_text(cli::col_grey(
+            "# ... with {total - n} more item{?s}"
+        ))
+    }
+    cli::cli_end(div)
+}

--- a/R/query-result.R
+++ b/R/query-result.R
@@ -1135,7 +1135,7 @@ EsgResult <- R6::R6Class(
 
             cli::cat_line(c(rbind(brief, size)))
 
-            query_result__trunc(self$id, n)
+            print__truncation_footer(self$id, n)
         }
         # }}}
     )
@@ -1143,18 +1143,6 @@ EsgResult <- R6::R6Class(
 # }}}
 
 # result collection helpers {{{
-query_result__trunc <- function(x, n, newline_before = is.data.frame(x)) {
-    d <- cli::cli_div(theme = list(body = list(`padding-left` = 0L, `margin-left` = 0L)))
-    total <- if (is.data.frame(x)) nrow(x) else length(x)
-    if (n < total) {
-        if (newline_before) {
-            cli::cli_text()
-        }
-        cli::cli_text(cli::col_grey("# ... with {total - n} more item{?s}"))
-    }
-    cli::cli_end(d)
-}
-
 query_result__context <- function(context = NULL) {
     if (is.null(context) || !length(context)) {
         return(list())

--- a/tests/testthat/test-print-truncation.R
+++ b/tests/testthat/test-print-truncation.R
@@ -1,0 +1,21 @@
+test_that("shared truncation footer preserves display behavior", {
+    testthat::local_reproducible_output(crayon = FALSE, unicode = TRUE)
+
+    vector_footer <- capture.output(
+        print__truncation_footer(letters[1:3], 2L, newline_before = FALSE),
+        type = "message"
+    )
+    expect_identical(vector_footer, "# ... with 1 more item")
+
+    table_footer <- capture.output(
+        print__truncation_footer(data.frame(value = 1:4), 2L),
+        type = "message"
+    )
+    expect_identical(table_footer, c("", "# ... with 2 more items"))
+
+    complete_footer <- capture.output(
+        print__truncation_footer(letters[1:2], 2L),
+        type = "message"
+    )
+    expect_identical(complete_footer, character())
+})

--- a/tests/testthat/test-query-result.R
+++ b/tests/testthat/test-query-result.R
@@ -2746,6 +2746,16 @@ test_that("EsgResultDataset$print() snapshots offline fixtures", {
     priv(datasets)$response$response$docs$number_of_aggregations <- c(2L, 0L)
 
     expect_snapshot(datasets$print(), transform = transform_print)
+
+    truncated <- capture.output(
+        datasets$print(n = 1L),
+        type = "message"
+    )
+    expect_match(
+        paste(cli::ansi_strip(truncated), collapse = "\n"),
+        "# ... with 1 more item",
+        fixed = TRUE
+    )
 })
 
 test_that("EsgResult$print_contents() batches content output", {


### PR DESCRIPTION
## Summary

- Removes duplicate truncation-footer rendering from dictionary and ESGF query-result modules.
- Preserves the existing public print output and ordering.

## Changes

- Adds internal `print__truncation_footer()` in `R/print-truncation.R`.
- Routes `Cmip6CV`, `Cmip6DReq`, and `EsgResult` truncation footers through the shared helper.
- Adds direct and public-path regression coverage for spacing, pluralization, and complete results.
- Closes #233.
