### PR TITLE
refactor: share temperature physical policy execution

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -550,6 +550,10 @@
 
 ## Internal changes
 
+* Consolidated temperature-only physical-policy execution across the shared
+  Daily/BTWS/Eames component and the Arima and Ek adapters, while preserving
+  each method's diagnostics, result schema, and selected policy (#236).
+
 * Consolidated dictionary and ESGF query-result truncation footer rendering
   while preserving their public print output, spacing, pluralization, and
   ordering (#234).

--- a/R/backend-arima-temperature.R
+++ b/R/backend-arima-temperature.R
@@ -446,15 +446,11 @@ arima__physics_apply <- function(data, inputs, context, options) {
     # Both published and harmonized variants pass through the shared physical
     # executor; the selected policy decides whether humidity is retained or
     # closed after the percentile-dependent temperature change.
-    physical <- epwphys__apply(
-        EpwPhysicalRequest(
-            template = baseline$weather,
-            fields = list(
-                dry_bulb_temperature = hourly[["temperature_projected"]]
-            ),
-            provenance = list(adapter = "arima_temperature")
-        ),
-        epwphys__recipe_policy(context$recipe)
+    physical <- epwphys__apply_temperature(
+        template = baseline$weather,
+        temperature = hourly[["temperature_projected"]],
+        policy = epwphys__recipe_policy(context$recipe),
+        adapter = "arima_temperature"
     )
     weather <- data.table::copy(physical@weather)
     moisture <- physical@state$humidity
@@ -476,13 +472,11 @@ arima__physics_apply <- function(data, inputs, context, options) {
             )
         )
     }
-    for (name in names(diagnostic_values)) {
-        data.table::set(
-            weather,
-            j = name,
-            value = diagnostic_values[[name]]
-        )
-    }
+    data.table::set(
+        weather,
+        j = names(diagnostic_values),
+        value = diagnostic_values
+    )
 
     diagnostics <- list()
     clamped <- data$factors[["percentile_clamped"]]

--- a/R/backend-ek-daily-temperature.R
+++ b/R/backend-ek-daily-temperature.R
@@ -548,15 +548,11 @@ ek__physics_apply <- function(data, inputs, context, options) {
     )
     # The shared executor applies either the paper-faithful preservation policy
     # or the harmonized specific-humidity policy to the same Ek temperature.
-    physical <- epwphys__apply(
-        EpwPhysicalRequest(
-            template = baseline$weather,
-            fields = list(
-                dry_bulb_temperature = hourly[["temperature_projected"]]
-            ),
-            provenance = list(adapter = "ek_daily_temperature")
-        ),
-        epwphys__recipe_policy(context$recipe)
+    physical <- epwphys__apply_temperature(
+        template = baseline$weather,
+        temperature = hourly[["temperature_projected"]],
+        policy = epwphys__recipe_policy(context$recipe),
+        adapter = "ek_daily_temperature"
     )
     weather <- data.table::copy(physical@weather)
     moisture <- physical@state$humidity
@@ -586,13 +582,11 @@ ek__physics_apply <- function(data, inputs, context, options) {
             )
         )
     }
-    for (name in names(diagnostic_values)) {
-        data.table::set(
-            weather,
-            j = name,
-            value = diagnostic_values[[name]]
-        )
-    }
+    data.table::set(
+        weather,
+        j = names(diagnostic_values),
+        value = diagnostic_values
+    )
 
     diagnostics <- list()
     fallback <- factors[["dtr_status"]] ==

--- a/R/backend-sobie-curry.R
+++ b/R/backend-sobie-curry.R
@@ -867,13 +867,11 @@ sobie__physics_apply <- function(data, inputs, context, options) {
             )
         )
     }
-    for (name in names(diagnostic_values)) {
-        data.table::set(
-            weather,
-            j = name,
-            value = diagnostic_values[[name]]
-        )
-    }
+    data.table::set(
+        weather,
+        j = names(diagnostic_values),
+        value = diagnostic_values
+    )
 
     diagnostics <- list()
     fallback <- factors[["temperature_dtr_status"]] ==

--- a/R/component-temperature-epw.R
+++ b/R/component-temperature-epw.R
@@ -4,31 +4,6 @@
 # EPW-header options remain owned by their corresponding stages.
 EPW_MORPH_TEMPERATURE_PROJECTION_OPTIONS <- list(tolerance = 1e-8)
 
-# Preserve baseline specific humidity after changing dry-bulb temperature and
-# expose the common physical result for method-specific diagnostics.
-temperature__moisture <- function(weather, temperature) {
-    physical <- epwphys__apply(
-        EpwPhysicalRequest(
-            template = weather,
-            fields = list(
-                dry_bulb_temperature = as.numeric(temperature)
-            ),
-            provenance = list(adapter = "daily_temperature")
-        ),
-        epwphys__policy("preserve_specific_humidity")
-    )
-    humidity <- physical@state$humidity
-    list(
-        weather = physical@weather,
-        relative_humidity = physical@weather[["relative_humidity"]],
-        dew_point_temperature = physical@weather[["dew_point_temperature"]],
-        baseline_specific_humidity = humidity$baseline_specific_humidity,
-        specific_humidity = humidity$specific_humidity,
-        status = humidity$status,
-        physical = physical
-    )
-}
-
 # Reduce one hourly projection to auditable daily targets and numerical closure
 # values shared by POWER, BTWS, and Eames temperature workflows.
 temperature__factor_rows <- function(targets, projected) {
@@ -178,12 +153,14 @@ temperature__physics_apply <- function(
     baseline <- data$baseline
     hourly <- data$hourly
     factors <- data$factors
-    moisture <- temperature__moisture(
-        baseline$weather,
-        hourly[["temperature_projected"]]
+    physical <- epwphys__apply_temperature(
+        template = baseline$weather,
+        temperature = hourly[["temperature_projected"]],
+        policy = epwphys__policy("preserve_specific_humidity"),
+        adapter = "daily_temperature"
     )
-
-    weather <- data.table::copy(moisture$weather)
+    humidity <- physical@state$humidity
+    weather <- data.table::copy(physical@weather)
 
     method_diagnostic_values <- if ("shape_exponent" %in% names(hourly)) {
         list(
@@ -219,13 +196,15 @@ temperature__physics_apply <- function(
         daily_temperature_boundary_jump_change =
             hourly[["boundary_jump_change"]],
         daily_temperature_baseline_specific_humidity =
-            moisture$baseline_specific_humidity,
-        daily_temperature_specific_humidity = moisture$specific_humidity,
-        daily_temperature_moisture_status = moisture$status
+            humidity$baseline_specific_humidity,
+        daily_temperature_specific_humidity = humidity$specific_humidity,
+        daily_temperature_moisture_status = humidity$status
     ))
-    for (name in names(diagnostic_values)) {
-        data.table::set(weather, j = name, value = diagnostic_values[[name]])
-    }
+    data.table::set(
+        weather,
+        j = names(diagnostic_values),
+        value = diagnostic_values
+    )
 
     diagnostics <- list()
     if (any(factors[["dtr_status"]] == "inherited_missing_extremes")) {
@@ -276,7 +255,7 @@ temperature__physics_apply <- function(
     }
     # Use the correction count produced by the shared physical executor so this
     # component does not independently reinterpret a closure status.
-    clipped <- moisture$physical@corrections$humidity_saturation_clipped
+    clipped <- physical@corrections$humidity_saturation_clipped
     if (clipped > 0L) {
         diagnostics[[length(diagnostics) + 1L]] <- morpher__diagnostic(
             stage = "runtime",

--- a/R/epw-physics.R
+++ b/R/epw-physics.R
@@ -762,6 +762,25 @@ epwphys__humidity_inconsistent <- function(weather) {
     as.integer(sum(state$humidity))
 }
 
+# Apply one temperature-only candidate through the shared physical boundary.
+# Method adapters retain policy selection and all method-specific diagnostics.
+epwphys__apply_temperature <- function(
+    template,
+    temperature,
+    policy,
+    adapter
+) {
+    checkmate::assert_string(adapter, min.chars = 1L)
+    epwphys__apply(
+        EpwPhysicalRequest(
+            template = template,
+            fields = list(dry_bulb_temperature = temperature),
+            provenance = list(adapter = adapter)
+        ),
+        policy
+    )
+}
+
 # Apply one validated policy to a method-neutral request. Method adapters own
 # statistical transforms; this executor owns only EPW physical interpretation.
 epwphys__apply <- function(request, policy) {

--- a/tests/testthat/test-epw-physics.R
+++ b/tests/testthat/test-epw-physics.R
@@ -120,6 +120,39 @@ test_that("paper-faithful preservation diagnoses without changing humidity", {
     )
 })
 
+test_that("temperature candidates share one physical-policy entry point", {
+    template <- epwphys_test__weather()
+    projected <- c(5, 25)
+    preserved <- epwphys__apply_temperature(
+        template = template,
+        temperature = projected,
+        policy = epwphys__policy("preserve_humidity_fields"),
+        adapter = "paper_temperature"
+    )
+    harmonized <- epwphys__apply_temperature(
+        template = template,
+        temperature = projected,
+        policy = epwphys__policy("preserve_specific_humidity"),
+        adapter = "harmonized_temperature"
+    )
+
+    expect_true(S7::S7_inherits(preserved, EpwPhysicalResult))
+    expect_true(S7::S7_inherits(harmonized, EpwPhysicalResult))
+    expect_identical(preserved@weather$dry_bulb_temperature, projected)
+    expect_identical(harmonized@weather$dry_bulb_temperature, projected)
+    expect_identical(
+        preserved@weather$relative_humidity,
+        template$relative_humidity
+    )
+    expect_null(preserved@state$humidity)
+    expect_named(harmonized@state$humidity)
+    expect_identical(preserved@provenance$adapter, "paper_temperature")
+    expect_identical(
+        harmonized@provenance$adapter,
+        "harmonized_temperature"
+    )
+})
+
 test_that("paper-faithful diagnostics retain pressure and union row masks", {
     template <- epwphys_test__weather(3L)
     template$relative_humidity[[1L]] <- 120


### PR DESCRIPTION
## Summary

- Gives temperature-only weather methods one shared entry into the EPW physical-policy layer.
- Preserves method-specific policy selection, diagnostics, settings, provenance identity, and result schemas.

## Changes

- Adds internal `epwphys__apply_temperature()` for the common temperature candidate request and policy execution.
- Routes the shared Daily/BTWS/Eames component and the Arima and Ek adapters through that entry point.
- Keeps Sobie-Curry's multivariable physical request explicit and writes existing diagnostic columns with one direct `data.table::set()` call.
- Adds policy-level regression coverage for paper-faithful and harmonized temperature candidates.
- Closes #235.
