### PR TITLE
fix: discover variable-specific CMIP6 tables

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -470,6 +470,14 @@
 
 ## Bug fixes
 
+* `shift_cmip6_avail(table = NULL)` now discovers one CMIP6 table per variable
+  at the requested frequency instead of constraining every variable to the
+  frequency-default table. Complete rows return a named `table` mapping that
+  can be passed directly to `shift_cmip6()`, while the reduction keeps each
+  variable on one table across all requested experiments. `member = NULL` is
+  now the default, so every returned member is evaluated independently without
+  a preferred variant label (#242).
+
 * `extract retry` and `morph retry` now filter candidates by the requested
   status instead of resolving the selector as the candidate table's `status`
   column. Their shared status validation and preview preparation retain each

--- a/R/cmip6-availability.R
+++ b/R/cmip6-availability.R
@@ -34,11 +34,10 @@ availability__coalesce_character <- function(...) {
 # Normalize provider Dataset records to the identity fields used by the
 # availability reduction and reapply requested filters defensively.
 availability__normalize_datasets <- function(datasets, experiments, variables,
-                                             frequency, table) {
+                                             frequency, tables = NULL) {
     checkmate::assert_data_frame(datasets)
     catalog <- data.table::as.data.table(data.table::copy(datasets))
     wanted_frequency <- frequency[[1L]]
-    wanted_table <- table[[1L]]
 
     catalog[["source_id"]] <- availability__character_column(
         catalog, "source_id")
@@ -71,10 +70,53 @@ availability__normalize_datasets <- function(datasets, experiments, variables,
         complete_identity &
             experiment_id %in% experiments &
             variable_id %in% variables &
-            frequency == wanted_frequency &
-            table_id == wanted_table
+            frequency == wanted_frequency
     ]
-    unique(catalog[, ..identity_fields])
+    if (!is.null(tables) && nrow(catalog)) {
+        # An explicit table specification is variable-specific. Compare each
+        # row with its variable's resolved table instead of accepting any of
+        # the tables used elsewhere in the request.
+        selected_tables <- unname(tables[catalog$variable_id])
+        catalog <- catalog[catalog$table_id == selected_tables]
+    }
+    unique(catalog[, identity_fields, with = FALSE])
+}
+
+# Choose one table for every variable within a stable model/member/grid
+# identity. Coverage across requested experiments is preferred, followed by
+# the frequency's conventional table and then a lexical tie-break.
+availability__select_tables <- function(catalog, variables, frequency,
+                                        tables = NULL) {
+    if (!is.null(tables)) {
+        return(tables)
+    }
+
+    selected <- stats::setNames(rep(NA_character_, length(variables)), variables)
+    preferred_table <- shift__cmip6_table_id(frequency)
+    for (target_variable in variables) {
+        data <- catalog[variable_id == target_variable]
+        if (!nrow(data)) {
+            next
+        }
+        scores <- unique(data[, .(experiment_id, table_id)])[
+            , .(coverage = data.table::uniqueN(experiment_id)), by = table_id
+        ]
+        if (is.null(preferred_table)) {
+            scores[["preferred"]] <- 1L
+        } else {
+            scores[["preferred"]] <- as.integer(
+                scores$table_id != preferred_table
+            )
+        }
+        data.table::setorderv(
+            scores,
+            c("coverage", "preferred", "table_id"),
+            c(-1L, 1L, 1L),
+            na.last = TRUE
+        )
+        selected[[target_variable]] <- scores$table_id[[1L]]
+    }
+    selected
 }
 
 # Return a typed empty availability table with the public column contract.
@@ -85,6 +127,7 @@ availability__empty <- function() {
         grid_label = character(),
         frequency = character(),
         table_id = character(),
+        table = I(vector("list", 0L)),
         complete = logical(),
         complete_experiments = integer(),
         required_experiments = integer(),
@@ -99,59 +142,80 @@ availability__empty <- function() {
 # Reduce variable-specific Dataset records to one row per stable CMIP6 identity.
 availability__summarize <- function(datasets, experiments, variables,
                                     frequency, table, index_node) {
+    table <- shift__cmip6_table_spec(table)
+    tables <- if (is.null(table)) {
+        NULL
+    } else {
+        shift__cmip6_variable_tables(variables, frequency, table)
+    }
     catalog <- availability__normalize_datasets(
         datasets,
         experiments = experiments,
         variables = variables,
         frequency = frequency,
-        table = table
+        tables = tables
     )
     if (!nrow(catalog)) {
         return(availability__empty())
     }
 
     identity_fields <- c(
-        "source_id", "variant_label", "grid_label", "frequency", "table_id"
+        "source_id", "variant_label", "grid_label", "frequency"
     )
-    identities <- unique(catalog[, ..identity_fields])
-    identities[, availability_join_key := 1L]
+    identities <- unique(catalog[, identity_fields, with = FALSE])
     required <- data.table::CJ(
         experiment_id = as.character(experiments),
         variable_id = as.character(variables),
         unique = TRUE
     )
-    required[, availability_join_key := 1L]
-    targets <- merge(
-        identities,
-        required,
-        by = "availability_join_key",
-        allow.cartesian = TRUE,
-        sort = FALSE
-    )
-    targets[, availability_join_key := NULL]
 
-    observed <- unique(catalog[
-        ,
-        c(identity_fields, "experiment_id", "variable_id"),
-        with = FALSE
-    ])
-    observed[, present := TRUE]
-    coverage <- observed[
-        targets,
-        on = c(identity_fields, "experiment_id", "variable_id")
-    ]
-    coverage[is.na(present), present := FALSE]
-
-    summary <- coverage[, {
-        missing_rows <- .SD[!present]
-        experiment_status <- .SD[, .(complete = all(present)),
+    rows <- vector("list", nrow(identities))
+    for (identity_index in seq_len(nrow(identities))) {
+        identity <- identities[identity_index]
+        identity_catalog <- catalog[
+            source_id == identity$source_id[[1L]] &
+                variant_label == identity$variant_label[[1L]] &
+                grid_label == identity$grid_label[[1L]] &
+                frequency == identity$frequency[[1L]]
+        ]
+        selected_tables <- availability__select_tables(
+            identity_catalog,
+            variables = variables,
+            frequency = frequency,
+            tables = tables
+        )
+        # A variable must use the same selected table in every experiment;
+        # records split across tables cannot be combined into false coverage.
+        wanted_tables <- unname(selected_tables[identity_catalog$variable_id])
+        observed <- unique(identity_catalog[
+            table_id == wanted_tables,
+            .(experiment_id, variable_id)
+        ])
+        observed[, present := TRUE]
+        coverage <- observed[required, on = c("experiment_id", "variable_id")]
+        coverage[is.na(present), present := FALSE]
+        missing_rows <- coverage[present == FALSE]
+        experiment_status <- coverage[, .(complete = all(present)),
             by = experiment_id]
-        list(
-            complete = all(present),
+        display_tables <- sort(unique(unname(selected_tables)))
+        display_tables <- display_tables[
+            !is.na(display_tables) & nzchar(display_tables)
+        ]
+
+        rows[[identity_index]] <- data.table::data.table(
+            source_id = identity$source_id[[1L]],
+            variant_label = identity$variant_label[[1L]],
+            grid_label = identity$grid_label[[1L]],
+            frequency = identity$frequency[[1L]],
+            table_id = paste(display_tables, collapse = "+"),
+            table = list(selected_tables),
+            complete = all(coverage$present),
             complete_experiments = sum(experiment_status$complete),
-            required_experiments = data.table::uniqueN(experiment_id),
-            available_pairs = sum(present),
-            required_pairs = .N,
+            required_experiments = data.table::uniqueN(
+                coverage$experiment_id
+            ),
+            available_pairs = sum(coverage$present),
+            required_pairs = nrow(coverage),
             missing = if (nrow(missing_rows)) {
                 paste(
                     sprintf(
@@ -165,7 +229,8 @@ availability__summarize <- function(datasets, experiments, variables,
                 NA_character_
             }
         )
-    }, by = identity_fields]
+    }
+    summary <- data.table::rbindlist(rows, use.names = TRUE, fill = TRUE)
     summary[, index_node := rep(index_node, .N)]
     data.table::setorderv(
         summary,
@@ -217,12 +282,14 @@ availability__index_node <- function(index_node) {
 #'   requested variables for the `"historical"` experiment.
 #' @param source Optional CMIP6 source/model IDs. `NULL` leaves the source
 #'   unconstrained and discovers all matching models.
-#' @param member Optional CMIP6 variant labels. The default limits discovery to
-#'   the first realization; use `NULL` to inspect every returned member.
+#' @param member Optional CMIP6 variant labels. `NULL`, the default, discovers
+#'   every returned member and evaluates each identity independently.
 #' @param grid Optional single CMIP6 grid label.
 #' @param frequency CMIP6 frequency. Defaults to daily data.
-#' @param table Optional single CMIP6 table ID. `NULL` infers the usual table
-#'   from `frequency`, for example `"day"` for daily data.
+#' @param table Optional CMIP6 table selection. `NULL` discovers a table for
+#'   each variable at the requested frequency. An unnamed scalar pins every
+#'   variable to one table. A named character vector or list overrides the
+#'   named variables and leaves the remainder on their frequency defaults.
 #' @param activity Future CMIP6 activity ID.
 #' @param historical_activity Historical CMIP6 activity ID.
 #' @param index_node ESGF index-node name or URL. Names are matched
@@ -234,9 +301,12 @@ availability__index_node <- function(index_node) {
 #' @param store Optional [EsgStore] or store path used by [shift_datasets()].
 #' @param ui Optional shift UI configuration forwarded to [shift_datasets()].
 #'
-#' @return A data frame with one row per model/member/grid/table identity.
+#' @return A data frame with one row per model/member/grid identity.
 #'   `complete` is `TRUE` only when every requested experiment-variable pair is
-#'   present. `missing` lists absent pairs as `experiment:variable`.
+#'   present. For complete rows, `table` is a list-column containing the named
+#'   per-variable table selection accepted by [shift_cmip6()]. Incomplete rows
+#'   use `NA` for variables with no available table. `table_id` is the compact
+#'   display value, and `missing` lists absent pairs as `experiment:variable`.
 #'
 #' @details
 #' This function reports Dataset metadata availability. It does not download
@@ -259,7 +329,7 @@ shift_cmip6_avail <- function(
     scenarios = c("ssp245", "ssp585"),
     include_historical = TRUE,
     source = NULL,
-    member = "r1i1p1f1",
+    member = NULL,
     grid = NULL,
     frequency = "day",
     table = NULL,
@@ -284,20 +354,17 @@ shift_cmip6_avail <- function(
         null.ok = TRUE)
     checkmate::assert_string(grid, min.chars = 1L, null.ok = TRUE)
     checkmate::assert_string(frequency, min.chars = 1L)
-    checkmate::assert_string(table, min.chars = 1L, null.ok = TRUE)
+    table <- shift__cmip6_table_spec(table)
     checkmate::assert_string(activity, min.chars = 1L)
     checkmate::assert_string(historical_activity, min.chars = 1L)
     checkmate::assert_string(index_node, min.chars = 1L, null.ok = TRUE)
     checkmate::assert_string(data_node, min.chars = 1L, null.ok = TRUE)
     checkmate::assert_list(filters, names = "unique")
 
-    if (is.null(table)) {
-        table <- shift__cmip6_table_id(frequency)
-        if (is.null(table)) {
-            cli::cli_abort(
-                "Cannot infer a CMIP6 table for frequency {.val {frequency}}; set `table` explicitly."
-            )
-        }
+    tables <- if (is.null(table)) {
+        NULL
+    } else {
+        shift__cmip6_variable_tables(variables, frequency, table)
     }
     index_node <- availability__index_node(index_node)
     experiments <- unique(c(
@@ -309,11 +376,14 @@ shift_cmip6_avail <- function(
         if (isTRUE(include_historical)) historical_activity
     ))
 
+    # `table = NULL` is the public all-table discovery form, so an additional
+    # filter cannot silently restore the former single-table behaviour.
+    filters$table_id <- NULL
     # Reapply these core constraints after user filters so the returned table
     # always describes the function arguments printed in its rows.
     query_filters <- utils::modifyList(filters, shift__compact_list(list(
         activity_id = activities,
-        table_id = table,
+        table_id = if (is.null(tables)) NULL else unique(unname(tables)),
         grid_label = grid,
         data_node = data_node,
         latest = TRUE,

--- a/man/shift_cmip6_avail.Rd
+++ b/man/shift_cmip6_avail.Rd
@@ -9,7 +9,7 @@ shift_cmip6_avail(
   scenarios = c("ssp245", "ssp585"),
   include_historical = TRUE,
   source = NULL,
-  member = "r1i1p1f1",
+  member = NULL,
   grid = NULL,
   frequency = "day",
   table = NULL,
@@ -33,15 +33,17 @@ requested variables for the \code{"historical"} experiment.}
 \item{source}{Optional CMIP6 source/model IDs. \code{NULL} leaves the source
 unconstrained and discovers all matching models.}
 
-\item{member}{Optional CMIP6 variant labels. The default limits discovery to
-the first realization; use \code{NULL} to inspect every returned member.}
+\item{member}{Optional CMIP6 variant labels. \code{NULL}, the default, discovers
+every returned member and evaluates each identity independently.}
 
 \item{grid}{Optional single CMIP6 grid label.}
 
 \item{frequency}{CMIP6 frequency. Defaults to daily data.}
 
-\item{table}{Optional single CMIP6 table ID. \code{NULL} infers the usual table
-from \code{frequency}, for example \code{"day"} for daily data.}
+\item{table}{Optional CMIP6 table selection. \code{NULL} discovers a table for
+each variable at the requested frequency. An unnamed scalar pins every
+variable to one table. A named character vector or list overrides the
+named variables and leaves the remainder on their frequency defaults.}
 
 \item{activity}{Future CMIP6 activity ID.}
 
@@ -61,9 +63,12 @@ precedence when names overlap.}
 \item{ui}{Optional shift UI configuration forwarded to \code{\link[=shift_datasets]{shift_datasets()}}.}
 }
 \value{
-A data frame with one row per model/member/grid/table identity.
+A data frame with one row per model/member/grid identity.
 \code{complete} is \code{TRUE} only when every requested experiment-variable pair is
-present. \code{missing} lists absent pairs as \code{experiment:variable}.
+present. For complete rows, \code{table} is a list-column containing the named
+per-variable table selection accepted by \code{\link[=shift_cmip6]{shift_cmip6()}}. Incomplete rows
+use \code{NA} for variables with no available table. \code{table_id} is the compact
+display value, and \code{missing} lists absent pairs as \code{experiment:variable}.
 }
 \description{
 Query CMIP6 Dataset metadata and identify model/member/grid identities that

--- a/tests/testthat/test-cmip6-availability.R
+++ b/tests/testthat/test-cmip6-availability.R
@@ -1,6 +1,7 @@
 # Build variable-specific Dataset rows for deterministic availability tests.
 availability_test__datasets <- function(source, experiment, variables,
-                                        member = "r1i1p1f1", grid = "gn") {
+                                        member = "r1i1p1f1", grid = "gn",
+                                        frequency = "day", table = "day") {
     data.table::rbindlist(lapply(variables, function(variable) {
         data.table::data.table(
             id = sprintf(
@@ -10,8 +11,8 @@ availability_test__datasets <- function(source, experiment, variables,
             source_id = source,
             experiment_id = experiment,
             member_id = member,
-            frequency = "day",
-            table_id = "day",
+            frequency = frequency,
+            table_id = table,
             variable_id = variable,
             grid_label = grid,
             latest = TRUE,
@@ -49,6 +50,79 @@ test_that("availability reduction requires every experiment-variable pair", {
     expect_equal(summary$complete_experiments, c(3L, 2L))
     expect_equal(summary$available_pairs, c(9L, 8L))
     expect_equal(summary$missing[[2L]], "ssp585:pr")
+    expect_identical(
+        summary$table[[1L]],
+        stats::setNames(rep("day", length(variables)), variables)
+    )
+})
+
+test_that("availability discovers one table per variable", {
+    experiments <- c("ssp585", "historical")
+    datasets <- data.table::rbindlist(list(
+        availability_test__datasets(
+            "Model-A", experiments[[1L]], "tas",
+            frequency = "3hr", table = "3hr"
+        ),
+        availability_test__datasets(
+            "Model-A", experiments[[2L]], "tas",
+            frequency = "3hr", table = "3hr"
+        ),
+        availability_test__datasets(
+            "Model-A", experiments[[1L]], "uas",
+            frequency = "3hr", table = "E3hr"
+        ),
+        availability_test__datasets(
+            "Model-A", experiments[[2L]], "uas",
+            frequency = "3hr", table = "E3hr"
+        )
+    ))
+    summary <- availability__summarize(
+        datasets,
+        experiments = experiments,
+        variables = c("tas", "uas"),
+        frequency = "3hr",
+        table = NULL,
+        index_node = "https://example.org/esg-search"
+    )
+
+    expect_true(summary$complete[[1L]])
+    expect_identical(summary$table_id[[1L]], "3hr+E3hr")
+    expect_identical(
+        summary$table[[1L]],
+        c(tas = "3hr", uas = "E3hr")
+    )
+    climate <- shift_cmip6(
+        model = summary$source_id[[1L]],
+        scenarios = "ssp585",
+        frequency = "3hr",
+        table = summary$table[[1L]]
+    )
+    expect_identical(climate@table, summary$table[[1L]])
+})
+
+test_that("availability does not combine one variable across tables", {
+    datasets <- data.table::rbindlist(list(
+        availability_test__datasets(
+            "Model-A", "historical", "tas",
+            frequency = "3hr", table = "3hr"
+        ),
+        availability_test__datasets(
+            "Model-A", "ssp585", "tas",
+            frequency = "3hr", table = "E3hr"
+        )
+    ))
+    summary <- availability__summarize(
+        datasets,
+        experiments = c("ssp585", "historical"),
+        variables = "tas",
+        frequency = "3hr",
+        table = NULL,
+        index_node = "https://example.org/esg-search"
+    )
+
+    expect_false(summary$complete[[1L]])
+    expect_identical(summary$table[[1L]], c(tas = "3hr"))
+    expect_identical(summary$missing[[1L]], "ssp585:tas")
 })
 
 test_that("availability identities do not combine members or grids", {
@@ -107,6 +181,7 @@ test_that("shift_cmip6_avail builds an unconstrained Dataset query", {
         source = NULL,
         frequency = "day",
         index_node = "https://example.org/esg-search",
+        filters = list(table_id = "Amon"),
         store = "availability-store",
         ui = "availability-ui"
     )
@@ -114,16 +189,84 @@ test_that("shift_cmip6_avail builds an unconstrained Dataset query", {
 
     expect_true(result$complete[[1L]])
     expect_null(request@meta$source)
+    expect_null(request@meta$variant)
     expect_equal(request@meta$experiment, c("ssp245", "historical"))
     expect_equal(request@meta$variables, c("tas", "pr"))
     expect_equal(request@meta$frequency, "day")
-    expect_equal(request@meta$filters$table_id, "day")
+    expect_null(request@meta$filters$table_id)
     expect_equal(
         request@meta$filters$activity_id,
         c("ScenarioMIP", "CMIP")
     )
     expect_identical(calls$store, "availability-store")
     expect_identical(calls$ui, "availability-ui")
+})
+
+test_that("availability discovers every member without a preferred label", {
+    calls <- new.env(parent = emptyenv())
+    datasets <- data.table::rbindlist(list(
+        availability_test__datasets(
+            "Model-A", "ssp585", "tas", member = "r1i1p1f1"
+        ),
+        availability_test__datasets(
+            "Model-A", "ssp585", c("tas", "pr"), member = "r2i1p1f1"
+        )
+    ))
+    local_mocked_bindings(
+        availability__collect = function(request, store, ui) {
+            calls$request <- request
+            datasets
+        },
+        .package = "epwshiftr"
+    )
+
+    result <- shift_cmip6_avail(
+        variables = c("tas", "pr"),
+        scenarios = "ssp585",
+        include_historical = FALSE,
+        index_node = "https://example.org/esg-search"
+    )
+
+    expect_null(calls$request@meta$variant)
+    expect_identical(result$variant_label, c("r2i1p1f1", "r1i1p1f1"))
+    expect_identical(result$complete, c(TRUE, FALSE))
+})
+
+test_that("availability accepts named table overrides", {
+    calls <- new.env(parent = emptyenv())
+    datasets <- data.table::rbindlist(list(
+        availability_test__datasets(
+            "Model-A", "ssp585", "tas",
+            frequency = "3hr", table = "3hr"
+        ),
+        availability_test__datasets(
+            "Model-A", "ssp585", "uas",
+            frequency = "3hr", table = "E3hr"
+        )
+    ))
+    local_mocked_bindings(
+        availability__collect = function(request, store, ui) {
+            calls$request <- request
+            datasets
+        },
+        .package = "epwshiftr"
+    )
+
+    result <- shift_cmip6_avail(
+        variables = c("tas", "uas"),
+        scenarios = "ssp585",
+        include_historical = FALSE,
+        frequency = "3hr",
+        table = c(uas = "E3hr"),
+        index_node = "https://example.org/esg-search"
+    )
+
+    expect_true(result$complete[[1L]])
+    expect_setequal(
+        calls$request@meta$filters$table_id,
+        c("3hr", "E3hr")
+    )
+    expect_identical(result$table[[1L]], c(tas = "3hr", uas = "E3hr"))
 })
 
 test_that("shift_cmip6_avail supports the named ORNL Bridge endpoint", {
@@ -184,18 +327,32 @@ test_that("availability can omit historical and returns a typed empty table", {
     expect_s3_class(result, "data.frame")
     expect_equal(nrow(result), 0L)
     expect_named(result, names(availability__empty()))
+    expect_type(result$table, "list")
     expect_equal(calls$request@meta$experiment, "ssp585")
     expect_equal(calls$request@meta$filters$activity_id, "ScenarioMIP")
 })
 
-test_that("availability requires an explicit table for unknown frequencies", {
-    expect_error(
-        shift_cmip6_avail(
-            variables = "tas",
-            scenarios = "ssp585",
-            frequency = "fx",
-            index_node = "https://example.org/esg-search"
-        ),
-        "set `table` explicitly"
+test_that("availability can discover tables for frequencies without defaults", {
+    calls <- new.env(parent = emptyenv())
+    local_mocked_bindings(
+        availability__collect = function(request, store, ui) {
+            calls$request <- request
+            availability_test__datasets(
+                "Model-A", "ssp585", "orog",
+                frequency = "fx", table = "fx"
+            )
+        },
+        .package = "epwshiftr"
     )
+    result <- shift_cmip6_avail(
+        variables = "orog",
+        scenarios = "ssp585",
+        include_historical = FALSE,
+        frequency = "fx",
+        index_node = "https://example.org/esg-search"
+    )
+
+    expect_true(result$complete[[1L]])
+    expect_null(calls$request@meta$filters$table_id)
+    expect_identical(result$table[[1L]], c(orog = "fx"))
 })

--- a/vignettes-raw/articles/epw-morpher.Rmd
+++ b/vignettes-raw/articles/epw-morpher.Rmd
@@ -198,6 +198,13 @@ seven-variable combination for both experiments, even though the published
 workflow used model-specific additions and fallbacks documented in its
 supplementary methods.
 
+Leaving `table = NULL` searches every CMIP6 table at the requested frequency.
+The availability reduction selects one table per variable within each
+model/member/grid identity and returns that named mapping in the `table`
+list-column. Pass the mapping to `shift_cmip6()` so the download request uses
+the same variable-specific selection; `table_id` is only its compact display
+value.
+
 ```r
 hourly_availability <- shift_cmip6_avail(
     variables = c(
@@ -206,7 +213,6 @@ hourly_availability <- shift_cmip6_avail(
     scenarios = "ssp585",
     member = NULL,
     frequency = "3hr",
-    table = "3hr",
     index_node = "ORNL"
 )
 available_hourly <- subset(hourly_availability, complete)
@@ -227,7 +233,7 @@ if (nrow(available_hourly)) {
         member = selected$variant_label,
         grid = selected$grid_label,
         frequency = "3hr",
-        table = selected$table_id
+        table = selected$table[[1L]]
     )
 
     hourly_plan <- shift_future_epw(

--- a/vignettes-raw/precompiled-checksums.csv
+++ b/vignettes-raw/precompiled-checksums.csv
@@ -1,7 +1,7 @@
 "source","output","source_md5","output_md5"
 "vignettes-raw/articles/cli-esgf-store.Rmd","vignettes/articles/cli-esgf-store.Rmd","cac788f79010ad56496939cdde3580bb","e58e5cafa0d3b2218081c25a1098273f"
 "vignettes-raw/articles/downloader.Rmd","vignettes/articles/downloader.Rmd","9668ccb5b39f0ca2f49e146a1a100a7c","4b67e4a9ddaecfe7ce3ac268936e2a2d"
-"vignettes-raw/articles/epw-morpher.Rmd","vignettes/articles/epw-morpher.Rmd","fea9dee592a954ad4484a8d461c163ec","29d42ee258a7409a7b0f079bbde070c8"
+"vignettes-raw/articles/epw-morpher.Rmd","vignettes/articles/epw-morpher.Rmd","829f5b5d4397cd796264aed46764b2a6","8d4eff856eceb09f7ceee1b482b9c7b5"
 "vignettes-raw/articles/esg-dictionaries.Rmd","vignettes/articles/esg-dictionaries.Rmd","94eb2513975549a6765afa221a2e10c1","290348d35a29e925f1b3732586e54cfb"
 "vignettes-raw/articles/esg-store.Rmd","vignettes/articles/esg-store.Rmd","c2d810261308c837b84c803a0d2632c5","bb73ddac53598a36b049797782ce3c02"
 "vignettes-raw/articles/esgf-query-results.Rmd","vignettes/articles/esgf-query-results.Rmd","9cb7e909ecc499eba79e4295857101d1","20854ab68644b18addeefcef1baafcfa"

--- a/vignettes/articles/epw-morpher.Rmd
+++ b/vignettes/articles/epw-morpher.Rmd
@@ -206,6 +206,13 @@ seven-variable combination for both experiments, even though the published
 workflow used model-specific additions and fallbacks documented in its
 supplementary methods.
 
+Leaving `table = NULL` searches every CMIP6 table at the requested frequency.
+The availability reduction selects one table per variable within each
+model/member/grid identity and returns that named mapping in the `table`
+list-column. Pass the mapping to `shift_cmip6()` so the download request uses
+the same variable-specific selection; `table_id` is only its compact display
+value.
+
 ```r
 hourly_availability <- shift_cmip6_avail(
     variables = c(
@@ -214,7 +221,6 @@ hourly_availability <- shift_cmip6_avail(
     scenarios = "ssp585",
     member = NULL,
     frequency = "3hr",
-    table = "3hr",
     index_node = "ORNL"
 )
 available_hourly <- subset(hourly_availability, complete)
@@ -235,7 +241,7 @@ if (nrow(available_hourly)) {
         member = selected$variant_label,
         grid = selected$grid_label,
         frequency = "3hr",
-        table = selected$table_id
+        table = selected$table[[1L]]
     )
 
     hourly_plan <- shift_future_epw(


### PR DESCRIPTION
## Summary

- Lets `shift_cmip6_avail()` discover variable-specific CMIP6 tables at one requested frequency.
- Closes #241.

## Changes

- Leaves `table_id` unconstrained when `table = NULL` and retains explicit scalar and named table selections.
- Selects one table per variable using requested-experiment coverage, the frequency default, and a deterministic lexical tie-break.
- Prevents historical and future records for one variable from being combined across different tables.
- Returns a named `table` mapping that complete rows can pass directly to `shift_cmip6()`.
- Discovers every member by default, evaluates members independently, and applies no preferred-member ranking.
- Updates deterministic tests, generated documentation, and the precompiled hourly KQDM article.
