### PR TITLE
fix: support variable-specific CMIP6 frequencies

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -46,6 +46,14 @@
 
 ## New features
 
+* Added variable-specific CMIP6 frequency contracts to availability discovery,
+  persisted workflow selection, component validation, and extraction planning.
+  The hourly kernel-QDM workflow now resolves point-sampled `3hrPt` state and
+  wind fields, interval-mean `3hr` radiation, and optional daily `tasmin` and
+  `tasmax` within one model/member/grid identity. Its internal source manifest
+  records the ten model-member combinations and special treatments reported by
+  Wang et al. (2023) (#244).
+
 * Aligned the experimental `hourly_kernel_qdm()` workflow with the published
   raw-model input boundary: model roles now request `tas`, `ps`, `huss`, `uas`,
   `vas`, `rsds`, and `rsdsdiff`, then derive hourly relative humidity, scalar

--- a/R/backend-hourly-kernel-qdm.R
+++ b/R/backend-hourly-kernel-qdm.R
@@ -14,6 +14,81 @@ EPW_MORPH_HOURLY_KQDM_VARIABLES <- c(
 # canonical signal variables exposed by the backend rules.
 EPW_MORPH_HOURLY_KQDM_MODEL_VARIABLES <- HOURLY_KQDM_MODEL_VARIABLES
 
+# Record the ten model-member identities and archive substitutions reported in
+# Supplementary Table 4 and Supplementary Method 3 of Wang et al. (2023).
+hourly_kqdm__source_manifest <- function() {
+    data.table::data.table(
+        source_id = c(
+            "ACCESS-CM2",
+            "BCC-CSM2-MR",
+            "CanESM5",
+            "CMCC-CM2-SR5",
+            "CMCC-ESM2",
+            "FGOALS-g3",
+            "GISS-E2-1-G",
+            "IITM-ESM",
+            "KACE-1-0-G",
+            "MRI-ESM2-0"
+        ),
+        variant_label = c(
+            "r1i1p1f1",
+            "r1i1p1f1",
+            "r1i1p2f1",
+            "r1i1p1f1",
+            "r1i1p1f1",
+            "r3i1p1f1",
+            "r1i1p1f2",
+            "r1i1p1f1",
+            "r1i1p1f1",
+            "r1i1p1f1"
+        ),
+        nominal_resolution_km = c(
+            250L, 100L, 500L, 100L, 100L,
+            250L, 250L, 250L, 250L, 100L
+        ),
+        published_frequencies = c(
+            "3hr,day",
+            "3hr,day",
+            "3hr,6hr,day",
+            "3hr",
+            "3hr,day",
+            "3hr,6hr,day",
+            "3hr,day",
+            "3hr,6hr,day",
+            "3hr,day",
+            "3hr,day"
+        ),
+        special_treatment = c(
+            NA_character_,
+            NA_character_,
+            paste(
+                "Use 6-hourly ps for ssp245, ssp370, and ssp585",
+                "when 3-hourly ps is unavailable"
+            ),
+            NA_character_,
+            NA_character_,
+            paste(
+                "Use 6-hourly sfcWind plus lowest-model-level ua and va",
+                "to reconstruct wind direction"
+            ),
+            paste(
+                "Correct rsdsdiff after download using the 3-hourly",
+                "cosine of the solar zenith angle"
+            ),
+            paste(
+                "Use psl at the highest available temporal resolution",
+                "and convert it to station surface pressure"
+            ),
+            NA_character_,
+            NA_character_
+        ),
+        reference = rep.int(
+            "https://doi.org/10.1038/s41467-023-41458-5",
+            10L
+        )
+    )
+}
+
 EPW_MORPH_HOURLY_KQDM_METHODS <- c(
     tdb = "kernel_quantile_delta_mapping",
     pressure = "kernel_quantile_delta_mapping",

--- a/R/calendar-subdaily.R
+++ b/R/calendar-subdaily.R
@@ -4,7 +4,9 @@
 # components. Named seconds keep validation independent of timestamp parsing.
 TEMPORAL_SOURCE_STEPS <- c(
     `3hr` = 10800,
-    `6hr` = 21600
+    `3hrPt` = 10800,
+    `6hr` = 21600,
+    `6hrPt` = 21600
 )
 
 # Known identity fields prevent unrelated sites, models, members, periods, or

--- a/R/cmip6-availability.R
+++ b/R/cmip6-availability.R
@@ -37,7 +37,7 @@ availability__normalize_datasets <- function(datasets, experiments, variables,
                                              frequency, tables = NULL) {
     checkmate::assert_data_frame(datasets)
     catalog <- data.table::as.data.table(data.table::copy(datasets))
-    wanted_frequency <- frequency[[1L]]
+    frequencies <- shift__cmip6_variable_frequencies(variables, frequency)
 
     catalog[["source_id"]] <- availability__character_column(
         catalog, "source_id")
@@ -66,6 +66,7 @@ availability__normalize_datasets <- function(datasets, experiments, variables,
             !is.na(catalog[[name]]) & nzchar(catalog[[name]])
         })
     )
+    wanted_frequency <- unname(frequencies[catalog$variable_id])
     catalog <- catalog[
         complete_identity &
             experiment_id %in% experiments &
@@ -91,13 +92,16 @@ availability__select_tables <- function(catalog, variables, frequency,
         return(tables)
     }
 
+    frequencies <- shift__cmip6_variable_frequencies(variables, frequency)
     selected <- stats::setNames(rep(NA_character_, length(variables)), variables)
-    preferred_table <- shift__cmip6_table_id(frequency)
     for (target_variable in variables) {
         data <- catalog[variable_id == target_variable]
         if (!nrow(data)) {
             next
         }
+        preferred_table <- shift__cmip6_table_id(
+            frequencies[[target_variable]]
+        )
         scores <- unique(data[, .(experiment_id, table_id)])[
             , .(coverage = data.table::uniqueN(experiment_id)), by = table_id
         ]
@@ -126,6 +130,7 @@ availability__empty <- function() {
         variant_label = character(),
         grid_label = character(),
         frequency = character(),
+        frequency_spec = I(vector("list", 0L)),
         table_id = character(),
         table = I(vector("list", 0L)),
         complete = logical(),
@@ -142,6 +147,7 @@ availability__empty <- function() {
 # Reduce variable-specific Dataset records to one row per stable CMIP6 identity.
 availability__summarize <- function(datasets, experiments, variables,
                                     frequency, table, index_node) {
+    frequencies <- shift__cmip6_variable_frequencies(variables, frequency)
     table <- shift__cmip6_table_spec(table)
     tables <- if (is.null(table)) {
         NULL
@@ -152,7 +158,7 @@ availability__summarize <- function(datasets, experiments, variables,
         datasets,
         experiments = experiments,
         variables = variables,
-        frequency = frequency,
+        frequency = frequencies,
         tables = tables
     )
     if (!nrow(catalog)) {
@@ -160,7 +166,7 @@ availability__summarize <- function(datasets, experiments, variables,
     }
 
     identity_fields <- c(
-        "source_id", "variant_label", "grid_label", "frequency"
+        "source_id", "variant_label", "grid_label"
     )
     identities <- unique(catalog[, identity_fields, with = FALSE])
     required <- data.table::CJ(
@@ -175,8 +181,7 @@ availability__summarize <- function(datasets, experiments, variables,
         identity_catalog <- catalog[
             source_id == identity$source_id[[1L]] &
                 variant_label == identity$variant_label[[1L]] &
-                grid_label == identity$grid_label[[1L]] &
-                frequency == identity$frequency[[1L]]
+                grid_label == identity$grid_label[[1L]]
         ]
         selected_tables <- availability__select_tables(
             identity_catalog,
@@ -206,7 +211,8 @@ availability__summarize <- function(datasets, experiments, variables,
             source_id = identity$source_id[[1L]],
             variant_label = identity$variant_label[[1L]],
             grid_label = identity$grid_label[[1L]],
-            frequency = identity$frequency[[1L]],
+            frequency = paste(unique(unname(frequencies)), collapse = "+"),
+            frequency_spec = list(frequencies),
             table_id = paste(display_tables, collapse = "+"),
             table = list(selected_tables),
             complete = all(coverage$present),
@@ -285,7 +291,9 @@ availability__index_node <- function(index_node) {
 #' @param member Optional CMIP6 variant labels. `NULL`, the default, discovers
 #'   every returned member and evaluates each identity independently.
 #' @param grid Optional single CMIP6 grid label.
-#' @param frequency CMIP6 frequency. Defaults to daily data.
+#' @param frequency CMIP6 frequency. An unnamed scalar applies to every
+#'   requested variable. A named character vector assigns one frequency to
+#'   every variable, for example `tas = "3hrPt"` and `rsds = "3hr"`.
 #' @param table Optional CMIP6 table selection. `NULL` discovers a table for
 #'   each variable at the requested frequency. An unnamed scalar pins every
 #'   variable to one table. A named character vector or list overrides the
@@ -303,10 +311,11 @@ availability__index_node <- function(index_node) {
 #'
 #' @return A data frame with one row per model/member/grid identity.
 #'   `complete` is `TRUE` only when every requested experiment-variable pair is
-#'   present. For complete rows, `table` is a list-column containing the named
-#'   per-variable table selection accepted by [shift_cmip6()]. Incomplete rows
-#'   use `NA` for variables with no available table. `table_id` is the compact
-#'   display value, and `missing` lists absent pairs as `experiment:variable`.
+#'   present. `frequency_spec` and `table` are list-columns containing named
+#'   per-variable selections accepted by [shift_cmip6()]. Incomplete rows use
+#'   `NA` for variables with no available table. `frequency` and `table_id` are
+#'   compact display values, and `missing` lists absent pairs as
+#'   `experiment:variable`.
 #'
 #' @details
 #' This function reports Dataset metadata availability. It does not download
@@ -353,7 +362,7 @@ shift_cmip6_avail <- function(
         member, any.missing = FALSE, min.len = 1L, unique = TRUE,
         null.ok = TRUE)
     checkmate::assert_string(grid, min.chars = 1L, null.ok = TRUE)
-    checkmate::assert_string(frequency, min.chars = 1L)
+    frequencies <- shift__cmip6_variable_frequencies(variables, frequency)
     table <- shift__cmip6_table_spec(table)
     checkmate::assert_string(activity, min.chars = 1L)
     checkmate::assert_string(historical_activity, min.chars = 1L)
@@ -364,7 +373,7 @@ shift_cmip6_avail <- function(
     tables <- if (is.null(table)) {
         NULL
     } else {
-        shift__cmip6_variable_tables(variables, frequency, table)
+        shift__cmip6_variable_tables(variables, frequencies, table)
     }
     index_node <- availability__index_node(index_node)
     experiments <- unique(c(
@@ -397,7 +406,7 @@ shift_cmip6_avail <- function(
         experiment = experiments,
         variant = member,
         variables = variables,
-        frequency = frequency,
+        frequency = unique(unname(frequencies)),
         filters = query_filters,
         options = list(index_node = index_node)
     )
@@ -406,7 +415,7 @@ shift_cmip6_avail <- function(
         datasets,
         experiments = experiments,
         variables = variables,
-        frequency = frequency,
+        frequency = frequencies,
         table = table,
         index_node = index_node
     )

--- a/R/component-hourly-kqdm-input.R
+++ b/R/component-hourly-kqdm-input.R
@@ -22,6 +22,20 @@ HOURLY_KQDM_MODEL_VARIABLES <- c(
     "rsdsdiff"
 )
 
+# CMIP6 stores instantaneous state and wind fields under `3hrPt`, averaged
+# radiation fluxes under `3hr`, and optional temperature extrema under `day`.
+HOURLY_KQDM_MODEL_FREQUENCIES <- c(
+    tas = "3hrPt",
+    ps = "3hrPt",
+    huss = "3hrPt",
+    uas = "3hrPt",
+    vas = "3hrPt",
+    rsds = "3hr",
+    rsdsdiff = "3hr",
+    tasmin = "day",
+    tasmax = "day"
+)
+
 HOURLY_KQDM_CANONICAL_UNITS <- c(
     tas = "K",
     ps = "Pa",
@@ -292,14 +306,24 @@ hourly_kqdm_input__component <- function() {
             model_historical = component__input_requirement(
                 "model_historical",
                 representations = "series",
-                frequencies = "3hr",
+                frequencies = unique(unname(
+                    HOURLY_KQDM_MODEL_FREQUENCIES
+                )),
+                variable_frequencies = as.list(
+                    HOURLY_KQDM_MODEL_FREQUENCIES
+                ),
                 calendars = CF_TIME_CALENDARS,
                 variable_sets = HOURLY_KQDM_MODEL_VARIABLES
             ),
             model_future = component__input_requirement(
                 "model_future",
                 representations = "series",
-                frequencies = "3hr",
+                frequencies = unique(unname(
+                    HOURLY_KQDM_MODEL_FREQUENCIES
+                )),
+                variable_frequencies = as.list(
+                    HOURLY_KQDM_MODEL_FREQUENCIES
+                ),
                 calendars = CF_TIME_CALENDARS,
                 variable_sets = HOURLY_KQDM_MODEL_VARIABLES
             )
@@ -313,6 +337,7 @@ hourly_kqdm_input__component <- function() {
             algorithm = "raw_model_to_hourly_kqdm_signals",
             references = HOURLY_WEATHER_REFERENCES,
             raw_model_variables = HOURLY_KQDM_MODEL_VARIABLES,
+            variable_frequencies = HOURLY_KQDM_MODEL_FREQUENCIES,
             signal_variables = HOURLY_KQDM_SIGNAL_VARIABLES,
             target_frequency = "hour"
         )

--- a/R/component-hourly-weather-interpolation.R
+++ b/R/component-hourly-weather-interpolation.R
@@ -123,7 +123,7 @@ weather_interp__model_source <- function(input, role) {
         }
     }
     if (length(extrema) &&
-        !identical(frequency_by_variable[["tas"]], "3hr")) {
+        !all(frequency_by_variable[["tas"]] %in% c("3hr", "3hrPt"))) {
         cli::cli_abort(
             "Role {.val {role}} requires three-hourly `tas` when daily extrema anchors are supplied."
         )
@@ -354,7 +354,9 @@ weather_interp__anchors <- function(
     modes,
     role
 ) {
-    if (!identical(unique(as.character(group[["frequency"]])), "3hr") ||
+    source_frequency <- unique(as.character(group[["frequency"]]))
+    if (length(source_frequency) != 1L ||
+        !source_frequency %in% c("3hr", "3hrPt") ||
         !identical(unique(as.character(group[["variable_id"]])), "tas")) {
         return(NULL)
     }

--- a/R/epw-morph-recipe.R
+++ b/R/epw-morph-recipe.R
@@ -121,7 +121,9 @@ morpher__input_variables <- function(recipe) {
     required_inputs <- unique(unlist(requirements, recursive = TRUE, use.names = FALSE))
     if (inherits(recipe, "epw_morph_recipe") &&
         identical(recipe$backend, "hourly_kernel_qdm")) {
-        return(required_inputs)
+        # Daily extrema are optional interpolation anchors and therefore do
+        # not belong to the backend's required-variable alternatives.
+        return(unique(c(required_inputs, HOURLY_WEATHER_EXTREMA_VARIABLES)))
     }
     optional <- epw_morph_variables(recipe, include_optional = TRUE)
     if (inherits(recipe, "epw_morph_recipe") &&
@@ -400,15 +402,18 @@ morpher__recipe_time_padding_seconds <- function(recipe) {
     }
     preprocess <- recipe$components$preprocess
     frequency <- morpher__recipe_required_frequency(recipe)
+    source_frequencies <- intersect(
+        unique(unname(frequency)),
+        names(TEMPORAL_SOURCE_STEPS)
+    )
     if (!preprocess %in% c(
         "hourly_weather_interpolation",
         "hourly_kernel_qdm_input_preparation"
     ) ||
-        is.null(frequency) ||
-        !frequency %in% names(TEMPORAL_SOURCE_STEPS)) {
+        !length(source_frequencies)) {
         return(0)
     }
-    as.numeric(TEMPORAL_SOURCE_STEPS[[frequency]])
+    max(as.numeric(TEMPORAL_SOURCE_STEPS[source_frequencies]))
 }
 
 morpher__recipe_methods <- function(methods = NULL, backend = epw_morph_backend("belcher")) {
@@ -489,19 +494,27 @@ morpher__recipe_accepts_observed_reference <- function(recipe) {
     morpher__recipe_accepts_role(recipe, "observed_reference")
 }
 
-# Return the component-declared CMIP frequency without duplicating that
-# constraint on the backend or staged workflow.
+# Return the component-declared scalar or variable-specific CMIP frequency
+# contract without duplicating it on the backend or staged workflow.
 morpher__recipe_required_frequency <- function(recipe) {
     if (!inherits(recipe, "epw_morph_recipe")) {
         cli::cli_abort("`recipe` must be created by {.fn epw_morph_recipe}.")
     }
     recipe_spec <- morpher__recipe_spec(recipe)
     if (!is.null(recipe_spec)) {
+        variable_frequencies <- recipe__variable_frequencies(recipe_spec)
+        if (length(variable_frequencies)) {
+            return(variable_frequencies)
+        }
         choices <- recipe__frequency_choices(recipe_spec)
     } else {
         spec <- pipeline__from_records(recipe$components)
         if (is.null(spec)) {
             return(NULL)
+        }
+        variable_frequencies <- pipeline__variable_frequencies(spec)
+        if (length(variable_frequencies)) {
+            return(variable_frequencies)
         }
         choices <- pipeline__frequency_choices(spec)
     }
@@ -513,37 +526,67 @@ morpher__recipe_required_frequency <- function(recipe) {
     choices
 }
 
-# Build a structural diagnostic when extracted or summarized climate data do not
-# match a backend's declared CMIP frequency.
+# Build a structural diagnostic when extracted or summarized climate data do
+# not match a backend's scalar or variable-specific CMIP frequency contract.
 morpher__frequency_diagnostic <- function(
-    recipe, frequency, stage, plan_id = NA_character_,
+    recipe, frequency, variable_id = NULL, stage, plan_id = NA_character_,
     summary_id = NA_character_
 ) {
     required <- morpher__recipe_required_frequency(recipe)
     if (is.null(required)) {
         return(morpher__empty_diagnostics())
     }
-    actual <- unique(tolower(as.character(frequency)))
-    actual <- actual[!is.na(actual) & nzchar(actual)]
-    if (identical(actual, required)) {
+    frequency <- as.character(frequency)
+    if (!is.null(names(required))) {
+        variable_id <- as.character(variable_id)
+        if (length(variable_id) != length(frequency)) {
+            actual <- list()
+        } else {
+            keep <- !is.na(variable_id) & nzchar(variable_id) &
+                !is.na(frequency) & nzchar(frequency)
+            actual <- split(frequency[keep], variable_id[keep])
+            actual <- lapply(actual, unique)
+        }
+        checked <- intersect(names(required), names(actual))
+        # Additional materialized variables are validated by their owning
+        # components; this diagnostic checks only the recipe-declared mapping.
+        matches <- length(checked) > 0L &&
+            all(vapply(checked, function(variable) {
+                identical(actual[[variable]], unname(required[[variable]]))
+            }, logical(1L)))
+    } else {
+        actual <- unique(tolower(frequency))
+        actual <- actual[!is.na(actual) & nzchar(actual)]
+        matches <- identical(actual, required)
+    }
+    if (isTRUE(matches)) {
         return(morpher__empty_diagnostics())
     }
-    shown <- if (length(actual)) paste(actual, collapse = ", ") else "<missing>"
+    shown <- if (length(frequency)) {
+        paste(unique(frequency), collapse = ", ")
+    } else {
+        "<missing>"
+    }
+    required_label <- if (is.null(names(required))) {
+        paste(required, collapse = ", ")
+    } else {
+        paste(paste(names(required), required, sep = "="), collapse = ", ")
+    }
     morpher__diagnostic(
         stage = stage,
         severity = "error",
         code = "unsupported_climate_frequency",
         message = sprintf(
-            "Backend %s requires CMIP frequency %s; found %s.",
+            "Backend %s requires CMIP frequencies %s; found %s.",
             recipe$backend,
-            required,
+            required_label,
             shown
         ),
         plan_id = plan_id,
         summary_id = summary_id,
-        action = sprintf(
-            "Extract climate data with frequency %s before morphing.",
-            required
+        action = paste(
+            "Extract climate data with the recipe's variable-specific",
+            "frequency contract before morphing."
         )
     )
 }

--- a/R/epw-morpher.R
+++ b/R/epw-morpher.R
@@ -1879,6 +1879,7 @@ EpwMorpher <- R6::R6Class(
                     } else {
                         character()
                     },
+                    variable_id = coverage$variable_id,
                     stage = "extraction",
                     plan_id = paste(plan_id, collapse = ", ")
                 )
@@ -2024,6 +2025,7 @@ EpwMorpher <- R6::R6Class(
                     } else {
                         character()
                     },
+                    variable_id = climate$variable_id,
                     stage = "climate_summary",
                     summary_id = summary_id
                 )

--- a/R/shift-stage.R
+++ b/R/shift-stage.R
@@ -207,7 +207,7 @@ ShiftCmip6Spec <- S7::new_class(
         scenarios = S7::new_property(S7::class_character),
         member = S7::new_property(S7::class_any, default = NULL),
         grid = S7::new_property(S7::class_any, default = NULL),
-        frequency = shift_prop_string(min.chars = 1L),
+        frequency = S7::new_property(S7::class_character),
         table = S7::new_property(S7::class_any, default = NULL),
         activity = shift_prop_string(min.chars = 1L),
         index_nodes = S7::new_property(S7::class_character),
@@ -1374,9 +1374,89 @@ shift__cmip6_table_id <- function(frequency) {
         mon = "Amon",
         day = "day",
         `3hr` = "3hr",
+        `3hrPt` = "3hr",
         `6hr` = "6hr",
+        `6hrPt` = "6hr",
         NULL
     )
+}
+
+# Validate scalar and variable-specific CMIP6 frequency specifications without
+# discarding names that are needed after a broad multi-frequency ESGF query.
+shift__cmip6_frequency_spec <- function(frequency, variables = NULL) {
+    if (is.list(frequency)) {
+        if (is.null(names(frequency)) || anyNA(names(frequency)) ||
+            any(!nzchar(names(frequency)))) {
+            cli::cli_abort(
+                "A list supplied as `frequency` must name every variable."
+            )
+        }
+        frequency <- vapply(frequency, function(value) {
+            checkmate::assert_string(value, min.chars = 1L)
+            value
+        }, character(1L))
+    }
+    checkmate::assert_character(
+        frequency,
+        any.missing = FALSE,
+        min.len = 1L
+    )
+    frequency_names <- names(frequency)
+    frequency <- as.character(frequency)
+    names(frequency) <- frequency_names
+    if (!is.null(frequency_names) && anyNA(frequency_names)) {
+        cli::cli_abort(
+            "A variable-specific `frequency` vector cannot have missing names."
+        )
+    }
+    named <- !is.null(frequency_names) && any(nzchar(frequency_names))
+    if (!isTRUE(named)) {
+        if (length(frequency) != 1L) {
+            cli::cli_abort(
+                "An unnamed `frequency` value must contain one CMIP6 frequency."
+            )
+        }
+        names(frequency) <- NULL
+        return(frequency)
+    }
+    if (any(!nzchar(frequency_names)) || anyDuplicated(frequency_names)) {
+        cli::cli_abort(
+            "A variable-specific `frequency` vector must have unique, non-empty variable names."
+        )
+    }
+    if (!is.null(variables)) {
+        variables <- unique(as.character(variables))
+        unknown <- setdiff(frequency_names, variables)
+        missing <- setdiff(variables, frequency_names)
+        if (length(unknown)) {
+            cli::cli_abort(
+                "`frequency` contains variable(s) not used by the request: {.val {unknown}}."
+            )
+        }
+        if (length(missing)) {
+            cli::cli_abort(
+                "`frequency` must specify every requested variable; missing {.val {missing}}."
+            )
+        }
+        frequency <- frequency[variables]
+    }
+    frequency
+}
+
+# Expand one scalar CMIP6 frequency or retain an explicit variable mapping so
+# downstream table selection and File coverage use the same source semantics.
+shift__cmip6_variable_frequencies <- function(variables, frequency) {
+    variables <- unique(as.character(variables))
+    checkmate::assert_character(
+        variables,
+        any.missing = FALSE,
+        min.len = 1L
+    )
+    frequency <- shift__cmip6_frequency_spec(frequency, variables)
+    if (is.null(names(frequency))) {
+        return(stats::setNames(rep(frequency[[1L]], length(variables)), variables))
+    }
+    frequency
 }
 
 # Validate the two supported table-selection forms. An unnamed scalar pins all
@@ -1422,12 +1502,18 @@ shift__cmip6_variable_tables <- function(variables, frequency, table = NULL) {
     variables <- unique(as.character(variables))
     checkmate::assert_character(variables, any.missing = FALSE, min.len = 1L)
     table <- shift__cmip6_table_spec(table)
-    default <- shift__cmip6_table_id(frequency)
-    if (is.null(default)) {
-        cli::cli_abort("Cannot infer a CMIP6 table for frequency {.val {frequency}}; set `table` explicitly.")
+    frequencies <- shift__cmip6_variable_frequencies(variables, frequency)
+    defaults <- vapply(frequencies, function(value) {
+        shift_coalesce(shift__cmip6_table_id(value), NA_character_)
+    }, character(1L))
+    unresolved <- names(defaults)[is.na(defaults)]
+    if (length(unresolved) && is.null(table)) {
+        cli::cli_abort(
+            "Cannot infer a CMIP6 table for variable(s) {.val {unresolved}}; set `table` explicitly."
+        )
     }
-    out <- stats::setNames(rep(default, length(variables)), variables)
-    if (identical(as.character(frequency)[[1L]], "mon") && "snd" %in% variables) {
+    out <- defaults
+    if ("snd" %in% variables && identical(frequencies[["snd"]], "mon")) {
         out[["snd"]] <- "LImon"
     }
     if (is.null(table)) {
@@ -1442,7 +1528,22 @@ shift__cmip6_variable_tables <- function(variables, frequency, table = NULL) {
         cli::cli_abort("`table` contains override(s) for variables not used by the recipe: {.val {unknown}}.")
     }
     out[names(table)] <- unname(table)
+    if (anyNA(out)) {
+        unresolved <- names(out)[is.na(out)]
+        cli::cli_abort(
+            "`table` must specify variable(s) whose CMIP6 table cannot be inferred: {.val {unresolved}}."
+        )
+    }
     out
+}
+
+# Interpret one direct request table as a pin, while treating a multi-table
+# query filter as discovery breadth whose variable mapping must be inferred.
+shift__cmip6_request_table_spec <- function(table_id) {
+    if (is.null(table_id) || length(table_id) != 1L) {
+        return(NULL)
+    }
+    table_id
 }
 
 # Collapse a possibly long vector into a stable console summary while retaining
@@ -1660,6 +1761,9 @@ shift_resolve_epw <- function(x) {
 #' @param project Optional provider project, for example `"CMIP6"`.
 #' @param source,experiment,variant,frequency Provider-neutral request fields.
 #'   Values must use the selected provider's controlled vocabulary.
+#'   In `shift_cmip6()`, an unnamed scalar `frequency` applies to every recipe
+#'   input, while a named character vector assigns one frequency to every
+#'   source variable so `3hrPt`, `3hr`, and `day` data can be collected together.
 #'   In `shift_reference_historical()`, `experiment` is the historical
 #'   reference experiment filter. Values are not translated; for ESGF, use
 #'   exact facet values such as `project = "CMIP6"` and `frequency = "mon"`.
@@ -2109,9 +2213,11 @@ arima_temperature <- function(
 #' @description
 #' `hourly_kernel_qdm()` creates a complete multi-year future-weather method
 #' from matching three-hourly historical and future model data plus an hourly
-#' observed reference. Model roles require raw `tas`, `ps`, `huss`, `uas`,
-#' `vas`, `rsds`, and `rsdsdiff`; the observed role requires `tas`, `ps`,
-#' `hurs`, `sfcWind`, `rsds`, and `rsdsdiff`.
+#' observed reference. CMIP6 model roles require point-sampled `3hrPt` `tas`,
+#' `ps`, `huss`, `uas`, and `vas`, together with interval-mean `3hr` `rsds`
+#' and `rsdsdiff`. Daily `tasmin` and `tasmax` are optional interpolation
+#' anchors. The observed role requires `tas`, `ps`, `hurs`, `sfcWind`, `rsds`,
+#' and `rsdsdiff`.
 #'
 #' Continuous model state variables and wind-vector components are interpolated
 #' to an hourly lattice. Relative humidity is derived from `huss`, `tas`, and
@@ -2131,7 +2237,8 @@ arima_temperature <- function(
 #'
 #' @param reference A required [historical_reference()],
 #'   [shift_reference_plan()], or extracted `ShiftClimate` stage containing
-#'   matching three-hourly historical model output.
+#'   matching variable-specific `3hrPt`, `3hr`, and optional daily historical
+#'   model output.
 #' @param observed_reference A required [shift_reference_plan()] or extracted
 #'   `ShiftClimate` stage containing hourly observed weather.
 #' @param signal_overrides Optional named list of variable-specific kernel-QDM
@@ -2230,7 +2337,7 @@ shift_cmip6 <- function(model, scenarios, member = NULL, grid = NULL,
     checkmate::assert_character(scenarios, any.missing = FALSE, min.len = 1L, unique = TRUE)
     checkmate::assert_character(member, any.missing = FALSE, min.len = 1L, unique = TRUE, null.ok = TRUE)
     checkmate::assert_string(grid, min.chars = 1L, null.ok = TRUE)
-    checkmate::assert_string(frequency, min.chars = 1L)
+    frequency <- shift__cmip6_frequency_spec(frequency)
     table <- shift__cmip6_table_spec(table)
     checkmate::assert_string(activity, min.chars = 1L)
     checkmate::assert_character(index_nodes, any.missing = FALSE, min.len = 1L, unique = TRUE, null.ok = TRUE)
@@ -2261,8 +2368,11 @@ shift_cmip6 <- function(model, scenarios, member = NULL, grid = NULL,
 # request consumed by the staged workflow and ESGF collector.
 shift__request_from_cmip6 <- function(climate, periods, method) {
     variables <- morpher__input_variables(method@recipe)
+    frequencies <- shift__cmip6_variable_frequencies(
+        variables, climate@frequency
+    )
     tables <- shift__cmip6_variable_tables(
-        variables, climate@frequency, climate@table
+        variables, frequencies, climate@table
     )
     request <- shift_cmip6_scenario(
         source = climate@model,
@@ -2270,7 +2380,7 @@ shift__request_from_cmip6 <- function(climate, periods, method) {
         member = climate@member,
         years = periods$year,
         variables = variables,
-        frequency = climate@frequency,
+        frequency = frequencies,
         activity = climate@activity,
         table_id = unique(unname(tables)),
         grid_label = climate@grid,
@@ -2329,8 +2439,8 @@ shift_control <- function(strict = TRUE, allow_partial = FALSE,
 #' @param years Optional years used to constrain the future request time window.
 #' @param activity CMIP6 activity ID. `shift_cmip6_scenario()` defaults to
 #'   `"ScenarioMIP"` and `shift_reference_historical()` defaults to `"CMIP"`.
-#' @param table_id One or more CMIP6 table IDs. If `NULL`, a common atmospheric
-#'   table is inferred from `frequency`.
+#' @param table_id One or more CMIP6 table IDs. If `NULL`, the native table is
+#'   inferred for each variable's `frequency`.
 #' @param grid_label Optional CMIP6 grid label.
 #' @param data_node Optional ESGF data node filter.
 #' @param index_node Optional ESGF index node.
@@ -2342,7 +2452,8 @@ shift_cmip6_scenario <- function(source, scenario, member = NULL,
     checkmate::assert_character(source, any.missing = FALSE, min.len = 1L)
     checkmate::assert_character(scenario, any.missing = FALSE, min.len = 1L)
     checkmate::assert_character(member, any.missing = FALSE, min.len = 1L, null.ok = TRUE)
-    checkmate::assert_character(frequency, any.missing = FALSE, min.len = 1L)
+    variables <- shift__variables_value(variables)
+    frequencies <- shift__cmip6_variable_frequencies(variables, frequency)
     checkmate::assert_string(activity, min.chars = 1L, null.ok = TRUE)
     checkmate::assert_character(table_id, any.missing = FALSE, min.len = 1L,
         unique = TRUE, null.ok = TRUE)
@@ -2353,7 +2464,11 @@ shift_cmip6_scenario <- function(source, scenario, member = NULL,
     checkmate::assert_list(options, names = "unique")
 
     time <- if (is.null(years)) NULL else shift_time_window(range(shift__years_value(years)))
-    table_id <- shift_coalesce(table_id, shift__cmip6_table_id(frequency))
+    if (is.null(table_id)) {
+        table_id <- unique(unname(shift__cmip6_variable_tables(
+            variables, frequencies
+        )))
+    }
     defaults <- shift__compact_list(list(
         activity_id = activity,
         table_id = table_id,
@@ -2368,8 +2483,8 @@ shift_cmip6_scenario <- function(source, scenario, member = NULL,
         source = source,
         experiment = scenario,
         variant = member,
-        variables = shift__variables_value(variables),
-        frequency = frequency,
+        variables = variables,
+        frequency = frequencies,
         time = time,
         filters = utils::modifyList(defaults, filters),
         options = options
@@ -2416,14 +2531,28 @@ shift__validate_method_frequency <- function(method, frequency) {
     if (is.null(required)) {
         return(invisible(TRUE))
     }
-    actual <- unique(tolower(as.character(frequency)))
-    actual <- actual[!is.na(actual) & nzchar(actual)]
-    if (!identical(actual, required)) {
-        shown <- if (length(actual)) actual else "<missing>"
+    variables <- morpher__input_variables(method@recipe)
+    actual <- tryCatch(
+        shift__cmip6_variable_frequencies(variables, frequency),
+        error = identity
+    )
+    required <- shift__cmip6_variable_frequencies(variables, required)
+    if (inherits(actual, "error") || !identical(
+        unname(actual[names(required)]),
+        unname(required)
+    )) {
+        shown <- paste(unique(as.character(frequency)), collapse = ", ")
+        if (!nzchar(shown)) {
+            shown <- "<missing>"
+        }
+        required_label <- paste(
+            paste(names(required), required, sep = "="),
+            collapse = ", "
+        )
         cli::cli_abort(c(
-            "Morphing method {.val {method@name}} requires CMIP frequency {.val {required}}.",
+            "Morphing method {.val {method@name}} requires CMIP frequencies {.val {required_label}}.",
             "x" = "The climate request uses {.val {shown}}.",
-            "i" = "Set {.code frequency = \"{required}\"} in the climate specification."
+            "i" = "Set a variable-specific {.arg frequency} vector in the climate specification."
         ))
     }
     invisible(TRUE)
@@ -4335,7 +4464,7 @@ shift_as_esg_query <- function(x) {
         experiment_id = x@meta$experiment,
         variant_label = x@meta$variant,
         variable_id = x@meta$variables,
-        frequency = x@meta$frequency
+        frequency = unique(unname(x@meta$frequency))
     )
     for (name in names(aliases)) {
         shift_query_set(query, name, aliases[[name]])
@@ -5205,7 +5334,13 @@ shift__climate_spec_value <- function(climate) {
         scenarios = climate@scenarios,
         member = climate@member,
         grid = climate@grid,
-        frequency = climate@frequency,
+        # Preserve variable names across JSON round-trips for mixed-frequency
+        # climate specifications.
+        frequency = if (!is.null(names(climate@frequency))) {
+            as.list(climate@frequency)
+        } else {
+            climate@frequency
+        },
         # JSON objects preserve variable names; named atomic vectors do not
         # when `auto_unbox = TRUE`, so overrides are persisted as a named list.
         table = if (!is.null(names(climate@table))) {
@@ -5232,6 +5367,32 @@ shift__climate_from_spec <- function(spec) {
     do.call(shift_cmip6, spec[setdiff(names(spec), "provider")])
 }
 
+# Preserve variable names on request frequency mappings because jsonlite
+# serializes named atomic vectors as arrays when automatic unboxing is enabled.
+shift__request_spec_value <- function(request) {
+    if (is.null(request)) {
+        return(NULL)
+    }
+    out <- request@meta
+    if (!is.null(names(out$frequency))) {
+        out$frequency <- as.list(out$frequency)
+    }
+    out
+}
+
+# Restore request frequencies without allowing character coercion to discard
+# names from a JSON object that represents a variable-specific mapping.
+shift__request_frequency_from_spec <- function(value) {
+    if (is.null(value)) {
+        return(NULL)
+    }
+    value <- unlist(value, use.names = TRUE)
+    value_names <- names(value)
+    value <- as.character(value)
+    names(value) <- value_names
+    value
+}
+
 # Convert a plan into a canonical, JSON-safe task specification. Deterministic
 # artifacts can be reused by spec hash while each invocation still gets a
 # unique run ID.
@@ -5249,7 +5410,11 @@ shift__plan_spec <- function(x) {
     list(
         version = 1L,
         task = "future_epw",
-        request = if (is.null(climate)) request else NULL,
+        request = if (is.null(climate)) {
+            shift__request_spec_value(meta$request)
+        } else {
+            NULL
+        },
         site = list(
             id = meta$site@id,
             lon = meta$site@lon,
@@ -5735,7 +5900,9 @@ shift__plan_from_spec <- function(spec, store = NULL) {
             experiment = if (is.null(request_spec$experiment)) NULL else as.character(request_spec$experiment),
             variant = if (is.null(request_spec$variant)) NULL else as.character(request_spec$variant),
             variables = if (is.null(request_spec$variables)) NULL else as.character(request_spec$variables),
-            frequency = if (is.null(request_spec$frequency)) NULL else as.character(request_spec$frequency),
+            frequency = shift__request_frequency_from_spec(
+                request_spec$frequency
+            ),
             time = request_spec$time,
             filters = shift_coalesce(request_spec$filters, list()),
             options = shift_coalesce(request_spec$options, list())
@@ -6757,7 +6924,9 @@ shift__catalog_years <- function(rows) {
 # columns whose one-row shape changes during jsonlite simplification.
 shift__cmip6_partition_json <- function(partitions) {
     partitions <- data.table::as.data.table(data.table::copy(partitions))
-    columns <- c("variable_id", "table_id", "grid_label", "required")
+    columns <- c(
+        "variable_id", "frequency", "table_id", "grid_label", "required"
+    )
     for (name in setdiff(columns, names(partitions))) {
         partitions[[name]] <- if (identical(name, "required")) {
             logical(nrow(partitions))
@@ -6768,7 +6937,7 @@ shift__cmip6_partition_json <- function(partitions) {
     partitions <- unique(partitions[, columns, with = FALSE])
     if (nrow(partitions)) {
         data.table::setorderv(partitions,
-            c("table_id", "grid_label", "variable_id"))
+            c("frequency", "table_id", "grid_label", "variable_id"))
     }
     # jsonlite marks its scalar result with class `json`; stripping that class
     # keeps complete and empty candidate tables type-compatible in rbindlist().
@@ -6785,13 +6954,19 @@ shift__cmip6_partitions <- function(value) {
     value <- value[!is.na(value) & nzchar(value)]
     if (!length(value)) {
         return(data.table::data.table(
-            variable_id = character(), table_id = character(),
-            grid_label = character(), required = logical()
+            variable_id = character(), frequency = character(),
+            table_id = character(), grid_label = character(),
+            required = logical()
         ))
     }
     out <- jsonlite::fromJSON(value[[1L]], simplifyDataFrame = TRUE)
     out <- data.table::as.data.table(out)
-    for (name in c("variable_id", "table_id", "grid_label")) {
+    # Older persisted selections predate per-variable frequency partitions.
+    # Their missing frequency is filled from the selection row at read time.
+    if (!"frequency" %in% names(out)) {
+        out[["frequency"]] <- rep(NA_character_, nrow(out))
+    }
+    for (name in c("variable_id", "frequency", "table_id", "grid_label")) {
         out[[name]] <- as.character(out[[name]])
     }
     out[["required"]] <- as.logical(out[["required"]])
@@ -6802,7 +6977,8 @@ shift__cmip6_partitions <- function(value) {
 # experiment. File ranges are expanded rather than inferred from min/max so a
 # gap in the middle cannot satisfy the contract.
 shift__cmip6_input_complete <- function(catalog, identity, experiment,
-                                        variable, table, grid, years) {
+                                        variable, frequency, table, grid,
+                                        years) {
     # ESGF providers may return convenience columns named `variable` and
     # `grid`. Local aliases prevent data.table from resolving those columns
     # instead of this helper's scalar arguments inside the row expression.
@@ -6810,6 +6986,7 @@ shift__cmip6_input_complete <- function(catalog, identity, experiment,
     wanted_variant_label <- identity$variant_label[[1L]]
     wanted_experiment <- experiment
     wanted_variable <- variable
+    wanted_frequency <- frequency
     wanted_table <- table
     wanted_grid <- grid
     files <- catalog[
@@ -6817,23 +6994,38 @@ shift__cmip6_input_complete <- function(catalog, identity, experiment,
             shift__catalog_match(variant_label, wanted_variant_label) &
             shift__catalog_match(experiment_id, wanted_experiment) &
             shift__catalog_match(variable_id, wanted_variable) &
+            shift__catalog_match(frequency, wanted_frequency) &
             shift__catalog_match(table_id, wanted_table) &
             shift__catalog_match(grid_label, wanted_grid)
     ]
     nrow(files) > 0L && !length(setdiff(years, shift__catalog_years(files)))
 }
 
-# Expand the per-table grid choices for one model/member. Missing tables retain
-# an explicit NA choice so the resolver can report the absent requirement
-# instead of discarding the near-match identity entirely.
-shift__cmip6_grid_combinations <- function(catalog, identity, tables,
+# Construct a stable key for one frequency/table partition. Frequency remains
+# explicit because CMIP6 can store point states and interval means in one table.
+shift__cmip6_partition_id <- function(frequency, table) {
+    paste(as.character(frequency), as.character(table), sep = "/")
+}
+
+# Expand the per-frequency/table grid choices for one model/member. Missing
+# partitions retain an explicit NA choice so near matches remain diagnosable.
+shift__cmip6_grid_combinations <- function(catalog, identity, partitions,
                                             grid = NULL) {
-    choices <- stats::setNames(vector("list", length(tables)), tables)
-    for (table_id in tables) {
-        wanted_table_id <- table_id
+    partitions <- unique(data.table::as.data.table(partitions)[, .(
+        frequency, table_id
+    )])
+    partition_ids <- shift__cmip6_partition_id(
+        partitions$frequency,
+        partitions$table_id
+    )
+    choices <- stats::setNames(vector("list", nrow(partitions)), partition_ids)
+    for (i in seq_len(nrow(partitions))) {
+        wanted_frequency <- partitions$frequency[[i]]
+        wanted_table_id <- partitions$table_id[[i]]
         values <- unique(catalog[
             shift__catalog_match(source_id, identity$source_id[[1L]]) &
                 shift__catalog_match(variant_label, identity$variant_label[[1L]]) &
+                shift__catalog_match(frequency, wanted_frequency) &
                 shift__catalog_match(table_id, wanted_table_id)
         ]$grid_label)
         values <- sort(values[!is.na(values) & nzchar(values)])
@@ -6846,7 +7038,7 @@ shift__cmip6_grid_combinations <- function(catalog, identity, tables,
         if (!length(values)) {
             values <- NA_character_
         }
-        choices[[table_id]] <- values
+        choices[[partition_ids[[i]]]] <- values
     }
     as.data.frame(do.call(expand.grid, c(
         choices,
@@ -6854,10 +7046,10 @@ shift__cmip6_grid_combinations <- function(catalog, identity, tables,
     )), check.names = FALSE, stringsAsFactors = FALSE)
 }
 
-# Compute complete model/member candidates while allowing each CMIP table to
-# use its own grid. The selected partition JSON is subsequently authoritative
-# for both download and extraction, so broad catalog queries cannot create
-# table/grid cross-products downstream.
+# Compute complete model/member candidates while allowing each frequency/table
+# partition to use its own grid. The selected partition JSON is authoritative
+# for download and extraction, so broad catalog queries cannot create invalid
+# frequency/variable or table/grid cross-products downstream.
 shift__cmip6_candidates <- function(catalog, models, experiments, variables,
                                     years, frequency, table = NULL,
                                     requirements = NULL, grid = NULL) {
@@ -6866,29 +7058,51 @@ shift__cmip6_candidates <- function(catalog, models, experiments, variables,
     experiments <- as.character(experiments)
     variables <- unique(as.character(variables))
     years <- sort(unique(as.integer(years)))
-    wanted_frequency <- as.character(frequency)
+    frequency_map <- shift__cmip6_variable_frequencies(variables, frequency)
     if (is.null(requirements)) {
         requirements <- stats::setNames(
             lapply(variables, function(variable) list(variable)),
             variables
         )
     }
-    table_map <- shift__cmip6_variable_tables(variables, frequency, table)
+    table_map <- shift__cmip6_variable_tables(
+        variables,
+        frequency_map,
+        table
+    )
     required_inputs <- unique(unlist(requirements, recursive = TRUE,
         use.names = FALSE))
     if (!all(required_inputs %in% names(table_map))) {
         cli::cli_abort("CMIP6 table mapping is missing one or more required recipe inputs.")
     }
-    required_tables <- unique(unname(table_map[required_inputs]))
+    variable_specs <- data.table::data.table(
+        variable_id = variables,
+        frequency = unname(frequency_map[variables]),
+        table_id = unname(table_map[variables])
+    )
+    required_specs <- unique(variable_specs[
+        variable_id %in% required_inputs,
+        .(frequency, table_id)
+    ])
     wanted_tables <- unique(unname(table_map))
     catalog <- catalog[
         source_id %in% models &
             experiment_id %in% experiments &
             variable_id %in% variables &
-            frequency %in% wanted_frequency &
+            frequency %in% unique(unname(frequency_map)) &
             table_id %in% wanted_tables
     ]
-    identities <- unique(catalog[, .(source_id, variant_label, frequency)])
+    # A broad ESGF query may return another requested frequency for the wrong
+    # variable. Enforce the declared pair before evaluating time coverage.
+    row_variables <- as.character(catalog$variable_id)
+    wanted_row_frequencies <- unname(frequency_map[row_variables])
+    wanted_row_tables <- unname(table_map[row_variables])
+    keep <- !is.na(catalog$frequency) &
+        as.character(catalog$frequency) == wanted_row_frequencies &
+        !is.na(catalog$table_id) &
+        as.character(catalog$table_id) == wanted_row_tables
+    catalog <- catalog[keep]
+    identities <- unique(catalog[, .(source_id, variant_label)])
     empty <- data.table::data.table(
         source_id = character(), variant_label = character(),
         grid_label = character(), frequency = character(),
@@ -6906,7 +7120,7 @@ shift__cmip6_candidates <- function(catalog, models, experiments, variables,
     for (identity_index in seq_len(nrow(identities))) {
         identity <- identities[identity_index]
         combinations <- shift__cmip6_grid_combinations(
-            catalog, identity, required_tables, grid = grid
+            catalog, identity, required_specs, grid = grid
         )
         for (combination_index in seq_len(nrow(combinations))) {
             grid_map <- stats::setNames(
@@ -6925,9 +7139,14 @@ shift__cmip6_candidates <- function(catalog, models, experiments, variables,
                 for (alternative in alternatives) {
                     input_ok <- vapply(experiments, function(experiment) {
                         all(vapply(alternative, function(input) {
+                            partition_id <- shift__cmip6_partition_id(
+                                frequency_map[[input]],
+                                table_map[[input]]
+                            )
                             shift__cmip6_input_complete(
                                 catalog, identity, experiment, input,
-                                table_map[[input]], grid_map[[table_map[[input]]]],
+                                frequency_map[[input]], table_map[[input]],
+                                grid_map[[partition_id]],
                                 years
                             )
                         }, logical(1L)))
@@ -6955,30 +7174,49 @@ shift__cmip6_candidates <- function(catalog, models, experiments, variables,
                 use.names = FALSE))
             required_partitions <- data.table::data.table(
                 variable_id = required_variables,
+                frequency = unname(frequency_map[required_variables]),
                 table_id = unname(table_map[required_variables]),
                 grid_label = unname(vapply(
-                    unname(table_map[required_variables]),
-                    function(value) grid_map[[value]], character(1L)
+                    required_variables,
+                    function(variable) {
+                        grid_map[[shift__cmip6_partition_id(
+                            frequency_map[[variable]],
+                            table_map[[variable]]
+                        )]]
+                    },
+                    character(1L)
                 )),
                 required = TRUE
             )
 
             optional_variables <- setdiff(variables, required_inputs)
             optional_partitions <- list()
-            for (table_id in unique(unname(table_map[optional_variables]))) {
-                wanted_table_id <- table_id
+            optional_specs <- unique(variable_specs[
+                variable_id %in% optional_variables,
+                .(frequency, table_id)
+            ])
+            for (optional_index in seq_len(nrow(optional_specs))) {
+                wanted_frequency <- optional_specs$frequency[[optional_index]]
+                wanted_table_id <- optional_specs$table_id[[optional_index]]
                 table_variables <- optional_variables[
-                    unname(table_map[optional_variables]) == table_id
+                    unname(frequency_map[optional_variables]) ==
+                        wanted_frequency &
+                        unname(table_map[optional_variables]) == wanted_table_id
                 ]
                 if (!length(table_variables)) {
                     next
                 }
-                if (table_id %in% names(grid_map)) {
-                    optional_grids <- grid_map[[table_id]]
+                partition_id <- shift__cmip6_partition_id(
+                    wanted_frequency,
+                    wanted_table_id
+                )
+                if (partition_id %in% names(grid_map)) {
+                    optional_grids <- grid_map[[partition_id]]
                 } else {
                     optional_grids <- unique(catalog[
                         shift__catalog_match(source_id, identity$source_id[[1L]]) &
                             shift__catalog_match(variant_label, identity$variant_label[[1L]]) &
+                            shift__catalog_match(frequency, wanted_frequency) &
                             shift__catalog_match(table_id, wanted_table_id)
                     ]$grid_label)
                     optional_grids <- sort(optional_grids[
@@ -6998,7 +7236,8 @@ shift__cmip6_candidates <- function(catalog, models, experiments, variables,
                             function(experiment) {
                                 shift__cmip6_input_complete(
                                     catalog, identity, experiment, variable,
-                                    table_id, optional_grid, years
+                                    wanted_frequency, wanted_table_id,
+                                    optional_grid, years
                                 )
                             }, logical(1L))),
                         logical(1L)
@@ -7012,7 +7251,11 @@ shift__cmip6_candidates <- function(catalog, models, experiments, variables,
                     next
                 }
                 scored <- scored[scores == max(scores)]
-                primary_grid <- if (length(grid_map)) grid_map[[1L]] else NA_character_
+                primary_grid <- if (nrow(required_partitions)) {
+                    required_partitions$grid_label[[1L]]
+                } else {
+                    NA_character_
+                }
                 preferred <- vapply(scored, function(value) {
                     if (!is.na(primary_grid) && identical(value$grid, primary_grid)) {
                         return(1L)
@@ -7024,7 +7267,8 @@ shift__cmip6_candidates <- function(catalog, models, experiments, variables,
                 optional_partitions[[length(optional_partitions) + 1L]] <-
                     data.table::data.table(
                         variable_id = chosen$variables,
-                        table_id = table_id,
+                        frequency = wanted_frequency,
+                        table_id = wanted_table_id,
                         grid_label = chosen$grid,
                         required = FALSE
                     )
@@ -7034,41 +7278,57 @@ shift__cmip6_candidates <- function(catalog, models, experiments, variables,
                 use.names = TRUE, fill = TRUE
             )
             partitions <- unique(partitions,
-                by = c("variable_id", "table_id", "grid_label"))
+                by = c(
+                    "variable_id", "frequency", "table_id", "grid_label"
+                ))
             required_grid_rows <- unique(required_partitions[, .(
-                table_id, grid_label
+                frequency, table_id, grid_label
             )])
             data.table::setorderv(required_grid_rows,
-                c("table_id", "grid_label"))
+                c("frequency", "table_id", "grid_label"))
             required_partition_key <- paste(
-                paste(required_grid_rows$table_id,
-                    required_grid_rows$grid_label, sep = "="),
+                paste(
+                    shift__cmip6_partition_id(
+                        required_grid_rows$frequency,
+                        required_grid_rows$table_id
+                    ),
+                    required_grid_rows$grid_label,
+                    sep = "="
+                ),
                 collapse = ";"
             )
-            all_grid_rows <- unique(partitions[, .(table_id, grid_label)])
-            data.table::setorderv(all_grid_rows, c("table_id", "grid_label"))
+            all_grid_rows <- unique(partitions[, .(
+                frequency, table_id, grid_label
+            )])
+            data.table::setorderv(
+                all_grid_rows,
+                c("frequency", "table_id", "grid_label")
+            )
             partition_key <- paste(
-                paste(all_grid_rows$table_id, all_grid_rows$grid_label,
-                    sep = "="),
+                paste(
+                    shift__cmip6_partition_id(
+                        all_grid_rows$frequency,
+                        all_grid_rows$table_id
+                    ),
+                    all_grid_rows$grid_label,
+                    sep = "="
+                ),
                 collapse = ";"
             )
             requirement_key <- paste(vapply(names(selected_sources),
                 function(canonical) sprintf("%s=%s", canonical,
                     paste(selected_sources[[canonical]], collapse = "+")),
                 character(1L)), collapse = ";")
-            primary_table <- shift__cmip6_table_id(frequency)
-            if (is.null(primary_table) || !primary_table %in% required_grid_rows$table_id) {
-                primary_table <- required_grid_rows$table_id[[1L]]
-            }
-            primary_grid <- required_grid_rows[
-                table_id == primary_table, grid_label
-            ][[1L]]
+            primary_grid <- required_partitions$grid_label[[1L]]
             display_tables <- sort(unique(partitions$table_id))
             rows[[length(rows) + 1L]] <- data.table::data.table(
                 source_id = identity$source_id[[1L]],
                 variant_label = identity$variant_label[[1L]],
                 grid_label = primary_grid,
-                frequency = identity$frequency[[1L]],
+                frequency = paste(
+                    unique(unname(frequency_map)),
+                    collapse = "+"
+                ),
                 table_id = paste(display_tables, collapse = "+"),
                 required_partition_key = required_partition_key,
                 requirement_key = requirement_key,
@@ -7451,7 +7711,7 @@ shift__abort_cmip6_resolution <- function(diagnostic) {
 shift__cmip6_shared_partitions <- function(future, reference) {
     future <- shift__cmip6_partitions(future)
     reference <- shift__cmip6_partitions(reference)
-    keys <- c("variable_id", "table_id", "grid_label")
+    keys <- c("variable_id", "frequency", "table_id", "grid_label")
     future_required <- future[required %in% TRUE]
     reference_required <- reference[required %in% TRUE]
     shared_optional <- merge(
@@ -7476,29 +7736,43 @@ shift__cmip6_shared_partitions <- function(future, reference) {
 }
 
 # Recompute display fields after optional partitions have been intersected.
-# Required partitions remain the selection identity; all partitions describe
-# the exact files that download and extraction are allowed to consume.
-shift__cmip6_partition_summary <- function(partitions, frequency) {
+# Required frequency/table/grid partitions remain the selection identity.
+shift__cmip6_partition_summary <- function(partitions) {
     partitions <- data.table::as.data.table(partitions)
-    grids <- unique(partitions[, .(table_id, grid_label)])
-    data.table::setorderv(grids, c("table_id", "grid_label"))
+    grids <- unique(partitions[, .(frequency, table_id, grid_label)])
+    data.table::setorderv(
+        grids,
+        c("frequency", "table_id", "grid_label")
+    )
     required_grids <- unique(partitions[required %in% TRUE,
-        .(table_id, grid_label)])
-    data.table::setorderv(required_grids, c("table_id", "grid_label"))
-    primary_table <- shift__cmip6_table_id(frequency)
-    if (is.null(primary_table) || !primary_table %in% required_grids$table_id) {
-        primary_table <- required_grids$table_id[[1L]]
-    }
+        .(frequency, table_id, grid_label)])
+    data.table::setorderv(
+        required_grids,
+        c("frequency", "table_id", "grid_label")
+    )
     list(
-        grid_label = required_grids[table_id == primary_table,
-            grid_label][[1L]],
+        grid_label = required_grids$grid_label[[1L]],
         table_id = paste(sort(unique(partitions$table_id)), collapse = "+"),
         required_partition_key = paste(
-            paste(required_grids$table_id, required_grids$grid_label,
-                sep = "="), collapse = ";"
+            paste(
+                shift__cmip6_partition_id(
+                    required_grids$frequency,
+                    required_grids$table_id
+                ),
+                required_grids$grid_label,
+                sep = "="
+            ),
+            collapse = ";"
         ),
         partition_key = paste(
-            paste(grids$table_id, grids$grid_label, sep = "="),
+            paste(
+                shift__cmip6_partition_id(
+                    grids$frequency,
+                    grids$table_id
+                ),
+                grids$grid_label,
+                sep = "="
+            ),
             collapse = ";"
         ),
         required_native_grid = all(required_grids$grid_label == "gn"),
@@ -7507,8 +7781,8 @@ shift__cmip6_partition_summary <- function(partitions, frequency) {
 }
 
 # Resolve future and, only when explicitly requested by the method, historical
-# catalogs against one shared model/member/frequency identity and a matching
-# grid for every required table.
+# catalogs against one shared model/member identity and a matching grid for
+# every required frequency/table partition.
 shift__resolve_cmip6_selection <- function(plan, future_catalog, reference_catalog = NULL) {
     meta <- plan@meta
     request <- meta$request@meta
@@ -7520,7 +7794,11 @@ shift__resolve_cmip6_selection <- function(plan, future_catalog, reference_catal
     member <- if (is.null(climate)) request$variant else climate@member
     grid <- if (is.null(climate)) request$filters$grid_label else climate@grid
     frequency <- if (is.null(climate)) request$frequency else climate@frequency
-    table <- if (is.null(climate)) request$filters$table_id else climate@table
+    table <- if (is.null(climate)) {
+        shift__cmip6_request_table_spec(request$filters$table_id)
+    } else {
+        climate@table
+    }
     future <- if (isTRUE(meta$control@allow_partial)) {
         shift__cmip6_partial_candidates(
             future_catalog,
@@ -7627,9 +7905,7 @@ shift__resolve_cmip6_selection <- function(plan, future_catalog, reference_catal
                     shift__cmip6_partition_json(shared$future)
                 future$reference_partitions_json[[i]] <-
                     shift__cmip6_partition_json(shared$reference)
-                summary <- shift__cmip6_partition_summary(
-                    shared$future, future$frequency[[i]]
-                )
+                summary <- shift__cmip6_partition_summary(shared$future)
                 for (name in names(summary)) {
                     future[[name]][[i]] <- summary[[name]]
                 }
@@ -8169,10 +8445,26 @@ shift__selection_partition_rows <- function(selection,
         if (!nrow(partitions)) {
             next
         }
+        if (anyNA(partitions$frequency) || any(!nzchar(partitions$frequency))) {
+            fallback <- as.character(selection$frequency[[i]])
+            if (length(fallback) != 1L || is.na(fallback) ||
+                !nzchar(fallback) || grepl("+", fallback, fixed = TRUE)) {
+                cli::cli_abort(
+                    "A legacy CMIP6 partition map has no unambiguous frequency."
+                )
+            }
+            missing_frequency <- is.na(partitions$frequency) |
+                !nzchar(partitions$frequency)
+            data.table::set(
+                partitions,
+                i = which(missing_frequency),
+                j = "frequency",
+                value = fallback
+            )
+        }
         partitions[, `:=`(
             source_id = selection$source_id[[i]],
-            variant_label = selection$variant_label[[i]],
-            frequency = selection$frequency[[i]]
+            variant_label = selection$variant_label[[i]]
         )]
         rows[[length(rows) + 1L]] <- partitions
     }
@@ -10033,6 +10325,27 @@ shift__format_cmip6_tables <- function(table) {
     sprintf("auto by variable \u00b7 %s", overrides)
 }
 
+# Render scalar and variable-specific frequency specifications without losing
+# the distinction between CMIP6 interval means and point samples.
+shift__format_cmip6_frequencies <- function(frequency) {
+    if (is.null(frequency) || !length(frequency)) {
+        return(NULL)
+    }
+    if (is.list(frequency) && !is.data.frame(frequency)) {
+        frequency <- unlist(frequency, use.names = TRUE)
+    }
+    frequency_names <- names(frequency)
+    frequency <- as.character(frequency)
+    names(frequency) <- frequency_names
+    if (is.null(frequency_names) || !any(nzchar(frequency_names))) {
+        return(shift__display_values(frequency, max = Inf))
+    }
+    paste(
+        sprintf("%s=%s", frequency_names, frequency),
+        collapse = " | "
+    )
+}
+
 # Render the exact table/grid partitions selected for download and extraction.
 # `grid_label` remains a compatibility summary, while `partition_key` is the
 # authoritative multi-table identity persisted by the resolver.
@@ -10359,8 +10672,10 @@ shift__print_plan <- function(x, n = 10L, width = NULL, verbose = FALSE) {
         control <- meta$control
         cli::cli_rule("Discovery")
         shift__print_facts(list(
-            "Frequency" = if (!is.null(climate)) climate@frequency else
-                request$frequency,
+            "Frequency" = shift__format_cmip6_frequencies(
+                if (!is.null(climate)) climate@frequency else
+                    request$frequency
+            ),
             "Table" = shift__format_cmip6_tables(
                 if (!is.null(climate)) climate@table else
                     request$filters$table_id),
@@ -10613,7 +10928,7 @@ shift__print_cmip6 <- function(x, n = 10L, width = NULL, verbose = FALSE) {
         "Scenarios" = shift__display_values(x@scenarios),
         "Member" = shift__format_auto(x@member),
         "Grid" = shift__format_auto(x@grid),
-        "Frequency" = x@frequency,
+        "Frequency" = shift__format_cmip6_frequencies(x@frequency),
         "Table" = shift__format_cmip6_tables(x@table),
         "Activity" = x@activity,
         "Index nodes" = sprintf("%d-node failover", length(x@index_nodes)),

--- a/R/weather-component.R
+++ b/R/weather-component.R
@@ -67,6 +67,10 @@ WeatherInputRequirement <- S7::new_class(
             S7::class_character,
             default = character()
         ),
+        variable_frequencies = S7::new_property(
+            S7::class_list,
+            default = list()
+        ),
         calendars = S7::new_property(
             S7::class_character,
             default = character()
@@ -95,6 +99,24 @@ WeatherInputRequirement <- S7::new_class(
         if (length(self@representations) &&
             !all(self@representations %in% WEATHER_INPUT_REPRESENTATIONS)) {
             return("`representations` contains an unknown input representation.")
+        }
+        if (length(self@variable_frequencies)) {
+            mapping <- self@variable_frequencies
+            if (is.null(names(mapping)) || any(!nzchar(names(mapping))) ||
+                anyDuplicated(names(mapping))) {
+                return(
+                    "`variable_frequencies` must be uniquely named by variable ID."
+                )
+            }
+            valid <- vapply(mapping, function(value) {
+                is.character(value) && length(value) && !anyNA(value) &&
+                    all(nzchar(value)) && !anyDuplicated(value)
+            }, logical(1L))
+            if (!all(valid)) {
+                return(
+                    "Every `variable_frequencies` entry must contain unique, non-empty frequencies."
+                )
+            }
         }
         for (variable_set in self@variable_sets) {
             if (!is.character(variable_set) ||
@@ -143,6 +165,7 @@ component__input_requirement <- function(
     role,
     representations = character(),
     frequencies = character(),
+    variable_frequencies = list(),
     calendars = character(),
     variable_sets = list()
 ) {
@@ -163,6 +186,10 @@ component__input_requirement <- function(
         frequencies = weather__descriptor_values(
             frequencies,
             "frequencies"
+        ),
+        variable_frequencies = weather__variable_frequencies(
+            variable_frequencies,
+            "variable_frequencies"
         ),
         calendars = weather__descriptor_values(calendars, "calendars"),
         variable_sets = component__variable_sets(variable_sets)
@@ -559,6 +586,33 @@ component__requirement_errors <- function(requirement, input) {
                     paste(required, collapse = ", ")
                 )
             )
+        }
+    }
+    if (length(requirement@variable_frequencies)) {
+        for (variable in intersect(
+            names(requirement@variable_frequencies),
+            input@variables
+        )) {
+            required <- requirement@variable_frequencies[[variable]]
+            available <- input@variable_frequencies[[variable]]
+            if (is.null(available) || !length(available) ||
+                !all(available %in% required)) {
+                shown <- if (length(available)) {
+                    paste(available, collapse = ", ")
+                } else {
+                    "<missing>"
+                }
+                errors <- c(
+                    errors,
+                    sprintf(
+                        "role `%s` variable `%s` frequencies `%s` do not satisfy `%s`",
+                        requirement@role,
+                        variable,
+                        shown,
+                        paste(required, collapse = ", ")
+                    )
+                )
+            }
         }
     }
     if (length(requirement@variable_sets)) {

--- a/R/weather-input.R
+++ b/R/weather-input.R
@@ -31,6 +31,10 @@ WeatherInput <- S7::new_class(
         representation = S7::new_property(S7::class_character),
         variables = S7::new_property(S7::class_character, default = character()),
         frequencies = S7::new_property(S7::class_character, default = character()),
+        variable_frequencies = S7::new_property(
+            S7::class_list,
+            default = list()
+        ),
         calendars = S7::new_property(S7::class_character, default = character()),
         provenance = S7::new_property(S7::class_list, default = list()),
         metadata = S7::new_property(S7::class_list, default = list())
@@ -65,6 +69,24 @@ WeatherInput <- S7::new_class(
                     "`%s` must contain unique, non-missing, non-empty values.",
                     property
                 ))
+            }
+        }
+        if (length(self@variable_frequencies)) {
+            mapping <- self@variable_frequencies
+            if (is.null(names(mapping)) || any(!nzchar(names(mapping))) ||
+                anyDuplicated(names(mapping))) {
+                return(
+                    "`variable_frequencies` must be uniquely named by variable ID."
+                )
+            }
+            valid <- vapply(mapping, function(value) {
+                is.character(value) && length(value) && !anyNA(value) &&
+                    all(nzchar(value)) && !anyDuplicated(value)
+            }, logical(1L))
+            if (!all(valid)) {
+                return(
+                    "Every `variable_frequencies` entry must contain unique, non-empty frequencies."
+                )
             }
         }
         NULL
@@ -139,6 +161,70 @@ weather__source_values <- function(source, columns) {
     values[!is.na(values) & nzchar(values)]
 }
 
+# Normalize a named variable-to-frequency mapping while allowing requirement
+# entries to declare more than one supported frequency for a variable.
+weather__variable_frequencies <- function(value, name) {
+    if (is.null(value) || !length(value)) {
+        return(list())
+    }
+    if (is.character(value)) {
+        value_names <- names(value)
+        if (is.null(value_names) || any(!nzchar(value_names))) {
+            cli::cli_abort("{.arg {name}} must be named by variable ID.")
+        }
+        value <- as.list(value)
+    }
+    checkmate::assert_list(value, names = "unique")
+    if (is.null(names(value)) || any(!nzchar(names(value)))) {
+        cli::cli_abort("{.arg {name}} must be named by variable ID.")
+    }
+    lapply(value, function(frequencies) {
+        weather__descriptor_values(frequencies, name)
+    })
+}
+
+# Intersect repeated variable-frequency declarations from roles or components
+# and require one resolvable source frequency for every declared variable.
+weather__combine_variable_frequencies <- function(mappings, context) {
+    mappings <- Filter(length, mappings)
+    if (!length(mappings)) {
+        return(NULL)
+    }
+    variables <- unique(unlist(lapply(mappings, names), use.names = FALSE))
+    resolved <- stats::setNames(rep(NA_character_, length(variables)), variables)
+    for (variable in variables) {
+        choices <- lapply(mappings, function(mapping) mapping[[variable]])
+        choices <- Filter(length, choices)
+        allowed <- Reduce(intersect, choices)
+        if (length(allowed) != 1L) {
+            cli::cli_abort(
+                "{context} does not resolve one source frequency for variable {.val {variable}}."
+            )
+        }
+        resolved[[variable]] <- allowed[[1L]]
+    }
+    resolved
+}
+
+# Derive the frequency values carried by each materialized variable so input
+# validation can distinguish `3hrPt` state fields from `3hr` mean fluxes.
+weather__source_variable_frequencies <- function(source) {
+    if (!is.data.frame(source) ||
+        !all(c("variable_id", "frequency") %in% names(source))) {
+        return(list())
+    }
+    variables <- as.character(source[["variable_id"]])
+    frequencies <- as.character(source[["frequency"]])
+    keep <- !is.na(variables) & nzchar(variables) &
+        !is.na(frequencies) & nzchar(frequencies)
+    variables <- variables[keep]
+    frequencies <- frequencies[keep]
+    ordered_variables <- unique(variables)
+    stats::setNames(lapply(ordered_variables, function(variable) {
+        unique(frequencies[variables == variable])
+    }), ordered_variables)
+}
+
 # Infer only the physical representation of common in-package sources. Unknown
 # objects remain explicit external inputs instead of being inspected by class
 # name heuristics that optional packages could accidentally satisfy.
@@ -158,7 +244,8 @@ weather__representation <- function(source) {
 # object unchanged and deriving only metadata that are already materialized.
 weather__new_input <- function(
     role, source, representation = NULL,
-    variables = NULL, frequencies = NULL, calendars = NULL,
+    variables = NULL, frequencies = NULL, variable_frequencies = NULL,
+    calendars = NULL,
     provenance = list(), metadata = list()
 ) {
     checkmate::assert_choice(role, WEATHER_INPUT_ROLES)
@@ -178,6 +265,9 @@ weather__new_input <- function(
     if (is.null(frequencies)) {
         frequencies <- weather__source_values(source, "frequency")
     }
+    if (is.null(variable_frequencies)) {
+        variable_frequencies <- weather__source_variable_frequencies(source)
+    }
     if (is.null(calendars)) {
         calendars <- weather__source_values(
             source,
@@ -195,6 +285,10 @@ weather__new_input <- function(
         frequencies = weather__descriptor_values(
             frequencies,
             "frequencies"
+        ),
+        variable_frequencies = weather__variable_frequencies(
+            variable_frequencies,
+            "variable_frequencies"
         ),
         calendars = weather__descriptor_values(calendars, "calendars"),
         provenance = provenance,

--- a/R/weather-pipeline.R
+++ b/R/weather-pipeline.R
@@ -235,6 +235,36 @@ pipeline__frequency_choices <- function(
     allowed
 }
 
+# Resolve variable-specific source frequencies across the ordered component
+# graph so extraction planning uses the same contract as runtime validation.
+pipeline__variable_frequencies <- function(
+    spec,
+    roles = c("model_historical", "model_future")
+) {
+    if (!S7::S7_inherits(spec, WeatherPipelineSpec)) {
+        cli::cli_abort("{.arg spec} must be a WeatherPipelineSpec object.")
+    }
+    checkmate::assert_subset(roles, WEATHER_INPUT_ROLES)
+    mappings <- list()
+    for (stage in WEATHER_COMPONENT_STAGES) {
+        component <- component__get(stage, spec@components[[stage]])
+        requirements <- c(
+            component@required_inputs,
+            component@optional_inputs
+        )
+        for (role in intersect(roles, names(requirements))) {
+            mapping <- requirements[[role]]@variable_frequencies
+            if (length(mapping)) {
+                mappings[[length(mappings) + 1L]] <- mapping
+            }
+        }
+    }
+    weather__combine_variable_frequencies(
+        mappings,
+        "Pipeline components"
+    )
+}
+
 # Convert either a component-provided envelope or its raw return value into the
 # single runtime representation consumed by the next stage.
 pipeline__stage_result <- function(component, value) {

--- a/R/weather-recipe.R
+++ b/R/weather-recipe.R
@@ -513,14 +513,20 @@ recipe__default_specs <- function() {
         model_historical = component__input_requirement(
             "model_historical",
             representations = "series",
-            frequencies = "3hr",
+            frequencies = unique(unname(HOURLY_KQDM_MODEL_FREQUENCIES)),
+            variable_frequencies = as.list(
+                HOURLY_KQDM_MODEL_FREQUENCIES
+            ),
             calendars = CF_TIME_CALENDARS,
             variable_sets = EPW_MORPH_HOURLY_KQDM_MODEL_VARIABLES
         ),
         model_future = component__input_requirement(
             "model_future",
             representations = "series",
-            frequencies = "3hr",
+            frequencies = unique(unname(HOURLY_KQDM_MODEL_FREQUENCIES)),
+            variable_frequencies = as.list(
+                HOURLY_KQDM_MODEL_FREQUENCIES
+            ),
             calendars = CF_TIME_CALENDARS,
             variable_sets = EPW_MORPH_HOURLY_KQDM_MODEL_VARIABLES
         )
@@ -877,8 +883,8 @@ recipe__default_specs <- function() {
                     "https://doi.org/10.1175/JCLI-D-14-00754.1"
                 ),
                 implementation_note = paste(
-                    "Three-hourly model variables are reconstructed to an",
-                    "hourly lattice before kernel-density QDM. Numerical KDE",
+                    "CMIP6 3hrPt states and 3hr radiation means are",
+                    "reconstructed to an hourly lattice before kernel-density QDM. Numerical KDE",
                     "and tail defaults not stated by the publication remain",
                     "explicit experimental settings."
                 )
@@ -1088,6 +1094,7 @@ recipe__requirement_record <- function(requirement) {
         role = requirement@role,
         representations = requirement@representations,
         frequencies = requirement@frequencies,
+        variable_frequencies = requirement@variable_frequencies,
         calendars = requirement@calendars,
         variable_sets = requirement@variable_sets
     )
@@ -1205,6 +1212,29 @@ recipe__frequency_choices <- function(
         )
     }
     allowed
+}
+
+# Resolve the per-variable frequency contract shared by historical and future
+# model roles while keeping scalar recipe frequencies backward compatible.
+recipe__variable_frequencies <- function(
+    spec,
+    roles = c("model_historical", "model_future")
+) {
+    if (!S7::S7_inherits(spec, WeatherRecipeSpec)) {
+        cli::cli_abort(
+            "{.arg spec} must be a WeatherRecipeSpec object."
+        )
+    }
+    checkmate::assert_subset(roles, WEATHER_INPUT_ROLES)
+    requirements <- c(spec@required_inputs, spec@optional_inputs)
+    mappings <- lapply(
+        intersect(roles, names(requirements)),
+        function(role) requirements[[role]]@variable_frequencies
+    )
+    weather__combine_variable_frequencies(
+        mappings,
+        sprintf("Recipe %s", spec@name)
+    )
 }
 
 # Return all role-level input failures before a registered recipe starts its

--- a/man/hourly_kernel_qdm.Rd
+++ b/man/hourly_kernel_qdm.Rd
@@ -13,7 +13,8 @@ hourly_kernel_qdm(
 \arguments{
 \item{reference}{A required \code{\link[=historical_reference]{historical_reference()}},
 \code{\link[=shift_reference_plan]{shift_reference_plan()}}, or extracted \code{ShiftClimate} stage containing
-matching three-hourly historical model output.}
+matching variable-specific \verb{3hrPt}, \verb{3hr}, and optional daily historical
+model output.}
 
 \item{observed_reference}{A required \code{\link[=shift_reference_plan]{shift_reference_plan()}} or extracted
 \code{ShiftClimate} stage containing hourly observed weather.}
@@ -27,9 +28,11 @@ A complete \code{ShiftMorphMethod} for \code{\link[=shift_future_epw]{shift_futu
 \description{
 \code{hourly_kernel_qdm()} creates a complete multi-year future-weather method
 from matching three-hourly historical and future model data plus an hourly
-observed reference. Model roles require raw \code{tas}, \code{ps}, \code{huss}, \code{uas},
-\code{vas}, \code{rsds}, and \code{rsdsdiff}; the observed role requires \code{tas}, \code{ps},
-\code{hurs}, \code{sfcWind}, \code{rsds}, and \code{rsdsdiff}.
+observed reference. CMIP6 model roles require point-sampled \verb{3hrPt} \code{tas},
+\code{ps}, \code{huss}, \code{uas}, and \code{vas}, together with interval-mean \verb{3hr} \code{rsds}
+and \code{rsdsdiff}. Daily \code{tasmin} and \code{tasmax} are optional interpolation
+anchors. The observed role requires \code{tas}, \code{ps}, \code{hurs}, \code{sfcWind}, \code{rsds},
+and \code{rsdsdiff}.
 
 Continuous model state variables and wind-vector components are interpolated
 to an hourly lattice. Relative humidity is derived from \code{huss}, \code{tas}, and

--- a/man/shift_api.Rd
+++ b/man/shift_api.Rd
@@ -312,6 +312,9 @@ shift_ui(
 
 \item{source, experiment, variant, frequency}{Provider-neutral request fields.
 Values must use the selected provider's controlled vocabulary.
+In \code{shift_cmip6()}, an unnamed scalar \code{frequency} applies to every recipe
+input, while a named character vector assigns one frequency to every
+source variable so \verb{3hrPt}, \verb{3hr}, and \code{day} data can be collected together.
 In \code{shift_reference_historical()}, \code{experiment} is the historical
 reference experiment filter. Values are not translated; for ESGF, use
 exact facet values such as \code{project = "CMIP6"} and \code{frequency = "mon"}.}
@@ -402,8 +405,8 @@ morphing results, or EPW outputs.}
 
 \item{years}{Optional years used to constrain the future request time window.}
 
-\item{table_id}{One or more CMIP6 table IDs. If \code{NULL}, a common atmospheric
-table is inferred from \code{frequency}.}
+\item{table_id}{One or more CMIP6 table IDs. If \code{NULL}, the native table is
+inferred for each variable's \code{frequency}.}
 
 \item{grid_label}{Optional CMIP6 grid label.}
 

--- a/man/shift_cmip6_avail.Rd
+++ b/man/shift_cmip6_avail.Rd
@@ -38,7 +38,9 @@ every returned member and evaluates each identity independently.}
 
 \item{grid}{Optional single CMIP6 grid label.}
 
-\item{frequency}{CMIP6 frequency. Defaults to daily data.}
+\item{frequency}{CMIP6 frequency. An unnamed scalar applies to every
+requested variable. A named character vector assigns one frequency to
+every variable, for example \code{tas = "3hrPt"} and \code{rsds = "3hr"}.}
 
 \item{table}{Optional CMIP6 table selection. \code{NULL} discovers a table for
 each variable at the requested frequency. An unnamed scalar pins every
@@ -65,10 +67,11 @@ precedence when names overlap.}
 \value{
 A data frame with one row per model/member/grid identity.
 \code{complete} is \code{TRUE} only when every requested experiment-variable pair is
-present. For complete rows, \code{table} is a list-column containing the named
-per-variable table selection accepted by \code{\link[=shift_cmip6]{shift_cmip6()}}. Incomplete rows
-use \code{NA} for variables with no available table. \code{table_id} is the compact
-display value, and \code{missing} lists absent pairs as \code{experiment:variable}.
+present. \code{frequency_spec} and \code{table} are list-columns containing named
+per-variable selections accepted by \code{\link[=shift_cmip6]{shift_cmip6()}}. Incomplete rows use
+\code{NA} for variables with no available table. \code{frequency} and \code{table_id} are
+compact display values, and \code{missing} lists absent pairs as
+\code{experiment:variable}.
 }
 \description{
 Query CMIP6 Dataset metadata and identify model/member/grid identities that

--- a/tests/testthat/test-backend-daily-temperature.R
+++ b/tests/testthat/test-backend-daily-temperature.R
@@ -363,7 +363,7 @@ test_that("daily temperature shift method validates frequency and reconstructs",
             store = tempfile("daily-temperature-store-"),
             dry_run = TRUE
         ),
-        "requires CMIP frequency.*day"
+        "requires CMIP frequencies.*day"
     )
 })
 

--- a/tests/testthat/test-backend-hourly-kernel-qdm.R
+++ b/tests/testthat/test-backend-hourly-kernel-qdm.R
@@ -121,8 +121,8 @@ hourly_kqdm_test__role <- function(
 }
 
 # Reduce the hourly fixture to bounded three-hourly model samples. Point-state
-# variables include one following boundary sample needed for the final two
-# hourly values; radiation variables retain complete contiguous time bounds.
+# variables use the CMIP6 `3hrPt` facet and include one following boundary
+# sample; radiation variables use the interval-mean `3hr` facet.
 hourly_kqdm_test__model_role <- function(
     years,
     role = c("historical", "future"),
@@ -148,7 +148,7 @@ hourly_kqdm_test__model_role <- function(
                 source$cf_second_of_day %% 10800 == 0) |
                 boundary,
         ]
-        source$frequency <- "3hr"
+        source$frequency <- "3hrPt"
         source$table_id <- "3hr"
         native_second <- temporal__native_seconds(source, calendar)
         source$time <- as.POSIXct("2000-01-01", tz = "UTC") +
@@ -218,8 +218,7 @@ test_that("hourly kernel QDM configures a complete high-level shift plan", {
         "ssp585",
         member = "r1i1p1f1",
         grid = "gr",
-        frequency = "3hr",
-        table = "3hr"
+        frequency = HOURLY_KQDM_MODEL_FREQUENCIES
     )
     plan <- shift_future_epw(
         epw = get_cache_epw(),
@@ -244,14 +243,23 @@ test_that("hourly kernel QDM configures a complete high-level shift plan", {
     )
     expect_identical(
         morpher__input_variables(recipe),
-        c("tas", "ps", "huss", "uas", "vas", "rsds", "rsdsdiff")
+        c(
+            "tas", "ps", "huss", "uas", "vas", "rsds", "rsdsdiff",
+            "tasmin", "tasmax"
+        )
     )
     expect_true(plan@meta$method@requires_reference)
     expect_true(plan@meta$method@requires_observed_reference)
-    expect_identical(plan@meta$climate@frequency, "3hr")
+    expect_identical(
+        plan@meta$climate@frequency,
+        HOURLY_KQDM_MODEL_FREQUENCIES
+    )
     expect_identical(
         plan@meta$request@meta$variables,
-        EPW_MORPH_HOURLY_KQDM_MODEL_VARIABLES
+        c(
+            EPW_MORPH_HOURLY_KQDM_MODEL_VARIABLES,
+            HOURLY_WEATHER_EXTREMA_VARIABLES
+        )
     )
     expect_identical(
         plan@meta$request@meta$time,
@@ -274,7 +282,10 @@ test_that("hourly kernel QDM configures a complete high-level shift plan", {
     )
     expect_identical(
         historical_request@meta$variables,
-        EPW_MORPH_HOURLY_KQDM_MODEL_VARIABLES
+        c(
+            EPW_MORPH_HOURLY_KQDM_MODEL_VARIABLES,
+            HOURLY_WEATHER_EXTREMA_VARIABLES
+        )
     )
     expect_identical(
         historical_request@meta$options$file_time,
@@ -304,7 +315,7 @@ test_that("hourly kernel QDM configures a complete high-level shift plan", {
             store = tempfile("hourly-kqdm-invalid-store-"),
             dry_run = TRUE
         ),
-        "requires CMIP frequency"
+        "requires CMIP frequencies"
     )
     expect_error(
         shift_future_epw(
@@ -318,6 +329,54 @@ test_that("hourly kernel QDM configures a complete high-level shift plan", {
         ),
         "requires at least two weather years"
     )
+})
+
+test_that("hourly kernel QDM retains the publication source manifest", {
+    manifest <- hourly_kqdm__source_manifest()
+
+    expect_identical(nrow(manifest), 10L)
+    expect_identical(
+        manifest[, paste(source_id, variant_label, sep = "/")],
+        c(
+            "ACCESS-CM2/r1i1p1f1",
+            "BCC-CSM2-MR/r1i1p1f1",
+            "CanESM5/r1i1p2f1",
+            "CMCC-CM2-SR5/r1i1p1f1",
+            "CMCC-ESM2/r1i1p1f1",
+            "FGOALS-g3/r3i1p1f1",
+            "GISS-E2-1-G/r1i1p1f2",
+            "IITM-ESM/r1i1p1f1",
+            "KACE-1-0-G/r1i1p1f1",
+            "MRI-ESM2-0/r1i1p1f1"
+        )
+    )
+    expect_match(
+        manifest[source_id == "GISS-E2-1-G", special_treatment],
+        "rsdsdiff"
+    )
+    expect_match(
+        manifest[source_id == "IITM-ESM", special_treatment],
+        "psl"
+    )
+})
+
+test_that("hourly frequency diagnostics validate only declared model variables", {
+    recipe <- epw_morph_recipe("hourly_kernel_qdm")
+    diagnostic <- morpher__frequency_diagnostic(
+        recipe,
+        frequency = c("3hrPt", "3hr", "hour"),
+        variable_id = c("tas", "rsds", "observed_tas"),
+        stage = "climate_summary"
+    )
+    invalid <- morpher__frequency_diagnostic(
+        recipe,
+        frequency = c("3hrPt", "3hrPt"),
+        variable_id = c("tas", "rsds"),
+        stage = "climate_summary"
+    )
+
+    expect_identical(nrow(diagnostic), 0L)
+    expect_identical(invalid$code[[1L]], "unsupported_climate_frequency")
 })
 
 test_that("hourly kernel QDM produces two physically closed EPW years", {

--- a/tests/testthat/test-cmip6-availability.R
+++ b/tests/testthat/test-cmip6-availability.R
@@ -3,6 +3,16 @@ availability_test__datasets <- function(source, experiment, variables,
                                         member = "r1i1p1f1", grid = "gn",
                                         frequency = "day", table = "day") {
     data.table::rbindlist(lapply(variables, function(variable) {
+        variable_frequency <- if (!is.null(names(frequency))) {
+            unname(frequency[[variable]])
+        } else {
+            frequency[[1L]]
+        }
+        variable_table <- if (!is.null(names(table))) {
+            unname(table[[variable]])
+        } else {
+            table[[1L]]
+        }
         data.table::data.table(
             id = sprintf(
                 "CMIP6.%s.%s.%s.%s.%s",
@@ -11,8 +21,8 @@ availability_test__datasets <- function(source, experiment, variables,
             source_id = source,
             experiment_id = experiment,
             member_id = member,
-            frequency = frequency,
-            table_id = table,
+            frequency = variable_frequency,
+            table_id = variable_table,
             variable_id = variable,
             grid_label = grid,
             latest = TRUE,
@@ -54,6 +64,45 @@ test_that("availability reduction requires every experiment-variable pair", {
         summary$table[[1L]],
         stats::setNames(rep("day", length(variables)), variables)
     )
+})
+
+test_that("availability combines point, mean, and daily CMIP6 frequencies", {
+    variables <- names(HOURLY_KQDM_MODEL_FREQUENCIES)
+    datasets <- data.table::rbindlist(lapply(
+        c("ssp245", "historical"),
+        function(experiment) {
+            availability_test__datasets(
+                "Model-A",
+                experiment,
+                variables,
+                frequency = HOURLY_KQDM_MODEL_FREQUENCIES,
+                table = c(
+                    stats::setNames(
+                        rep("3hr", 7L),
+                        EPW_MORPH_HOURLY_KQDM_MODEL_VARIABLES
+                    ),
+                    tasmin = "day",
+                    tasmax = "day"
+                )
+            )
+        }
+    ))
+    summary <- availability__summarize(
+        datasets,
+        experiments = c("ssp245", "historical"),
+        variables = variables,
+        frequency = HOURLY_KQDM_MODEL_FREQUENCIES,
+        table = NULL,
+        index_node = "https://example.org/esg-search"
+    )
+
+    expect_true(summary$complete[[1L]])
+    expect_identical(summary$frequency[[1L]], "3hrPt+3hr+day")
+    expect_identical(
+        summary$frequency_spec[[1L]],
+        HOURLY_KQDM_MODEL_FREQUENCIES
+    )
+    expect_identical(summary$table_id[[1L]], "3hr+day")
 })
 
 test_that("availability discovers one table per variable", {

--- a/tests/testthat/test-component-hourly-weather-interpolation.R
+++ b/tests/testthat/test-component-hourly-weather-interpolation.R
@@ -29,7 +29,7 @@ weather_interp_test__tas <- function(value_offset = 0) {
         variable_id = "tas",
         value = c(290, 295, 300, 296, 292) + value_offset,
         units = "K",
-        frequency = "3hr",
+        frequency = "3hrPt",
         time = as.POSIXct("2061-01-01", tz = "UTC") + offsets,
         coordinates$coordinates,
         stringsAsFactors = FALSE

--- a/tests/testthat/test-method-temporal-interpolation.R
+++ b/tests/testthat/test-method-temporal-interpolation.R
@@ -210,18 +210,18 @@ test_that("linear temporal interpolation keeps independent groups isolated", {
 })
 
 test_that("linear temporal interpolation supports mixed source frequencies", {
-    three_hourly <- temporal_test__series()
+    three_hourly <- temporal_test__series(frequency = "3hrPt")
     six_hourly <- temporal_test__series(
-        frequency = "6hr",
+        frequency = "6hrPt",
         variable = "hurs",
         offsets = seq.int(0, 43200, by = 21600),
         value_offset = 40
     )
     historical <- rbind(three_hourly, six_hourly)
     future <- rbind(
-        temporal_test__series(value_offset = 100),
+        temporal_test__series(frequency = "3hrPt", value_offset = 100),
         temporal_test__series(
-            frequency = "6hr",
+            frequency = "6hrPt",
             variable = "hurs",
             offsets = seq.int(0, 43200, by = 21600),
             value_offset = 50
@@ -241,7 +241,7 @@ test_that("linear temporal interpolation supports mixed source frequencies", {
     expect_identical(data[variable_id == "hurs", .N], 13L)
     expect_identical(
         provenance$source_frequencies,
-        c("3hr", "6hr")
+        c("3hrPt", "6hrPt")
     )
     expect_identical(
         provenance$source_step_seconds,

--- a/tests/testthat/test-shift-stage.R
+++ b/tests/testthat/test-shift-stage.R
@@ -406,6 +406,10 @@ test_that("Shift scientific labels preserve profiles, table policy, and partitio
         shift__format_cmip6_tables(c(snd = "LImon")),
         "auto by variable · snd=LImon"
     )
+    expect_identical(
+        shift__format_cmip6_frequencies(c(tas = "3hrPt", rsds = "3hr")),
+        "tas=3hrPt | rsds=3hr"
+    )
     selection <- data.table::data.table(
         source_id = "BCC-CSM2-MR",
         partition_key = "Amon=gn;LImon=gr"
@@ -427,6 +431,43 @@ test_that("Shift scientific labels preserve profiles, table policy, and partitio
         shift__climate_from_spec(decoded)@table,
         c(snd = "LImon")
     )
+
+    hourly_climate <- shift_cmip6(
+        "BCC-CSM2-MR",
+        "ssp585",
+        frequency = c(tas = "3hrPt", rsds = "3hr")
+    )
+    hourly_encoded <- shift__spec_json(list(
+        climate = shift__climate_spec_value(hourly_climate)
+    ))
+    hourly_decoded <- jsonlite::fromJSON(
+        hourly_encoded,
+        simplifyVector = TRUE
+    )$climate
+    expect_identical(
+        shift__climate_from_spec(hourly_decoded)@frequency,
+        c(tas = "3hrPt", rsds = "3hr")
+    )
+
+    request <- shift_cmip6_scenario(
+        source = "BCC-CSM2-MR",
+        scenario = "ssp585",
+        variables = c("tas", "rsds"),
+        frequency = c(tas = "3hrPt", rsds = "3hr")
+    )
+    request_encoded <- shift__spec_json(
+        shift__request_spec_value(request)
+    )
+    request_decoded <- jsonlite::fromJSON(
+        request_encoded,
+        simplifyVector = TRUE
+    )
+    expect_identical(
+        shift__request_frequency_from_spec(request_decoded$frequency),
+        c(tas = "3hrPt", rsds = "3hr")
+    )
+    expect_null(shift__cmip6_request_table_spec(c("3hr", "day")))
+    expect_identical(shift__cmip6_request_table_spec("3hr"), "3hr")
 })
 
 test_that("shift_cmip6_scenario() and shift_plan() describe future EPW workflows", {
@@ -678,10 +719,93 @@ test_that("resolver inputs are not masked by provider convenience columns", {
         identity,
         experiment = "ssp245",
         variable = "tas",
+        frequency = "day",
         table = "day",
         grid = "gn",
         years = 2041L
     ))
+})
+
+test_that("resolver enforces variable-specific CMIP6 frequencies", {
+    recipe <- epw_morph_recipe("hourly_kernel_qdm")
+    variables <- morpher__input_variables(recipe)
+    frequencies <- morpher__recipe_required_frequency(recipe)
+    tables <- shift__cmip6_variable_tables(variables, frequencies)
+    catalog <- data.table::rbindlist(lapply(
+        c("ssp245", "historical"),
+        function(experiment) {
+            data.table::rbindlist(lapply(variables, function(variable) {
+                docs <- shift_test_file_docs(
+                    sprintf(
+                        "%s_%s_Model-A_%s_r1i1p1f1_gn_19900101-20651231.nc",
+                        variable,
+                        tables[[variable]],
+                        experiment
+                    ),
+                    variable_id = variable,
+                    datetime_start = "1990-01-01T00:00:00Z",
+                    datetime_end = "2065-12-31T23:59:59Z"
+                )
+                docs$source_id <- "Model-A"
+                docs$experiment_id <- experiment
+                docs$variant_label <- "r1i1p1f1"
+                docs$frequency <- frequencies[[variable]]
+                docs$table_id <- tables[[variable]]
+                docs$grid_label <- "gn"
+                docs
+            }), use.names = TRUE, fill = TRUE)
+        }
+    ), use.names = TRUE, fill = TRUE)
+
+    candidates <- shift__cmip6_candidates(
+        catalog,
+        models = "Model-A",
+        experiments = c("ssp245", "historical"),
+        variables = variables,
+        years = 2000:2001,
+        frequency = frequencies,
+        requirements = morpher__variable_requirements(recipe)
+    )
+    partitions <- shift__cmip6_partitions(candidates$partitions_json[[1L]])
+
+    expect_true(candidates$complete[[1L]])
+    expect_identical(candidates$frequency[[1L]], "3hrPt+3hr+day")
+    expect_identical(
+        stats::setNames(partitions$frequency, partitions$variable_id)[variables],
+        frequencies
+    )
+    expect_false(any(partitions[
+        variable_id %in% HOURLY_WEATHER_EXTREMA_VARIABLES,
+        required
+    ]))
+
+    core_candidates <- shift__cmip6_candidates(
+        catalog[!variable_id %in% HOURLY_WEATHER_EXTREMA_VARIABLES],
+        models = "Model-A",
+        experiments = c("ssp245", "historical"),
+        variables = variables,
+        years = 2000:2001,
+        frequency = frequencies,
+        requirements = morpher__variable_requirements(recipe)
+    )
+    core_partitions <- shift__cmip6_partitions(
+        core_candidates$partitions_json[[1L]]
+    )
+    expect_true(core_candidates$complete[[1L]])
+    expect_false(any(
+        core_partitions$variable_id %in% HOURLY_WEATHER_EXTREMA_VARIABLES
+    ))
+
+    scalar_candidates <- shift__cmip6_candidates(
+        catalog,
+        models = "Model-A",
+        experiments = c("ssp245", "historical"),
+        variables = variables,
+        years = 2000:2001,
+        frequency = "3hr",
+        requirements = morpher__variable_requirements(recipe)
+    )
+    expect_false(scalar_candidates$complete[[1L]])
 })
 
 test_that("resolver satisfies canonical hurs only from direct data or huss plus tas and ps", {

--- a/tests/testthat/test-weather-component.R
+++ b/tests/testthat/test-weather-component.R
@@ -258,6 +258,46 @@ test_that("component input validation distinguishes required and optional roles"
     expect_length(errors, 1L)
 })
 
+test_that("component input requirements validate frequency by variable", {
+    requirement <- component__input_requirement(
+        "model_future",
+        representations = "series",
+        frequencies = c("3hrPt", "3hr"),
+        variable_frequencies = list(tas = "3hrPt", rsds = "3hr"),
+        variable_sets = c("tas", "rsds")
+    )
+    component <- component__spec(
+        name = "mixed_frequency_input",
+        stage = "preprocess",
+        required_inputs = list(model_future = requirement),
+        input_kinds = "role_inputs",
+        output_kinds = "hourly_role_inputs",
+        operations = list(apply = identity)
+    )
+    valid <- weather__new_inputs(model_future = weather__new_input(
+        "model_future",
+        data.frame(
+            variable_id = c("tas", "rsds"),
+            frequency = c("3hrPt", "3hr")
+        )
+    ))
+    invalid <- weather__new_inputs(model_future = weather__new_input(
+        "model_future",
+        data.frame(
+            variable_id = c("tas", "rsds"),
+            frequency = c("3hr", "3hrPt")
+        )
+    ))
+
+    expect_identical(component__input_errors(component, valid), character())
+    errors <- component__input_errors(component, invalid)
+    expect_true(any(grepl(
+        "variable `tas` frequencies `3hr`",
+        errors,
+        fixed = TRUE
+    )))
+})
+
 test_that("component specs reject missing or stage-inappropriate operations", {
     expect_error(
         component__spec(

--- a/tests/testthat/test-weather-input.R
+++ b/tests/testthat/test-weather-input.R
@@ -49,8 +49,26 @@ test_that("future-weather inputs preserve four distinct semantic roles", {
         "day"
     )
     expect_identical(
+        weather__get_input(inputs, "model_future")@variable_frequencies,
+        list(tas = "day", tasmin = "day", tasmax = "day")
+    )
+    expect_identical(
         weather__get_input(inputs, "model_future")@calendars,
         "360_day"
+    )
+})
+
+test_that("future-weather inputs retain mixed frequency variables", {
+    source <- data.frame(
+        variable_id = c("tas", "rsds", "tasmin"),
+        frequency = c("3hrPt", "3hr", "day")
+    )
+    input <- weather__new_input("model_future", source)
+
+    expect_identical(input@frequencies, c("3hrPt", "3hr", "day"))
+    expect_identical(
+        input@variable_frequencies,
+        list(tas = "3hrPt", rsds = "3hr", tasmin = "day")
     )
 })
 

--- a/tests/testthat/test-weather-recipe.R
+++ b/tests/testthat/test-weather-recipe.R
@@ -137,6 +137,7 @@ test_that("registered recipe policies resolve backend profiles explicitly", {
     faithful <- epw_morph_recipe("belcher_monthly")
     enhanced <- epw_morph_recipe("epwshiftr_monthly")
     daily <- epw_morph_recipe("epwshiftr_daily_power")
+    hourly <- epw_morph_recipe("hourly_kernel_qdm")
 
     expect_identical(faithful$backend, "belcher")
     expect_identical(faithful$profile, "legacy")
@@ -170,6 +171,10 @@ test_that("registered recipe policies resolve backend profiles explicitly", {
     expect_identical(
         morpher__recipe_required_frequency(daily),
         "day"
+    )
+    expect_identical(
+        morpher__recipe_required_frequency(hourly),
+        HOURLY_KQDM_MODEL_FREQUENCIES
     )
 
     expect_error(

--- a/vignettes-raw/articles/epw-morpher.Rmd
+++ b/vignettes-raw/articles/epw-morpher.Rmd
@@ -185,20 +185,23 @@ sobie_curry_harmonized <- epw_morph_recipe(
 ```
 
 The complete hourly workflow requires hourly observed `tas`, `ps`, `hurs`,
-`sfcWind`, `rsds`, and `rsdsdiff`. Historical and future model roles use the
-published raw inputs `tas`, `ps`, `huss`, `uas`, `vas`, `rsds`, and
-`rsdsdiff`. After hourly reconstruction, the input adapter derives relative
-humidity, scalar wind speed, and meteorological direction before KQDM. It
-preserves every complete future model year as a separate output member instead
-of collapsing the corrected sequence into a representative year.
+`sfcWind`, `rsds`, and `rsdsdiff`. Historical and future model roles use
+point-sampled `3hrPt` `tas`, `ps`, `huss`, `uas`, and `vas`, together with
+interval-mean `3hr` `rsds` and `rsdsdiff`. Daily `tasmin` and `tasmax` are
+optional interpolation anchors. After hourly reconstruction, the input adapter
+derives relative humidity, scalar wind speed, and meteorological direction
+before KQDM. It preserves every complete future model year as a separate
+output member instead of collapsing the corrected sequence into a
+representative year.
 
-Check the live Dataset catalogue before selecting a model. A query returning no
-complete rows is a valid result: the public catalogue may not contain the exact
-seven-variable combination for both experiments, even though the published
-workflow used model-specific additions and fallbacks documented in its
-supplementary methods.
+Check the live Dataset catalogue before selecting a model. CMIP6 stores the
+required state variables and radiation fluxes under different `frequency`
+facets even though they share the `3hr` table. A scalar `frequency = "3hr"`
+therefore excludes the point-sampled fields and creates a false incomplete
+result. Some models in the publication still require the pressure, wind, or
+radiation treatments documented in its supplementary methods.
 
-Leaving `table = NULL` searches every CMIP6 table at the requested frequency.
+Leaving `table = NULL` searches every CMIP6 table at the requested frequencies.
 The availability reduction selects one table per variable within each
 model/member/grid identity and returns that named mapping in the `table`
 list-column. Pass the mapping to `shift_cmip6()` so the download request uses
@@ -206,13 +209,26 @@ the same variable-specific selection; `table_id` is only its compact display
 value.
 
 ```r
+hourly_frequencies <- c(
+    tas = "3hrPt",
+    ps = "3hrPt",
+    huss = "3hrPt",
+    uas = "3hrPt",
+    vas = "3hrPt",
+    rsds = "3hr",
+    rsdsdiff = "3hr",
+    tasmin = "day",
+    tasmax = "day"
+)
 hourly_availability <- shift_cmip6_avail(
     variables = c(
         "tas", "ps", "huss", "uas", "vas", "rsds", "rsdsdiff"
     ),
     scenarios = "ssp585",
     member = NULL,
-    frequency = "3hr",
+    frequency = hourly_frequencies[c(
+        "tas", "ps", "huss", "uas", "vas", "rsds", "rsdsdiff"
+    )],
     index_node = "ORNL"
 )
 available_hourly <- subset(hourly_availability, complete)
@@ -232,7 +248,7 @@ if (nrow(available_hourly)) {
         scenarios = "ssp585",
         member = selected$variant_label,
         grid = selected$grid_label,
-        frequency = "3hr",
+        frequency = hourly_frequencies,
         table = selected$table[[1L]]
     )
 

--- a/vignettes-raw/precompiled-checksums.csv
+++ b/vignettes-raw/precompiled-checksums.csv
@@ -1,7 +1,7 @@
 "source","output","source_md5","output_md5"
 "vignettes-raw/articles/cli-esgf-store.Rmd","vignettes/articles/cli-esgf-store.Rmd","cac788f79010ad56496939cdde3580bb","e58e5cafa0d3b2218081c25a1098273f"
 "vignettes-raw/articles/downloader.Rmd","vignettes/articles/downloader.Rmd","9668ccb5b39f0ca2f49e146a1a100a7c","4b67e4a9ddaecfe7ce3ac268936e2a2d"
-"vignettes-raw/articles/epw-morpher.Rmd","vignettes/articles/epw-morpher.Rmd","829f5b5d4397cd796264aed46764b2a6","8d4eff856eceb09f7ceee1b482b9c7b5"
+"vignettes-raw/articles/epw-morpher.Rmd","vignettes/articles/epw-morpher.Rmd","d7872590c1089e40a4f3f1eabe70d783","8d79fcf61dadfa93b947683a1108f540"
 "vignettes-raw/articles/esg-dictionaries.Rmd","vignettes/articles/esg-dictionaries.Rmd","94eb2513975549a6765afa221a2e10c1","290348d35a29e925f1b3732586e54cfb"
 "vignettes-raw/articles/esg-store.Rmd","vignettes/articles/esg-store.Rmd","c2d810261308c837b84c803a0d2632c5","bb73ddac53598a36b049797782ce3c02"
 "vignettes-raw/articles/esgf-query-results.Rmd","vignettes/articles/esgf-query-results.Rmd","9cb7e909ecc499eba79e4295857101d1","20854ab68644b18addeefcef1baafcfa"

--- a/vignettes/articles/epw-morpher.Rmd
+++ b/vignettes/articles/epw-morpher.Rmd
@@ -193,20 +193,23 @@ sobie_curry_harmonized <- epw_morph_recipe(
 ```
 
 The complete hourly workflow requires hourly observed `tas`, `ps`, `hurs`,
-`sfcWind`, `rsds`, and `rsdsdiff`. Historical and future model roles use the
-published raw inputs `tas`, `ps`, `huss`, `uas`, `vas`, `rsds`, and
-`rsdsdiff`. After hourly reconstruction, the input adapter derives relative
-humidity, scalar wind speed, and meteorological direction before KQDM. It
-preserves every complete future model year as a separate output member instead
-of collapsing the corrected sequence into a representative year.
+`sfcWind`, `rsds`, and `rsdsdiff`. Historical and future model roles use
+point-sampled `3hrPt` `tas`, `ps`, `huss`, `uas`, and `vas`, together with
+interval-mean `3hr` `rsds` and `rsdsdiff`. Daily `tasmin` and `tasmax` are
+optional interpolation anchors. After hourly reconstruction, the input adapter
+derives relative humidity, scalar wind speed, and meteorological direction
+before KQDM. It preserves every complete future model year as a separate
+output member instead of collapsing the corrected sequence into a
+representative year.
 
-Check the live Dataset catalogue before selecting a model. A query returning no
-complete rows is a valid result: the public catalogue may not contain the exact
-seven-variable combination for both experiments, even though the published
-workflow used model-specific additions and fallbacks documented in its
-supplementary methods.
+Check the live Dataset catalogue before selecting a model. CMIP6 stores the
+required state variables and radiation fluxes under different `frequency`
+facets even though they share the `3hr` table. A scalar `frequency = "3hr"`
+therefore excludes the point-sampled fields and creates a false incomplete
+result. Some models in the publication still require the pressure, wind, or
+radiation treatments documented in its supplementary methods.
 
-Leaving `table = NULL` searches every CMIP6 table at the requested frequency.
+Leaving `table = NULL` searches every CMIP6 table at the requested frequencies.
 The availability reduction selects one table per variable within each
 model/member/grid identity and returns that named mapping in the `table`
 list-column. Pass the mapping to `shift_cmip6()` so the download request uses
@@ -214,13 +217,26 @@ the same variable-specific selection; `table_id` is only its compact display
 value.
 
 ```r
+hourly_frequencies <- c(
+    tas = "3hrPt",
+    ps = "3hrPt",
+    huss = "3hrPt",
+    uas = "3hrPt",
+    vas = "3hrPt",
+    rsds = "3hr",
+    rsdsdiff = "3hr",
+    tasmin = "day",
+    tasmax = "day"
+)
 hourly_availability <- shift_cmip6_avail(
     variables = c(
         "tas", "ps", "huss", "uas", "vas", "rsds", "rsdsdiff"
     ),
     scenarios = "ssp585",
     member = NULL,
-    frequency = "3hr",
+    frequency = hourly_frequencies[c(
+        "tas", "ps", "huss", "uas", "vas", "rsds", "rsdsdiff"
+    )],
     index_node = "ORNL"
 )
 available_hourly <- subset(hourly_availability, complete)
@@ -240,7 +256,7 @@ if (nrow(available_hourly)) {
         scenarios = "ssp585",
         member = selected$variant_label,
         grid = selected$grid_label,
-        frequency = "3hr",
+        frequency = hourly_frequencies,
         table = selected$table[[1L]]
     )
 


### PR DESCRIPTION
## Summary

- Resolve hourly `CMIP6` state, radiation, and optional extrema inputs using their variable-specific frequency facets.
- Preserve mixed-frequency identities through availability, candidate selection, extraction, and recipe validation.
- Record the published Wang et al. model manifest and special treatments.

## Changes

- Add named frequency mappings to `CMIP6` specs, availability results, weather inputs, component requirements, and persisted partition maps.
- Treat `3hrPt`, `3hr`, and `day` as one model/member/grid workflow while preventing cross-variable frequency mixing.
- Update hourly interpolation, documentation, raw vignettes, and regression coverage.
- Closes #243.